### PR TITLE
Better build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ If you want to jump right in, run the following to immediately start integrating
 ```
 git clone https://github.com/alphal00p/gammaloop.git && cd gammaloop
 ./bin/compile.sh
-source python/gammaloop/dependencies/venv/bin/activate
 ./bin/gammaloop example/cards/scalar_mercedes.gL
 ```
 
@@ -26,11 +25,11 @@ source python/gammaloop/dependencies/venv/bin/activate
 
 * `Rust`: You can easily instal Rust with this [one-liner](https://www.rust-lang.org/tools/install)
 
-* `Python3`: v3.10+
+* `Python3`: v3.10+ (equipped with `pip`)
 
-* `gcc`: v10+
+* `GNU gcc`: v10+
 
-*Note*: The project has been tested on Linux and MacOS. 
+*Note*: The project has been tested on Linux and MacOS. However, on MacOS, the default `clang` compiler is not supported due to lack of `libquadmath` support, and `GNU gcc` must be installed and setup as default compiler.
 
 Windows users are encouraged to use [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/).
 
@@ -38,19 +37,25 @@ Windows users are encouraged to use [WSL 2](https://learn.microsoft.com/en-us/wi
 ```
 pip install gammaloop
 gammaloop --build_dependencies
-source `gammaloop -venv`
 ```
-
-*Note:* when using the `fish` shell, the last command should be replaced by: `. (./bin/gammaloop -venv).fish`
 
 ### > Installation from sources
 ```
 git clone https://github.com/alphal00p/gammaloop.git
 cd gammaloop
 ./bin/compile.sh
-source python/gammaloop/dependencies/venv/bin/activate
 ```
 The relevant binaries will then be in `./bin/` and the gammaloop python module is located at `./python/gammaloop`.
+
+*Note:* Alternatively, the dependencies can be built within a python virtual environment as follows:
+
+```
+./bin/build_dependencies.sh clean
+./bin/build_dependencies.sh with_venv
+source `./bin/gammaloop -venv`
+```
+
+and when using the `fish` shell, the last command should be replaced by: `. (./bin/gammaloop -venv).fish`
 
 ## Tests
 

--- a/python/gammaloop/__init__.py
+++ b/python/gammaloop/__init__.py
@@ -23,7 +23,7 @@ class CLIColour(StrEnum):
     END = '\033[0m'
 
 
-def check_gammaloop_dependencies(clean_dependencies=False, build_dependencies=False, no_gammaloop_python_venv=False):
+def check_gammaloop_dependencies(clean_dependencies=False, build_dependencies=False, no_gammaloop_python_venv=False, install_dependencies_with_venv=False):
 
     global DEPENDENCIES_CHECKED
     if DEPENDENCIES_CHECKED and all(opt is False for opt in [clean_dependencies, build_dependencies, no_gammaloop_python_venv]):
@@ -44,7 +44,7 @@ def check_gammaloop_dependencies(clean_dependencies=False, build_dependencies=Fa
     if build_dependencies:
         print("Building gammaloop dependencies in '%s' using the %s./bin/build_dependencies.sh%s script ..." % (
             os.path.abspath(os.path.join(gammaloop_root_path, 'dependencies')), CLIColour.GREEN, CLIColour.END))
-        Popen([f"bash {os.path.join('.', 'bin', 'build_dependencies.sh')}",],
+        Popen([f"bash {os.path.join('.', 'bin', 'build_dependencies.sh')}{' with_venv' if install_dependencies_with_venv else ''}",],
               shell=True, cwd=gammaloop_root_path).wait()
         if not os.path.isfile(os.path.join(gammaloop_root_path, 'dependencies', 'INSTALLED')):
             print("%sCould not build the dependencies. Find more information in '%s'.%s" % (
@@ -64,15 +64,20 @@ def check_gammaloop_dependencies(clean_dependencies=False, build_dependencies=Fa
         gammaloop_root_path, 'dependencies', 'venv'))
 
     if venv_path != os.path.abspath(os.path.join(os.path.dirname(sys.executable), os.path.pardir)):
-        # Do not warn about this for now as it is not strictly necessary as of now
+        # Do not warn about this for now as it is not strictly necessary
         # print("%sWARNING:%s It is recommended to run gammaloop within its Python virtual environment, by issuing the command:\n\n%ssource %s/bin/activate%s\n" % (
         #    CLIColour.YELLOW, CLIColour.END, CLIColour.GREEN, venv_path, CLIColour.END))
         pass
 
+    additional_python_paths = []
+
     if not no_gammaloop_python_venv:
+
         if not os.path.isfile(os.path.join(venv_path, 'site_paths.txt')):
-            print("%sWARNING:%s Could not find Python virtual environment list of sites in file '%s'.\nConsider running '%sgammaloop --clean_dependencies --build_dependencies%s' to re-install gammaloop dependencies.\n" % (
-                CLIColour.YELLOW, CLIColour.END, os.path.join(venv_path, 'venv_site_paths.txt'), CLIColour.GREEN, CLIColour.END))
+            # Do not warn about this for now as it is not strictly necessary
+            # print("%sWARNING:%s Could not find Python virtual environment list of sites in file '%s'.\nConsider running '%sgammaloop --clean_dependencies --build_dependencies%s' to re-install gammaloop dependencies.\n" % (
+            #     CLIColour.YELLOW, CLIColour.END, os.path.join(venv_path, 'venv_site_paths.txt'), CLIColour.GREEN, CLIColour.END))
+            pass
         else:
             try:
                 with open(os.path.join(venv_path, 'site_paths.txt'), 'r') as f:
@@ -82,13 +87,27 @@ def check_gammaloop_dependencies(clean_dependencies=False, build_dependencies=Fa
                 print("%sWARNING:%s Could not extract list of site paths of the Python virtual environment of gammaloop from file '%s' (error: %s%s%s).\nConsider running '%sgammaloop --clean_dependencies --build_dependencies%s' to re-install gammaloop dependencies.\n" % (
                     CLIColour.YELLOW, CLIColour.END, os.path.join(venv_path, 'site_paths.txt'), CLIColour.RED, str(e), CLIColour.END, CLIColour.GREEN, CLIColour.END))
             if site_paths is not None:
-                site_paths = [sp for sp in site_paths if sp.startswith(
-                    venv_path) and (len(sys.path) == 0 or sp != sys.path[0])]
-                if len(site_paths) > 0:
-                    print("%sINFO:%s The following paths have been automatically and temporarily added by gammaloop to your PYTHONPATH:\n%s" % (
-                        CLIColour.GREEN, CLIColour.END, '\n'.join('%s%s%s' % (CLIColour.BLUE, site_path, CLIColour.END) for site_path in site_paths)))
-                    for site_path in site_paths:
-                        sys.path.insert(0, site_path)
+                additional_python_paths.extend([sp for sp in site_paths if sp.startswith(
+                    venv_path) and (len(sys.path) == 0 or sp != sys.path[0])])
+
+    if not os.path.isfile(os.path.join(gammaloop_root_path, 'dependencies', 'symbolica', 'symbolica_path.txt')):
+        print("\nSymbolica dependency appears to be incorrectly %sinstalled%s. Run '%sgammaloop --clean_dependencies --build_dependencies%s' to re-install gammaloop dependencies. Exiting.\n" % (
+            CLIColour.RED, CLIColour.END, CLIColour.GREEN, CLIColour.END))
+        sys.exit(1)
+    else:
+        with open(os.path.join(gammaloop_root_path, 'dependencies', 'symbolica', 'symbolica_path.txt'), 'r') as f:
+            symbolica_path = f.read()
+        if symbolica_path == '.':
+            symbolica_path = os.path.join(
+                gammaloop_root_path, 'dependencies', 'symbolica')
+        if symbolica_path not in sys.path:
+            additional_python_paths.append(symbolica_path)
+
+    if len(additional_python_paths) > 0:
+        print("%sINFO:%s The following paths have been automatically and temporarily added by gammaloop to your PYTHONPATH:\n%s" % (
+            CLIColour.GREEN, CLIColour.END, '\n'.join('%s%s%s' % (CLIColour.BLUE, site_path, CLIColour.END) for site_path in additional_python_paths)))
+        for additional_python_path in additional_python_paths:
+            sys.path.insert(0, additional_python_path)
 
     DEPENDENCIES_CHECKED = True
 
@@ -106,6 +125,8 @@ def cli():
                            default=False, help='Enable debug mode')
     argparser.add_argument('--build_dependencies', '-bd', action='store_true',
                            default=False, help='Build dependencies')
+    argparser.add_argument('--install_dependencies_with_venv', '-wv', action='store_true',
+                           default=False, help='Install dependencies within a virtual environment')
     argparser.add_argument('--clean_dependencies', '-cd', action='store_true',
                            default=False, help='Clean dependencies build')
     argparser.add_argument('--no_gammaloop_python_venv', '-no_venv', action='store_true',
@@ -140,7 +161,7 @@ def cli():
 
     # Before importing anything of gammaloop, check the dependencies with proper arguments
     check_gammaloop_dependencies(args.clean_dependencies, args.build_dependencies,
-                                 args.no_gammaloop_python_venv)
+                                 args.no_gammaloop_python_venv, args.install_dependencies_with_venv)
 
     from .interface.gammaloop_interface import CommandList
     from .interface.gammaloop_interface import GammaLoop

--- a/python/gammaloop/dependencies/fjcore/Makefile
+++ b/python/gammaloop/dependencies/fjcore/Makefile
@@ -1,6 +1,4 @@
-CXX=g++
-
-CXXFLAGS=-O2 -fPIC
+CXX ?= g++
 
 all: libfjcore
 
@@ -14,5 +12,5 @@ distclean: clean
 	rm -f fjcore.o wrapper.o libfjcore.a
 
 .cc.o:         $<
-	$(CXX) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) -O2 -fPIC -c $< -o $@
 

--- a/python/gammaloop/misc/common.py
+++ b/python/gammaloop/misc/common.py
@@ -48,7 +48,7 @@ try:
     import symbolica  # pylint: disable=import-error # type: ignore
     # pylint: disable=unused-import
     from symbolica import Expression, Transformer, set_license_key  # type: ignore
-    if not str(os.path.abspath(symbolica.__file__)).startswith(str(os.path.join(GL_PATH, 'dependencies', 'venv'))):
+    if not str(os.path.abspath(symbolica.__file__)).startswith(str(os.path.join(GL_PATH, 'dependencies'))):
         logger.warning(
             """\n\n/*
 |
@@ -56,7 +56,7 @@ try:
 | Instead it was loaded from %s%s%s.
 | This may lead to unexpected behaviour. You can avoid this by running the following command:
 |
-| %sgammaloop --build_dependencies && source %s%s
+| %sgammaloop --build_dependencies with_venv && source %s%s
 |
 \\*
 """,
@@ -64,7 +64,7 @@ try:
             Colour.GREEN, os.path.abspath(os.path.join(GL_PATH, 'dependencies', 'venv', 'bin', 'activate')), Colour.END)
 except ImportError:
     logger.critical(
-        "Could not import Symbolica, please run\n\n%sgammaloop --build_dependencies && source %s%s\n", Colour.GREEN,
+        "Could not import Symbolica, please run\n\n%sgammaloop --build_dependencies with_venv && source %s%s\n", Colour.GREEN,
         os.path.abspath(os.path.join(
             GL_PATH, 'dependencies', 'venv', 'bin', 'activate')),
         Colour.END)
@@ -90,7 +90,7 @@ def register_symbolica() -> bool:
     global gl_is_symbolica_registered
 
     # Check if is_licensed exist for backward compatibility. Later on, it can be removed.
-    if gl_is_symbolica_registered is not None or (hasattr(symbolica, 'is_licensed') and symbolica.is_licensed()):
+    if gl_is_symbolica_registered is not None or (hasattr(symbolica, 'is_licensed') and symbolica.is_licensed()):  # type: ignore # nopep8
         gl_is_symbolica_registered = True
         return True
 


### PR DESCRIPTION
Get rid of venv in build_dependencies as it causes problems for people using a Conda python.
Instead, by default, the python module of our symbolica fork is built "manually" with `cargo build --features=python_api` instead of using maturin.