### PR TITLE
add ratatui integration dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ MANIFEST
 IGNORE/
 crates/gammaloop-api/python/gammaloop/libgammaloop_api*
 # Temporary cache files
-*.swo
+*.sw*
 
 gammaloop_state_integration_workspace/
 result/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@
 - Backward compatibility with old on-disk GammaLoop states is also currently a non-goal: it is acceptable to rename/remove legacy state files, layouts, and loaders when that simplifies the implementation.
 - Do not keep compatibility fallbacks for old state formats/names unless the task explicitly asks for migration support.
 - Never be afraid to modify existing functions to obtain the most elegant and concise code as opposed to trying to be backward compatible or leave existing code untouched.
+- When suitable, prefer implementing behavior as methods on existing structs/enums instead of free functions to improve discoverability.
 - In generic or arbitrary-precision code, do not introduce constants or intermediate values through `from_f64`, `std::f64::consts::*`, or other lossy `f64` routes unless that exact location is an explicit `f64` boundary by design (for example persisted settings that are already `f64`, or histogram/output accumulation that is intentionally `f64`).
 - `f64` values originating from user-supplied settings are an allowed boundary: converting those setting values into `F<T>` with `from_f64` is acceptable. Do not extend that exception to internally generated constants or intermediate values.
 - When working with `F<T>` or other precision-generic numeric code, build constants from an in-scope representative value of the correct type using helpers such as `.zero()`, `.one()`, `.epsilon()`, `.PI()`, `.TAU()`, `.from_usize()`, `.from_isize()`, etc., so the active precision is preserved exactly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "base62"
-version = "2.2.3"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adf9755786e27479693dedd3271691a92b5e242ab139cacb9fb8e7fb5381111"
+checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
 
 [[package]]
 name = "base64"
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -1404,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -1905,18 +1905,18 @@ checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 
 [[package]]
 name = "gmp-mpfr-sys"
-version = "1.6.8"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
+checksum = "8cfc928d8ff4ab3767a3674cf55f81186436fb6070866bb1443ffe65a640d2d6"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "graphica"
 version = "1.2.1"
-source = "git+https://github.com/benruijl/symbolica?branch=dev#650ba97bf3da7cf2ff5ada92875f92d5f71e7a31"
+source = "git+https://github.com/benruijl/symbolica?branch=dev#72fe9f2a2267c88440d028cb70c935afb700631e"
 dependencies = [
  "ahash",
  "dyn-clone",
@@ -2285,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -2891,7 +2891,7 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 [[package]]
 name = "numerica"
 version = "1.3.0"
-source = "git+https://github.com/benruijl/symbolica?branch=dev#650ba97bf3da7cf2ff5ada92875f92d5f71e7a31"
+source = "git+https://github.com/benruijl/symbolica?branch=dev#72fe9f2a2267c88440d028cb70c935afb700631e"
 dependencies = [
  "ahash",
  "bincode 2.0.1",
@@ -2908,7 +2908,7 @@ dependencies = [
  "rug",
  "serde",
  "smallvec",
- "wide 1.1.1",
+ "wide 1.2.0",
 ]
 
 [[package]]
@@ -3232,9 +3232,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -3837,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "rug"
-version = "1.28.1"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de190ec858987c79cad4da30e19e546139b3339331282832af004d0ea7829639"
+checksum = "25f6c8f906c90b48e0c1745c9f814c3a31c5eba847043b05c3e9a934dec7c4b3"
 dependencies = [
  "az",
  "gmp-mpfr-sys",
@@ -4596,7 +4596,7 @@ dependencies = [
 [[package]]
 name = "symbolica"
 version = "1.4.0"
-source = "git+https://github.com/benruijl/symbolica?branch=dev#650ba97bf3da7cf2ff5ada92875f92d5f71e7a31"
+source = "git+https://github.com/benruijl/symbolica?branch=dev#72fe9f2a2267c88440d028cb70c935afb700631e"
 dependencies = [
  "ahash",
  "append-only-vec",
@@ -4625,7 +4625,7 @@ dependencies = [
  "tinyjson",
  "tracing",
  "tracing-subscriber",
- "wide 1.1.1",
+ "wide 1.2.0",
 ]
 
 [[package]]
@@ -4948,7 +4948,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4980,7 +4980,7 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4995,16 +4995,16 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -5015,9 +5015,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tracing"
@@ -5600,7 +5600,7 @@ dependencies = [
 [[package]]
 name = "wasm-minimal-protocol"
 version = "0.1.0"
-source = "git+https://github.com/astrale-sharp/wasm-minimal-protocol#53d45d0e4b626d692aca84b825867611ecb07be9"
+source = "git+https://github.com/astrale-sharp/wasm-minimal-protocol#41a1b1ced851768ad1867ccf2ca97cba85dbf81b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5742,9 +5742,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac11b009ebeae802ed758530b6496784ebfee7a87b9abfbcaf3bbe25b814eb25"
+checksum = "198f6abc41fab83526d10880fa5c17e2b4ee44e763949b4bb34e2fd1e8ca48e4"
 dependencies = [
  "bytemuck",
  "safe_arch 1.0.0",
@@ -6072,6 +6072,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6181,18 +6187,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "amd"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,12 +317,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -466,6 +493,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -693,6 +729,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +784,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -838,6 +897,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more 2.1.1",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,13 +940,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf 0.11.3",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix",
+ "nix 0.31.2",
  "windows-sys 0.61.2",
 ]
 
@@ -891,6 +978,16 @@ checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core 0.20.11",
  "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -922,6 +1019,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +1054,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "delegate"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1074,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deprecate-until"
@@ -1043,7 +1170,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1065,6 +1192,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1151,6 +1279,15 @@ name = "distrs"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3b3318a6ce94bae6f71c71dfbb5c91059ea2afa3c2ac86d8fb9b1f6ea5de83"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "dot-parser"
@@ -1285,6 +1422,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,10 +1472,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -1341,6 +1511,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "funty"
@@ -1397,7 +1573,7 @@ dependencies = [
  "color-eyre",
  "colored 3.1.1",
  "console 0.16.3",
- "crossterm",
+ "crossterm 0.28.1",
  "dirs 6.0.0",
  "eyre",
  "figment",
@@ -1417,6 +1593,7 @@ dependencies = [
  "pyo3-build-config 0.28.2",
  "pyo3-stub-gen",
  "rand 0.9.2",
+ "ratatui",
  "rayon",
  "reedline",
  "regex",
@@ -1509,6 +1686,7 @@ dependencies = [
  "pyo3",
  "pyo3-stub-gen",
  "rand 0.9.2",
+ "ratatui",
  "rayon",
  "ref-ops",
  "ringbuffer",
@@ -1763,7 +1941,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1771,6 +1949,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1789,6 +1972,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexf"
@@ -1965,6 +2154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,6 +2176,19 @@ dependencies = [
  "tempfile",
  "toml_edit 0.23.10+spec-1.0.0",
  "toml_writer",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2130,6 +2341,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2361,12 @@ dependencies = [
  "euclid",
  "smallvec",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lalrpop-util"
@@ -2199,6 +2427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2281,6 +2518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2537,25 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
 
 [[package]]
 name = "maplit"
@@ -2325,6 +2587,21 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2460,6 +2737,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
@@ -2529,6 +2819,17 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -2675,6 +2976,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,6 +3101,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -2800,7 +3111,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -2833,6 +3144,19 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3013,8 +3337,8 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
@@ -3262,6 +3586,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.0",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm 0.28.1",
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,14 +3735,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9152b55a7af872d1ea9ac81c619fd02368d3e3b27ff195c56ab3fc300f4fd0"
 dependencies = [
  "chrono",
- "crossterm",
+ "crossterm 0.28.1",
  "fd-lock",
  "itertools 0.13.0",
  "nu-ansi-term",
  "serde",
  "strip-ansi-escapes",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-width",
@@ -3405,7 +3815,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bitflags 2.11.0",
  "serde",
  "serde_derive",
@@ -4140,6 +4550,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4149,6 +4568,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4278,6 +4709,69 @@ checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf 0.11.3",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf 0.11.3",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -4759,6 +5253,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4815,6 +5320,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vakint"
@@ -4959,6 +5476,15 @@ checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
  "memchr",
+]
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
 ]
 
 [[package]]
@@ -5121,6 +5647,78 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim 0.11.1",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ pyo3-build-config = "0.28"
 pyo3-stub-gen = { version = "0.17", default-features = false }
 pyo3-stub-gen-derive = { version = "0.17", default-features = false }
 rand = "0.9"
+ratatui = "0.30.0"
 rayon = "1.5"
 schemars = "1.0.4"
 serde = "1.0.219"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
 use vergen_gitcl::{Emitter, GitclBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-env-changed=EXTRA_MACOS_LIBS_FOR_GNU_GCC");
+
     #[cfg(not(test))]
     {
         let git = GitclBuilder::default().branch(true).build()?;

--- a/crates/gammaloop-api/Cargo.toml
+++ b/crates/gammaloop-api/Cargo.toml
@@ -58,6 +58,7 @@ rand = { workspace = true, features = ["small_rng"] }
 rayon = { workspace = true }
 reedline = "0.42.0"
 regex = "1.11.2"
+ratatui = { workspace = true, features = ["crossterm_0_28"] }
 rust-embed = { version = "8.4", features = ["interpolate-folder-path"] }
 schemars = { workspace = true }
 serde = { workspace = true }

--- a/crates/gammaloop-api/build.rs
+++ b/crates/gammaloop-api/build.rs
@@ -4,6 +4,8 @@ use vergen_gitcl::{Emitter, GitclBuilder};
 use walkdir::WalkDir;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-env-changed=EXTRA_MACOS_LIBS_FOR_GNU_GCC");
+
     #[cfg(feature = "vergen_gitcl")]
     {
         let git = GitclBuilder::default().branch(true).build()?;

--- a/crates/gammaloop-api/src/commands/evaluate_samples.rs
+++ b/crates/gammaloop-api/src/commands/evaluate_samples.rs
@@ -83,7 +83,14 @@ impl<'a> EvaluateSamples<'a> {
             let samples =
                 build_havana_samples(integrand, &self.points, self.discrete_dims.as_ref())?;
             integrand
-                .evaluate_samples_raw(&model, &samples, 1, self.use_arb_prec, Complex::new_zero())?
+                .evaluate_samples_raw(
+                    &model,
+                    &samples,
+                    1,
+                    self.use_arb_prec,
+                    false,
+                    Complex::new_zero(),
+                )?
                 .samples
         };
 

--- a/crates/gammaloop-api/src/commands/integrate.rs
+++ b/crates/gammaloop-api/src/commands/integrate.rs
@@ -4,13 +4,20 @@ use std::{
     io::{self, IsTerminal, Write},
     ops::Deref,
     path::PathBuf,
+    sync::mpsc,
+    thread,
+    time::Duration,
 };
 
 use clap::{ArgAction, Args, ValueEnum};
 use crossterm::{
-    cursor::{MoveDown, MoveToColumn, MoveUp},
-    queue,
-    terminal::{self, Clear, ClearType},
+    cursor::{Hide, MoveDown, MoveToColumn, MoveUp, Show},
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    execute, queue,
+    terminal::{
+        self, disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen,
+        LeaveAlternateScreen,
+    },
 };
 use gammalooprs::utils::serde_utils::SmartSerde;
 use schemars::JsonSchema;
@@ -28,11 +35,13 @@ use gammalooprs::{
         render_saved_integration_summary, render_status_update_tabled, slot_workspace_path,
         workspace_manifest_path, workspace_state_path, ContributionSortMode, IntegrationState,
         IntegrationStatusKind, IntegrationStatusPhaseDisplay, IntegrationStatusViewOptions,
-        IntegrationWorkspaceManifest, IterationBatchingSettings, SamplingCorrelationMode, SlotMeta,
-        StatusUpdate, TabledRenderOptions, WorkspaceSnapshotControl,
+        IntegrationWorkspaceManifest, IterationBatchingSettings, RatatuiDashboardState,
+        SamplingCorrelationMode, SlotMeta, StatusUpdate, TabledRenderOptions,
+        WorkspaceSnapshotControl,
     },
     model::{Model, SerializableInputParamCard},
     observables::ObservableSnapshotBundle,
+    request_interrupt, request_iteration_abort,
     settings::{
         runtime::{IntegratedPhase, IntegrationResult},
         RuntimeSettings,
@@ -40,6 +49,7 @@ use gammalooprs::{
     utils::F,
 };
 use itertools::Itertools;
+use ratatui::{backend::CrosstermBackend, Terminal};
 use symbolica::numerical_integration::Grid;
 use tracing::{info, warn};
 
@@ -144,6 +154,10 @@ pub struct Integrate {
     #[arg(long = "no-stream-updates")]
     pub no_stream_updates: bool,
 
+    /// Renderer used for interactive streaming integration updates
+    #[arg(long = "renderer", default_value = "ratatui")]
+    pub renderer: RendererOption,
+
     /// Evaluate each iteration in per-core batches of this size
     #[arg(long = "batch-size")]
     pub batch_size: Option<usize>,
@@ -219,6 +233,7 @@ impl Default for Integrate {
             show_summary_only: false,
             no_stream_iterations: false,
             no_stream_updates: false,
+            renderer: RendererOption::Ratatui,
             batch_size: None,
             batch_timing: 5.0,
             min_time_between_status_updates: 0.0,
@@ -264,6 +279,15 @@ pub enum ContributionSortOption {
     Error,
 }
 
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, ValueEnum, Default,
+)]
+pub enum RendererOption {
+    Tabled,
+    #[default]
+    Ratatui,
+}
+
 impl From<ContributionSortOption> for ContributionSortMode {
     fn from(value: ContributionSortOption) -> Self {
         match value {
@@ -274,20 +298,23 @@ impl From<ContributionSortOption> for ContributionSortMode {
     }
 }
 
-struct StreamRenderer {
+struct TabledStreamRenderer {
     stderr: io::Stderr,
     rendered_line_count: usize,
+    control_listener: Option<TabledControlListener>,
 }
 
-impl StreamRenderer {
+impl TabledStreamRenderer {
     fn new() -> Self {
         Self {
             stderr: io::stderr(),
             rendered_line_count: 0,
+            control_listener: None,
         }
     }
 
     fn render(&mut self, block: &str) -> Result<()> {
+        self.ensure_control_listener();
         let prepared = prepare_stream_block(block, stream_terminal_width());
         if self.rendered_line_count > 0 {
             self.clear_rendered_block()?;
@@ -301,13 +328,31 @@ impl StreamRenderer {
     }
 
     fn clear(&mut self) -> Result<()> {
-        if self.rendered_line_count == 0 {
-            return Ok(());
+        if self.rendered_line_count > 0 {
+            self.clear_rendered_block()?;
+            self.rendered_line_count = 0;
+            self.stderr.flush()?;
         }
 
-        self.clear_rendered_block()?;
-        self.rendered_line_count = 0;
-        self.stderr.flush()?;
+        self.shutdown_control_listener()?;
+        Ok(())
+    }
+
+    fn ensure_control_listener(&mut self) {
+        if self.control_listener.is_none() {
+            self.control_listener = TabledControlListener::new()
+                .map_err(|err| {
+                    warn!("Failed to start tabled streaming control listener: {err}");
+                    err
+                })
+                .ok();
+        }
+    }
+
+    fn shutdown_control_listener(&mut self) -> Result<()> {
+        if let Some(mut control_listener) = self.control_listener.take() {
+            control_listener.shutdown()?;
+        }
         Ok(())
     }
 
@@ -337,9 +382,273 @@ impl StreamRenderer {
     }
 }
 
-impl Drop for StreamRenderer {
+impl Drop for TabledStreamRenderer {
     fn drop(&mut self) {
         let _ = self.clear();
+    }
+}
+
+enum TabledControlCommand {
+    Shutdown(mpsc::SyncSender<Result<()>>),
+}
+
+struct TabledControlListener {
+    sender: mpsc::Sender<TabledControlCommand>,
+    handle: Option<thread::JoinHandle<Result<()>>>,
+}
+
+impl TabledControlListener {
+    fn new() -> Result<Self> {
+        let (sender, receiver) = mpsc::channel();
+        let (startup_sender, startup_receiver) = mpsc::sync_channel(0);
+        let handle = thread::spawn(move || tabled_control_event_loop(receiver, startup_sender));
+        startup_receiver
+            .recv()
+            .map_err(|err| eyre!("Failed to start tabled control listener: {err}"))?
+            .map_err(|err| eyre!("Failed to start tabled control listener: {err}"))?;
+        Ok(Self {
+            sender,
+            handle: Some(handle),
+        })
+    }
+
+    fn shutdown(&mut self) -> Result<()> {
+        let (ack_sender, ack_receiver) = mpsc::sync_channel(0);
+        self.sender
+            .send(TabledControlCommand::Shutdown(ack_sender))
+            .map_err(|err| eyre!("Failed to stop tabled control listener: {err}"))?;
+        ack_receiver.recv().map_err(|err| {
+            eyre!("Failed to receive tabled control listener acknowledgement: {err}")
+        })??;
+        if let Some(handle) = self.handle.take() {
+            handle
+                .join()
+                .map_err(|_| eyre!("Tabled control listener thread panicked"))??;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for TabledControlListener {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+enum DashboardCommand {
+    Update(StatusUpdate),
+    Suspend(mpsc::SyncSender<Result<()>>),
+    Shutdown(mpsc::SyncSender<Result<()>>),
+}
+
+struct RatatuiTerminal {
+    terminal: Terminal<CrosstermBackend<io::Stderr>>,
+}
+
+impl RatatuiTerminal {
+    fn enter() -> Result<Self> {
+        enable_raw_mode()?;
+        let mut stderr = io::stderr();
+        execute!(stderr, EnterAlternateScreen, Hide)?;
+        let backend = CrosstermBackend::new(io::stderr());
+        let mut terminal = Terminal::new(backend)?;
+        terminal.clear()?;
+        Ok(Self { terminal })
+    }
+
+    fn draw(&mut self, dashboard: &RatatuiDashboardState) -> Result<()> {
+        self.terminal.draw(|frame| dashboard.draw(frame))?;
+        Ok(())
+    }
+
+    fn leave(mut self) -> Result<()> {
+        self.terminal.clear()?;
+        execute!(self.terminal.backend_mut(), Show, LeaveAlternateScreen)?;
+        disable_raw_mode()?;
+        Ok(())
+    }
+}
+
+struct RatatuiStreamRenderer {
+    sender: mpsc::Sender<DashboardCommand>,
+    handle: Option<thread::JoinHandle<Result<()>>>,
+}
+
+impl RatatuiStreamRenderer {
+    fn new() -> Self {
+        let (sender, receiver) = mpsc::channel();
+        let handle = thread::spawn(move || dashboard_event_loop(receiver));
+        Self {
+            sender,
+            handle: Some(handle),
+        }
+    }
+
+    fn render(&mut self, update: StatusUpdate) -> Result<()> {
+        self.sender
+            .send(DashboardCommand::Update(update))
+            .map_err(|err| eyre!("Failed to send dashboard update: {err}"))?;
+        Ok(())
+    }
+
+    fn suspend(&mut self) -> Result<()> {
+        self.send_ack_command(DashboardCommand::Suspend)
+    }
+
+    fn shutdown(&mut self) -> Result<()> {
+        self.send_ack_command(DashboardCommand::Shutdown)?;
+        if let Some(handle) = self.handle.take() {
+            handle
+                .join()
+                .map_err(|_| eyre!("Ratatui dashboard thread panicked"))??;
+        }
+        Ok(())
+    }
+
+    fn send_ack_command(
+        &mut self,
+        build: impl FnOnce(mpsc::SyncSender<Result<()>>) -> DashboardCommand,
+    ) -> Result<()> {
+        let (ack_sender, ack_receiver) = mpsc::sync_channel(0);
+        self.sender
+            .send(build(ack_sender))
+            .map_err(|err| eyre!("Failed to send dashboard command: {err}"))?;
+        ack_receiver
+            .recv()
+            .map_err(|err| eyre!("Failed to receive dashboard acknowledgement: {err}"))??;
+        Ok(())
+    }
+}
+
+impl Drop for RatatuiStreamRenderer {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+enum StreamRenderer {
+    Tabled(TabledStreamRenderer),
+    Ratatui(RatatuiStreamRenderer),
+}
+
+impl StreamRenderer {
+    fn new(renderer: RendererOption) -> Self {
+        match renderer {
+            RendererOption::Tabled => Self::Tabled(TabledStreamRenderer::new()),
+            RendererOption::Ratatui => Self::Ratatui(RatatuiStreamRenderer::new()),
+        }
+    }
+
+    fn render(&mut self, update: StatusUpdate, tabled_block: &str) -> Result<()> {
+        match self {
+            Self::Tabled(renderer) => renderer.render(tabled_block),
+            Self::Ratatui(renderer) => renderer.render(update),
+        }
+    }
+
+    fn clear(&mut self) -> Result<()> {
+        match self {
+            Self::Tabled(renderer) => renderer.clear(),
+            Self::Ratatui(renderer) => renderer.suspend(),
+        }
+    }
+
+    fn shutdown(&mut self) -> Result<()> {
+        match self {
+            Self::Tabled(renderer) => renderer.clear(),
+            Self::Ratatui(renderer) => renderer.shutdown(),
+        }
+    }
+}
+
+struct StreamingDisplayController {
+    renderer_kind: RendererOption,
+    stream_updates: bool,
+    stream_iterations: bool,
+    tabled_options: TabledRenderOptions,
+    renderer: Option<StreamRenderer>,
+}
+
+impl StreamingDisplayController {
+    fn new(
+        renderer_kind: RendererOption,
+        stream_updates: bool,
+        stream_iterations: bool,
+        tabled_options: TabledRenderOptions,
+    ) -> Self {
+        Self {
+            renderer_kind,
+            stream_updates,
+            stream_iterations,
+            tabled_options,
+            renderer: (stream_updates || stream_iterations)
+                .then(|| StreamRenderer::new(renderer_kind)),
+        }
+    }
+
+    fn handle_status_update(&mut self, status_update: StatusUpdate) -> Result<()> {
+        let kind = status_update.kind();
+        let renderer_kind = self.renderer_kind;
+        let tabled_options = self.tabled_options;
+
+        if let Some(renderer) = self.renderer.as_mut() {
+            match kind {
+                IntegrationStatusKind::Live => {
+                    if self.stream_updates || status_update.is_initial_live_status() {
+                        let status_block = Self::render_stream_block(
+                            renderer_kind,
+                            tabled_options,
+                            &status_update,
+                        );
+                        renderer.render(status_update, &status_block)?;
+                    }
+                }
+                IntegrationStatusKind::Iteration => {
+                    if self.stream_iterations {
+                        let status_block = Self::render_stream_block(
+                            renderer_kind,
+                            tabled_options,
+                            &status_update,
+                        );
+                        renderer.render(status_update, &status_block)?;
+                    } else {
+                        renderer.clear()?;
+                        self.emit_tabled_status(kind, &status_update)?;
+                    }
+                }
+                IntegrationStatusKind::Final => {
+                    if let Some(mut renderer) = self.renderer.take() {
+                        renderer.shutdown()?;
+                    }
+                    self.emit_tabled_status(kind, &status_update)?;
+                }
+            }
+        } else if kind != IntegrationStatusKind::Live {
+            self.emit_tabled_status(kind, &status_update)?;
+        }
+
+        Ok(())
+    }
+
+    fn emit_tabled_status(
+        &self,
+        kind: IntegrationStatusKind,
+        status_update: &StatusUpdate,
+    ) -> Result<()> {
+        let status_block = render_status_update_tabled(status_update, &self.tabled_options);
+        emit_integration_status_via_tracing(kind, &status_block)
+    }
+
+    fn render_stream_block(
+        renderer_kind: RendererOption,
+        tabled_options: TabledRenderOptions,
+        status_update: &StatusUpdate,
+    ) -> String {
+        if matches!(renderer_kind, RendererOption::Tabled) {
+            render_status_update_tabled(status_update, &tabled_options)
+        } else {
+            String::new()
+        }
     }
 }
 
@@ -354,7 +663,9 @@ fn prepare_stream_block(block: &str, max_width: usize) -> String {
         .lines()
         .map(|line| truncate_ansi_line(line, max_width))
         .collect::<Vec<_>>()
-        .join("\n")
+        // Tabled streaming can run while the terminal is in raw mode, where a
+        // bare `\n` no longer returns the cursor to column zero.
+        .join("\r\n")
 }
 
 fn truncate_ansi_line(line: &str, max_width: usize) -> String {
@@ -397,6 +708,182 @@ fn truncate_ansi_line(line: &str, max_width: usize) -> String {
     }
 
     truncated
+}
+
+fn tabled_control_event_loop(
+    receiver: mpsc::Receiver<TabledControlCommand>,
+    startup_sender: mpsc::SyncSender<std::result::Result<(), String>>,
+) -> Result<()> {
+    if let Err(err) = enable_raw_mode() {
+        let _ = startup_sender.send(Err(err.to_string()));
+        return Err(err.into());
+    }
+    let _ = startup_sender.send(Ok(()));
+
+    let result = (|| -> Result<()> {
+        loop {
+            match receiver.recv_timeout(Duration::from_millis(50)) {
+                Ok(TabledControlCommand::Shutdown(ack_sender)) => {
+                    let _ = ack_sender.send(Ok(()));
+                    break;
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+
+            while event::poll(Duration::from_millis(0))? {
+                if let Event::Key(key) = event::read()? {
+                    if key.kind != KeyEventKind::Press {
+                        continue;
+                    }
+
+                    match handle_tabled_key_event(key) {
+                        TabledKeyAction::Ignored => {}
+                        TabledKeyAction::InterruptIntegration => request_interrupt(),
+                        TabledKeyAction::AbortCurrentIteration => request_iteration_abort(),
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    })();
+
+    disable_raw_mode()?;
+    result
+}
+
+fn dashboard_event_loop(receiver: mpsc::Receiver<DashboardCommand>) -> Result<()> {
+    let mut dashboard = RatatuiDashboardState::new();
+    let mut terminal = None;
+    let mut dirty = false;
+
+    loop {
+        match receiver.recv_timeout(Duration::from_millis(50)) {
+            Ok(DashboardCommand::Update(update)) => {
+                dashboard.update(update);
+                if terminal.is_none() {
+                    terminal = Some(RatatuiTerminal::enter()?);
+                }
+                dirty = true;
+            }
+            Ok(DashboardCommand::Suspend(ack_sender)) => {
+                let result = match terminal.take() {
+                    Some(terminal) => terminal.leave(),
+                    None => Ok(()),
+                };
+                let _ = ack_sender.send(result);
+                dirty = false;
+            }
+            Ok(DashboardCommand::Shutdown(ack_sender)) => {
+                let result = match terminal.take() {
+                    Some(terminal) => terminal.leave(),
+                    None => Ok(()),
+                };
+                let _ = ack_sender.send(result);
+                break;
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+
+        while terminal.is_some() && event::poll(Duration::from_millis(0))? {
+            let mut handled = false;
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    handled = match handle_dashboard_key_event(&mut dashboard, key) {
+                        DashboardKeyAction::Redraw => true,
+                        DashboardKeyAction::InterruptIntegration => {
+                            request_interrupt();
+                            true
+                        }
+                        DashboardKeyAction::AbortCurrentIteration => {
+                            request_iteration_abort();
+                            true
+                        }
+                        DashboardKeyAction::Ignored => false,
+                    };
+                }
+                Event::Resize(_, _) => handled = true,
+                _ => {}
+            }
+            dirty |= handled;
+        }
+
+        if dirty {
+            if let Some(terminal) = terminal.as_mut() {
+                terminal.draw(&dashboard)?;
+                dirty = false;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DashboardKeyAction {
+    Ignored,
+    Redraw,
+    InterruptIntegration,
+    AbortCurrentIteration,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TabledKeyAction {
+    Ignored,
+    InterruptIntegration,
+    AbortCurrentIteration,
+}
+
+fn handle_tabled_key_event(key: KeyEvent) -> TabledKeyAction {
+    if key.modifiers.contains(KeyModifiers::CONTROL)
+        && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('C'))
+    {
+        return TabledKeyAction::InterruptIntegration;
+    }
+
+    if matches!(key.code, KeyCode::Char('x') | KeyCode::Char('X')) {
+        return TabledKeyAction::AbortCurrentIteration;
+    }
+
+    TabledKeyAction::Ignored
+}
+
+fn handle_dashboard_key_event(
+    dashboard: &mut RatatuiDashboardState,
+    key: KeyEvent,
+) -> DashboardKeyAction {
+    if key.modifiers.contains(KeyModifiers::CONTROL)
+        && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('C'))
+    {
+        return DashboardKeyAction::InterruptIntegration;
+    }
+
+    if matches!(key.code, KeyCode::Char('x') | KeyCode::Char('X')) {
+        return DashboardKeyAction::AbortCurrentIteration;
+    }
+
+    match key.code {
+        KeyCode::Char('1') => dashboard.select_tab(0),
+        KeyCode::Char('2') => dashboard.select_tab(1),
+        KeyCode::Char('3') => dashboard.select_tab(2),
+        KeyCode::Left => dashboard.previous_tab(),
+        KeyCode::Right => dashboard.next_tab(),
+        KeyCode::Char('[') => dashboard.focus_previous_slot(),
+        KeyCode::Char(']') => dashboard.focus_next_slot(),
+        KeyCode::Down | KeyCode::Char('j') => dashboard.select_next_discrete_row(),
+        KeyCode::Up | KeyCode::Char('k') => dashboard.select_previous_discrete_row(),
+        KeyCode::Char('s') => dashboard.cycle_discrete_sort(),
+        KeyCode::Char('v') => dashboard.toggle_discrete_sort_direction(),
+        KeyCode::Char('r') => dashboard.toggle_relative_error(),
+        KeyCode::Char('c') => dashboard.toggle_chi_sq(),
+        KeyCode::Char('w') => dashboard.toggle_max_weight_impact(),
+        KeyCode::Char('m') => dashboard.cycle_density(),
+        KeyCode::Esc | KeyCode::Char('?') => dashboard.toggle_help(),
+        _ => return DashboardKeyAction::Ignored,
+    }
+    DashboardKeyAction::Redraw
 }
 
 #[derive(Debug, Clone)]
@@ -596,6 +1083,12 @@ impl Integrate {
             phase_display: self
                 .show_phase
                 .resolve(settings.integrator.integrated_phase),
+            training_phase_display: match settings.integrator.integrated_phase {
+                IntegratedPhase::Real => IntegrationStatusPhaseDisplay::Real,
+                IntegratedPhase::Imag => IntegrationStatusPhaseDisplay::Imag,
+                IntegratedPhase::Both => IntegrationStatusPhaseDisplay::Both,
+            },
+            training_slot: 0,
             show_statistics,
             show_max_weight_details: self.show_max_weight_info,
             show_top_discrete_grid: self.show_top_discrete_grid,
@@ -608,6 +1101,11 @@ impl Integrate {
     fn build_tabled_render_options(&self) -> TabledRenderOptions {
         TabledRenderOptions {
             max_table_width: self.max_table_width,
+            show_statistics: !self.no_show_integration_statistics,
+            show_max_weight_details: self.show_max_weight_info,
+            show_top_discrete_grid: self.show_top_discrete_grid,
+            show_discrete_contributions_sum: self.show_discrete_contributions_sum,
+            show_max_weight_info_for_discrete_bins: self.show_max_weight_info_for_discrete_bins,
         }
     }
 
@@ -625,12 +1123,17 @@ impl Integrate {
         }
     }
 
-    fn build_batching_settings(&self, emit_live_status_updates: bool) -> IterationBatchingSettings {
+    fn build_batching_settings(
+        &self,
+        emit_live_status_updates: bool,
+        emit_initial_status_update: bool,
+    ) -> IterationBatchingSettings {
         IterationBatchingSettings {
             batch_size: self.batch_size,
             batch_timing_seconds: self.batch_timing,
             min_time_between_status_updates_seconds: self.min_time_between_status_updates,
             emit_live_status_updates,
+            emit_initial_status_update,
         }
     }
 
@@ -1214,7 +1717,13 @@ impl Integrate {
                 "Streaming integration updates disabled because stderr is not a TTY; live updates will be skipped and iteration summaries will be logged."
             );
         }
-        let mut stream_renderer = (stream_updates || stream_iterations).then(StreamRenderer::new);
+        let stream_renderer_kind = self.renderer;
+        let mut stream_controller = StreamingDisplayController::new(
+            stream_renderer_kind,
+            stream_updates,
+            stream_iterations,
+            tabled_options.clone(),
+        );
 
         let result = havana_integrate(
             slot_settings,
@@ -1233,36 +1742,10 @@ impl Integrate {
             integration_state,
             Some(workspace_path.clone()),
             self.workspace_snapshot_control(),
-            self.build_batching_settings(stream_updates),
+            self.build_batching_settings(stream_updates, stream_updates || stream_iterations),
             view_options,
             move |status_update: StatusUpdate| {
-                let status_block = render_status_update_tabled(&status_update, &tabled_options);
-                let kind = status_update.kind();
-                if let Some(renderer) = stream_renderer.as_mut() {
-                    match kind {
-                        IntegrationStatusKind::Live => {
-                            if stream_updates {
-                                renderer.render(&status_block)?;
-                            }
-                        }
-                        IntegrationStatusKind::Iteration => {
-                            if stream_iterations {
-                                renderer.render(&status_block)?;
-                            } else {
-                                renderer.clear()?;
-                                emit_integration_status_via_tracing(kind, &status_block)?;
-                            }
-                        }
-                        IntegrationStatusKind::Final => {
-                            renderer.clear()?;
-                            emit_integration_status_via_tracing(kind, &status_block)?;
-                        }
-                    }
-                } else if kind != IntegrationStatusKind::Live {
-                    emit_integration_status_via_tracing(kind, &status_block)?;
-                }
-
-                Ok(())
+                stream_controller.handle_status_update(status_update)
             },
         )?;
 
@@ -1282,8 +1765,9 @@ mod tests {
     use super::Integrate;
     use super::IntegrationOutput;
     use super::ResolvedIntegrandSlot;
-    use super::{ContributionSortOption, ShowPhaseOption};
+    use super::{ContributionSortOption, DashboardKeyAction, ShowPhaseOption, TabledKeyAction};
     use crate::{state::ProcessRef, CLISettings, SessionSettings, StateSettings};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use gammalooprs::{
         integrate::{ContributionSortMode, IntegrationStatusPhaseDisplay, SlotMeta},
         observables::ObservableSnapshotBundle,
@@ -1353,7 +1837,7 @@ mod tests {
         let block = "123456789\nabcdefghi";
         let prepared = super::prepare_stream_block(block, 5);
 
-        assert_eq!(prepared, "12345\nabcde");
+        assert_eq!(prepared, "12345\r\nabcde");
     }
 
     #[test]
@@ -1504,5 +1988,51 @@ mod tests {
             ContributionSortMode::Integral
         );
         assert!(render_options.show_max_weight_info_for_discrete_bins);
+    }
+
+    #[test]
+    fn dashboard_ctrl_c_requests_integration_interrupt() {
+        let mut dashboard = gammalooprs::integrate::RatatuiDashboardState::new();
+
+        assert_eq!(
+            super::handle_dashboard_key_event(
+                &mut dashboard,
+                KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL),
+            ),
+            DashboardKeyAction::InterruptIntegration
+        );
+    }
+
+    #[test]
+    fn dashboard_x_requests_iteration_abort() {
+        let mut dashboard = gammalooprs::integrate::RatatuiDashboardState::new();
+
+        assert_eq!(
+            super::handle_dashboard_key_event(
+                &mut dashboard,
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            ),
+            DashboardKeyAction::AbortCurrentIteration
+        );
+    }
+
+    #[test]
+    fn tabled_ctrl_c_requests_integration_interrupt() {
+        assert_eq!(
+            super::handle_tabled_key_event(KeyEvent::new(
+                KeyCode::Char('c'),
+                KeyModifiers::CONTROL,
+            )),
+            TabledKeyAction::InterruptIntegration
+        );
+    }
+
+    #[test]
+    fn batching_settings_can_emit_initial_status_without_live_updates() {
+        let integrate = Integrate::default();
+        let batching = integrate.build_batching_settings(false, true);
+
+        assert!(!batching.emit_live_status_updates);
+        assert!(batching.emit_initial_status_update);
     }
 }

--- a/crates/gammaloop-api/src/commands/integrate.rs
+++ b/crates/gammaloop-api/src/commands/integrate.rs
@@ -1119,6 +1119,8 @@ impl Integrate {
                 })
                 .collect(),
             per_slot_training_phase: self.uncorrelated,
+            target_relative_accuracy: settings.integrator.target_relative_accuracy,
+            target_absolute_accuracy: settings.integrator.target_absolute_accuracy,
             show_statistics,
             show_max_weight_details: self.show_max_weight_info,
             show_top_discrete_grid: self.show_top_discrete_grid,

--- a/crates/gammaloop-api/src/commands/integrate.rs
+++ b/crates/gammaloop-api/src/commands/integrate.rs
@@ -720,11 +720,12 @@ fn tabled_control_event_loop(
     }
     let _ = startup_sender.send(Ok(()));
 
+    let mut shutdown_ack = None;
     let result = (|| -> Result<()> {
         loop {
             match receiver.recv_timeout(Duration::from_millis(50)) {
                 Ok(TabledControlCommand::Shutdown(ack_sender)) => {
-                    let _ = ack_sender.send(Ok(()));
+                    shutdown_ack = Some(ack_sender);
                     break;
                 }
                 Err(mpsc::RecvTimeoutError::Timeout) => {}
@@ -749,7 +750,15 @@ fn tabled_control_event_loop(
         Ok(())
     })();
 
-    disable_raw_mode()?;
+    let cleanup_result: Result<()> = disable_raw_mode().map_err(|err| eyre!(err));
+    if let Some(ack_sender) = shutdown_ack.take() {
+        let ack_result = match cleanup_result.as_ref() {
+            Ok(()) => Ok(()),
+            Err(err) => Err(eyre!(err.to_string())),
+        };
+        let _ = ack_sender.send(ack_result);
+    }
+    cleanup_result?;
     result
 }
 
@@ -879,7 +888,13 @@ fn handle_dashboard_key_event(
         KeyCode::Char('r') => dashboard.toggle_relative_error(),
         KeyCode::Char('c') => dashboard.toggle_chi_sq(),
         KeyCode::Char('w') => dashboard.toggle_max_weight_impact(),
-        KeyCode::Char('m') => dashboard.cycle_density(),
+        KeyCode::Char('p') | KeyCode::Char('P') => dashboard.toggle_chart_component(),
+        KeyCode::Char('g') | KeyCode::Char('G') => dashboard.toggle_chart_history_window(),
+        KeyCode::Char('+') | KeyCode::Char('=') => dashboard.widen_chart_history_window(),
+        KeyCode::Char('-') | KeyCode::Char('_') => dashboard.narrow_chart_history_window(),
+        KeyCode::Char(',') | KeyCode::Char('<') => dashboard.narrow_chart_y_sigma_span(),
+        KeyCode::Char('.') | KeyCode::Char('>') => dashboard.widen_chart_y_sigma_span(),
+        KeyCode::Char('0') => dashboard.reset_chart_y_sigma_span(),
         KeyCode::Esc | KeyCode::Char('?') => dashboard.toggle_help(),
         _ => return DashboardKeyAction::Ignored,
     }
@@ -1001,6 +1016,15 @@ impl Integrate {
         }
     }
 
+    fn selected_training_phase_display(
+        integrated_phase: IntegratedPhase,
+    ) -> IntegrationStatusPhaseDisplay {
+        match integrated_phase {
+            IntegratedPhase::Real | IntegratedPhase::Both => IntegrationStatusPhaseDisplay::Real,
+            IntegratedPhase::Imag => IntegrationStatusPhaseDisplay::Imag,
+        }
+    }
+
     fn resolve_selected_slots(&self, state: &State) -> Result<Vec<ResolvedIntegrandSlot>> {
         let selections = if self.process.is_empty() && self.integrand_name.is_empty() {
             vec![state.find_integrand_ref(None, None)?]
@@ -1076,19 +1100,25 @@ impl Integrate {
 
     fn build_render_options(
         &self,
-        settings: &RuntimeSettings,
+        slot_settings: &[RuntimeSettings],
         show_statistics: bool,
     ) -> IntegrationStatusViewOptions {
+        let settings = &slot_settings[0];
         IntegrationStatusViewOptions {
             phase_display: self
                 .show_phase
                 .resolve(settings.integrator.integrated_phase),
-            training_phase_display: match settings.integrator.integrated_phase {
-                IntegratedPhase::Real => IntegrationStatusPhaseDisplay::Real,
-                IntegratedPhase::Imag => IntegrationStatusPhaseDisplay::Imag,
-                IntegratedPhase::Both => IntegrationStatusPhaseDisplay::Both,
-            },
+            training_phase_display: Self::selected_training_phase_display(
+                settings.integrator.integrated_phase,
+            ),
             training_slot: 0,
+            slot_training_phase_displays: slot_settings
+                .iter()
+                .map(|slot_settings| {
+                    Self::selected_training_phase_display(slot_settings.integrator.integrated_phase)
+                })
+                .collect(),
+            per_slot_training_phase: self.uncorrelated,
             show_statistics,
             show_max_weight_details: self.show_max_weight_info,
             show_top_discrete_grid: self.show_top_discrete_grid,
@@ -1633,7 +1663,7 @@ impl Integrate {
                 slot_settings_path(&workspace_path, slot0_meta),
                 &format!("workspace settings for {}", slot0_meta.key()),
             )?;
-            let view_options = self.build_render_options(&slot0_settings, true);
+            let view_options = self.build_render_options(&[slot0_settings.clone()], true);
             let tabled_options = self.build_tabled_render_options();
             emit_integration_status_via_tracing(
                 IntegrationStatusKind::Final,
@@ -1695,7 +1725,7 @@ impl Integrate {
             .map(|integrand| integrand.get_settings().clone())
             .collect_vec();
         let view_options =
-            self.build_render_options(&slot_settings[0], !self.no_show_integration_statistics);
+            self.build_render_options(&slot_settings, !self.no_show_integration_statistics);
         let tabled_options = self.build_tabled_render_options();
         self.write_workspace_manifest_and_settings(
             &slot_integrands,
@@ -1973,7 +2003,7 @@ mod tests {
             ..RuntimeSettings::default()
         };
 
-        let render_options = integrate.build_render_options(&settings, false);
+        let render_options = integrate.build_render_options(&[settings.clone()], false);
 
         assert_eq!(
             render_options.phase_display,
@@ -1988,6 +2018,29 @@ mod tests {
             ContributionSortMode::Integral
         );
         assert!(render_options.show_max_weight_info_for_discrete_bins);
+    }
+
+    #[test]
+    fn build_render_options_defaults_training_phase_to_real_for_both() {
+        let integrate = Integrate::default();
+        let settings = RuntimeSettings {
+            integrator: IntegratorSettings {
+                integrated_phase: IntegratedPhase::Both,
+                ..Default::default()
+            },
+            ..RuntimeSettings::default()
+        };
+
+        let render_options = integrate.build_render_options(&[settings], false);
+
+        assert_eq!(
+            render_options.training_phase_display,
+            IntegrationStatusPhaseDisplay::Real
+        );
+        assert_eq!(
+            render_options.slot_training_phase_displays,
+            vec![IntegrationStatusPhaseDisplay::Real]
+        );
     }
 
     #[test]
@@ -2013,6 +2066,71 @@ mod tests {
                 KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
             ),
             DashboardKeyAction::AbortCurrentIteration
+        );
+    }
+
+    #[test]
+    fn dashboard_g_toggles_chart_history_window() {
+        let mut dashboard = gammalooprs::integrate::RatatuiDashboardState::new();
+
+        assert_eq!(
+            super::handle_dashboard_key_event(
+                &mut dashboard,
+                KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+            ),
+            DashboardKeyAction::Redraw
+        );
+    }
+
+    #[test]
+    fn dashboard_plus_adjusts_chart_history_window() {
+        let mut dashboard = gammalooprs::integrate::RatatuiDashboardState::new();
+
+        assert_eq!(
+            super::handle_dashboard_key_event(
+                &mut dashboard,
+                KeyEvent::new(KeyCode::Char('+'), KeyModifiers::NONE),
+            ),
+            DashboardKeyAction::Redraw
+        );
+    }
+
+    #[test]
+    fn dashboard_comma_adjusts_chart_y_range() {
+        let mut dashboard = gammalooprs::integrate::RatatuiDashboardState::new();
+
+        assert_eq!(
+            super::handle_dashboard_key_event(
+                &mut dashboard,
+                KeyEvent::new(KeyCode::Char(','), KeyModifiers::NONE),
+            ),
+            DashboardKeyAction::Redraw
+        );
+    }
+
+    #[test]
+    fn dashboard_zero_resets_chart_y_range() {
+        let mut dashboard = gammalooprs::integrate::RatatuiDashboardState::new();
+
+        assert_eq!(
+            super::handle_dashboard_key_event(
+                &mut dashboard,
+                KeyEvent::new(KeyCode::Char('0'), KeyModifiers::NONE),
+            ),
+            DashboardKeyAction::Redraw
+        );
+    }
+
+    #[test]
+    fn dashboard_p_toggles_chart_phase() {
+        let mut dashboard = gammalooprs::integrate::RatatuiDashboardState::new();
+
+        assert_eq!(
+            super::handle_dashboard_key_event(
+                &mut dashboard,
+                KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+            ),
+            DashboardKeyAction::Redraw
         );
     }
 

--- a/crates/gammaloop-api/src/commands/integrate.rs
+++ b/crates/gammaloop-api/src/commands/integrate.rs
@@ -33,11 +33,11 @@ use gammalooprs::{
         build_integration_result, emit_integration_status_via_tracing, havana_integrate,
         latest_observable_resume_state_path, print_integral_result,
         render_saved_integration_summary, render_status_update_tabled, slot_workspace_path,
-        workspace_manifest_path, workspace_state_path, ContributionSortMode, IntegrationState,
-        IntegrationStatusKind, IntegrationStatusPhaseDisplay, IntegrationStatusViewOptions,
-        IntegrationWorkspaceManifest, IterationBatchingSettings, RatatuiDashboardState,
-        SamplingCorrelationMode, SlotMeta, StatusUpdate, TabledRenderOptions,
-        WorkspaceSnapshotControl,
+        workspace_manifest_path, workspace_state_path, ContributionSortMode,
+        HavanaIntegrateRequest, IntegrationSlot, IntegrationState, IntegrationStatusKind,
+        IntegrationStatusPhaseDisplay, IntegrationStatusViewOptions, IntegrationWorkspaceManifest,
+        IterationBatchingSettings, RatatuiDashboardState, SamplingCorrelationMode, SlotMeta,
+        StatusUpdate, TabledRenderOptions, WorkspaceSnapshotControl,
     },
     model::{Model, SerializableInputParamCard},
     observables::ObservableSnapshotBundle,
@@ -48,7 +48,7 @@ use gammalooprs::{
     },
     utils::F,
 };
-use itertools::Itertools;
+use itertools::{izip, Itertools};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use symbolica::numerical_integration::Grid;
 use tracing::{info, warn};
@@ -1756,26 +1756,36 @@ impl Integrate {
             stream_iterations,
             tabled_options.clone(),
         );
+        let slots = izip!(
+            selected_slots.iter().map(|slot| slot.slot_meta.clone()),
+            slot_settings,
+            slot_models,
+            slot_integrands,
+            targets
+        )
+        .map(|(meta, settings, model, integrand, target)| {
+            IntegrationSlot::new(
+                meta,
+                settings,
+                model,
+                Integrand::ProcessIntegrand(integrand),
+                target,
+            )
+        })
+        .collect();
 
         let result = havana_integrate(
-            slot_settings,
-            self.sampling_correlation_mode(),
-            slot_models,
-            selected_slots
-                .iter()
-                .map(|slot| slot.slot_meta.clone())
-                .collect(),
-            slot_integrands
-                .into_iter()
-                .map(Integrand::ProcessIntegrand)
-                .collect(),
-            n_cores,
-            targets,
-            integration_state,
-            Some(workspace_path.clone()),
-            self.workspace_snapshot_control(),
-            self.build_batching_settings(stream_updates, stream_updates || stream_iterations),
-            view_options,
+            HavanaIntegrateRequest {
+                slots,
+                sampling_correlation_mode: self.sampling_correlation_mode(),
+                n_cores,
+                state: integration_state,
+                workspace: Some(workspace_path.clone()),
+                output_control: self.workspace_snapshot_control(),
+                batching: self
+                    .build_batching_settings(stream_updates, stream_updates || stream_iterations),
+                view_options,
+            },
             move |status_update: StatusUpdate| {
                 stream_controller.handle_status_update(status_update)
             },

--- a/crates/gammaloop-api/src/python.rs
+++ b/crates/gammaloop-api/src/python.rs
@@ -1129,6 +1129,7 @@ fn build_python_integrate_command(
     integrate.min_time_between_status_updates = min_time_between_status_updates;
     integrate.max_table_width = max_table_width;
     integrate.write_results_for_each_iteration = write_results_for_each_iteration;
+    integrate.renderer = crate::commands::integrate::RendererOption::Tabled;
 
     if let Some(target) = target {
         if let Ok(target_dict) = target.cast::<PyDict>() {

--- a/crates/gammalooprs/Cargo.toml
+++ b/crates/gammalooprs/Cargo.toml
@@ -71,6 +71,7 @@ pathfinding = "4.11.0"
 pyo3-stub-gen = { workspace = true, optional = true }
 rand = { workspace = true, features = ["small_rng"] }
 rayon = { workspace = true }
+ratatui = { workspace = true, features = ["crossterm_0_28"] }
 # constcat = "0.5.0"
 ref-ops = "0.2.5"
 ringbuffer = "0.16.0"

--- a/crates/gammalooprs/build.rs
+++ b/crates/gammalooprs/build.rs
@@ -1,6 +1,8 @@
 use vergen_gitcl::{Emitter, GitclBuilder};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-env-changed=EXTRA_MACOS_LIBS_FOR_GNU_GCC");
+
     // if cfg!(feature = "python_api") {
     //    pyo3_build_config::add_extension_module_link_args();
     // }

--- a/crates/gammalooprs/src/integrands/mod.rs
+++ b/crates/gammalooprs/src/integrands/mod.rs
@@ -16,6 +16,7 @@ use crate::observables::{
 };
 use crate::utils::{F, FloatLike};
 use crate::{
+    is_interrupted,
     settings::{
         RuntimeSettings,
         runtime::{IntegratorSettings, Precision},
@@ -113,15 +114,24 @@ impl Integrand {
         model: &Model,
         iter: usize,
         use_arb_prec: bool,
+        stop_on_interrupt: bool,
         max_eval: Complex<F<f64>>,
     ) -> Result<RawBatchEvaluationResult> {
         match self {
-            Integrand::ProcessIntegrand(integrand) => {
-                integrand.evaluate_samples_raw(model, samples, iter, use_arb_prec, max_eval)
-            }
+            Integrand::ProcessIntegrand(integrand) => integrand.evaluate_samples_raw(
+                model,
+                samples,
+                iter,
+                use_arb_prec,
+                stop_on_interrupt,
+                max_eval,
+            ),
             _ => {
                 let mut results = Vec::with_capacity(samples.len());
                 for sample in samples {
+                    if stop_on_interrupt && is_interrupted() {
+                        break;
+                    }
                     results.push(self.evaluate_sample(
                         sample,
                         model,
@@ -130,6 +140,9 @@ impl Integrand {
                         use_arb_prec,
                         max_eval,
                     )?);
+                    if stop_on_interrupt && is_interrupted() {
+                        break;
+                    }
                 }
                 Ok(RawBatchEvaluationResult {
                     statistics: evaluation::StatisticsCounter::from_evaluation_results(&results),

--- a/crates/gammalooprs/src/integrands/process/mod.rs
+++ b/crates/gammalooprs/src/integrands/process/mod.rs
@@ -595,10 +595,14 @@ impl ProcessIntegrand {
         samples: &[Sample<F<f64>>],
         iter: usize,
         use_arb_prec: bool,
+        stop_on_interrupt: bool,
         max_eval: Complex<F<f64>>,
     ) -> Result<RawBatchEvaluationResult> {
         let mut results = Vec::with_capacity(samples.len());
         for sample in samples {
+            if stop_on_interrupt && crate::is_interrupted() {
+                break;
+            }
             let mut result = match self {
                 ProcessIntegrand::Amplitude(integrand) => evaluate_sample(
                     integrand,
@@ -623,6 +627,9 @@ impl ProcessIntegrand {
             self.process_evaluation_result(&result);
             maybe_discard_generated_events_in_result(self.get_settings(), &mut result);
             results.push(result);
+            if stop_on_interrupt && crate::is_interrupted() {
+                break;
+            }
         }
 
         Ok(RawBatchEvaluationResult {

--- a/crates/gammalooprs/src/integrate/display.rs
+++ b/crates/gammalooprs/src/integrate/display.rs
@@ -49,6 +49,14 @@ impl TextStyle {
     pub(crate) const fn red() -> Self {
         Self::PLAIN.with_color(TextColor::Red)
     }
+
+    pub(crate) const fn yellow() -> Self {
+        Self::PLAIN.with_color(TextColor::Yellow)
+    }
+
+    pub(crate) const fn pink() -> Self {
+        Self::PLAIN.with_color(TextColor::Pink)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -56,6 +64,8 @@ pub(crate) enum TextColor {
     Green,
     Blue,
     Red,
+    Yellow,
+    Pink,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/gammalooprs/src/integrate/mod.rs
+++ b/crates/gammalooprs/src/integrate/mod.rs
@@ -54,7 +54,10 @@ pub use status_update::{
     ContributionSortMode, IntegrationStatusKind, IntegrationStatusPhaseDisplay,
     IntegrationStatusViewOptions, StatusUpdate,
 };
-use status_update::{build_saved_status_update, build_status_update, evaluate_target_accuracy};
+use status_update::{
+    StatusUpdateBuildRequest, build_saved_status_update, build_status_update,
+    evaluate_target_accuracy,
+};
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -88,6 +91,43 @@ impl Default for IterationBatchingSettings {
             emit_initial_status_update: true,
         }
     }
+}
+
+pub struct IntegrationSlot {
+    pub meta: SlotMeta,
+    pub settings: RuntimeSettings,
+    pub model: Model,
+    pub integrand: Integrand,
+    pub target: Option<Complex<F<f64>>>,
+}
+
+impl IntegrationSlot {
+    pub fn new(
+        meta: SlotMeta,
+        settings: RuntimeSettings,
+        model: Model,
+        integrand: Integrand,
+        target: Option<Complex<F<f64>>>,
+    ) -> Self {
+        Self {
+            meta,
+            settings,
+            model,
+            integrand,
+            target,
+        }
+    }
+}
+
+pub struct HavanaIntegrateRequest {
+    pub slots: Vec<IntegrationSlot>,
+    pub sampling_correlation_mode: SamplingCorrelationMode,
+    pub n_cores: usize,
+    pub state: Option<IntegrationState>,
+    pub workspace: Option<PathBuf>,
+    pub output_control: WorkspaceSnapshotControl,
+    pub batching: IterationBatchingSettings,
+    pub view_options: IntegrationStatusViewOptions,
 }
 
 // const N_INTEGRAND_ACCUMULATORS: usize = 2;
@@ -189,6 +229,14 @@ impl SamplingSlotState {
         };
         Self::new(grid, discrete_axis_labels)
     }
+}
+
+#[derive(Default)]
+struct MonitoredDiscreteSetup {
+    path: Option<Vec<usize>>,
+    axis_label: Option<String>,
+    bin_descriptions: Option<Vec<String>>,
+    warning: Option<String>,
 }
 
 #[derive(Tabled)]
@@ -874,21 +922,19 @@ fn coalesce_first_non_trivial_discrete_bin_descriptions(
 }
 
 fn resolve_first_non_trivial_discrete_bin_descriptions(
-    slot_metas: &[SlotMeta],
-    slot_integrands: &[Integrand],
+    slots: &[IntegrationSlot],
     monitored_path: &[usize],
     axis_label: &str,
 ) -> (Option<Vec<String>>, Option<String>) {
-    let Some(slot_descriptions) = slot_metas
+    let Some(slot_descriptions) = slots
         .iter()
-        .zip(slot_integrands.iter())
-        .map(|(slot_meta, integrand)| {
+        .map(|slot| {
             first_non_trivial_discrete_bin_descriptions_for_integrand(
-                integrand,
+                &slot.integrand,
                 monitored_path,
                 axis_label,
             )
-            .map(|descriptions| (slot_meta.key(), descriptions))
+            .map(|descriptions| (slot.meta.key(), descriptions))
         })
         .collect::<Option<Vec<_>>>()
     else {
@@ -900,23 +946,17 @@ fn resolve_first_non_trivial_discrete_bin_descriptions(
 
 fn resolve_monitored_discrete_setup(
     sampling_correlation_mode: SamplingCorrelationMode,
-    slot_metas: &[SlotMeta],
-    slot_integrands: &[Integrand],
+    slots: &[IntegrationSlot],
     sampling_states: &[SamplingSlotState],
-) -> (
-    Option<Vec<usize>>,
-    Option<String>,
-    Option<Vec<String>>,
-    Option<String>,
-) {
+) -> MonitoredDiscreteSetup {
     let Some(reference_state) = sampling_states.first() else {
-        return (None, None, None, None);
+        return MonitoredDiscreteSetup::default();
     };
 
     let Some((reference_path, reference_axis_label, reference_bin_count)) =
         monitored_discrete_layout(&reference_state.grid, &reference_state.discrete_axis_labels)
     else {
-        return (None, None, None, None);
+        return MonitoredDiscreteSetup::default();
     };
 
     if sampling_correlation_mode == SamplingCorrelationMode::Uncorrelated {
@@ -925,47 +965,42 @@ fn resolve_monitored_discrete_setup(
                 &sampling_state.grid,
                 &sampling_state.discrete_axis_labels,
             ) else {
-                return (
-                    None,
-                    None,
-                    None,
-                    Some(
+                return MonitoredDiscreteSetup {
+                    warning: Some(
                         "Selected integrands do not all expose a compatible first non-trivial monitored discrete dimension. Shared discrete-bin monitoring tables will be disabled."
                             .to_string(),
                     ),
-                );
+                    ..MonitoredDiscreteSetup::default()
+                };
             };
 
             if path != reference_path
                 || axis_label != reference_axis_label
                 || bin_count != reference_bin_count
             {
-                return (
-                    None,
-                    None,
-                    None,
-                    Some(format!(
+                return MonitoredDiscreteSetup {
+                    warning: Some(format!(
                         "Selected integrands do not share a compatible first non-trivial monitored discrete layout (mismatch at {}). Shared discrete-bin monitoring tables will be disabled.",
-                        slot_metas[slot_index].key().blue()
+                        slots[slot_index].meta.key().blue()
                     )),
-                );
+                    ..MonitoredDiscreteSetup::default()
+                };
             }
         }
     }
 
     let (descriptions, label_warning) = resolve_first_non_trivial_discrete_bin_descriptions(
-        slot_metas,
-        slot_integrands,
+        slots,
         &reference_path,
         &reference_axis_label,
     );
 
-    (
-        Some(reference_path),
-        Some(reference_axis_label),
-        descriptions,
-        label_warning,
-    )
+    MonitoredDiscreteSetup {
+        path: Some(reference_path),
+        axis_label: Some(reference_axis_label),
+        bin_descriptions: descriptions,
+        warning: label_warning,
+    }
 }
 
 fn render_orientation_description(description: &str) -> String {
@@ -1493,10 +1528,9 @@ fn max_weight_row_descriptors(
     rows
 }
 
-fn max_eval_entry(
-    accumulator: &StatisticsAccumulator<F<f64>>,
-    positive: bool,
-) -> Option<(F<f64>, Option<&Sample<F<f64>>>)> {
+type MaxEvalEntry<'a> = Option<(F<f64>, Option<&'a Sample<F<f64>>>)>;
+
+fn max_eval_entry(accumulator: &StatisticsAccumulator<F<f64>>, positive: bool) -> MaxEvalEntry<'_> {
     let (value, sample) = if positive {
         (
             accumulator.max_eval_positive,
@@ -1695,8 +1729,8 @@ impl CoreIterationState {
 
     fn evaluate_chunk(
         &mut self,
-        slot_settings: &[RuntimeSettings],
-        slot_models: &[Model],
+        slot_settings: &[&RuntimeSettings],
+        slot_models: &[&Model],
         iter: usize,
         current_max_evals: &[Complex<F<f64>>],
         chunk_size: usize,
@@ -1739,7 +1773,7 @@ impl CoreIterationState {
                     let evaluation_start = Instant::now();
                     let raw_batch = integrand.evaluate_samples_raw(
                         &samples,
-                        &slot_models[slot_index],
+                        slot_models[slot_index],
                         iter,
                         false,
                         true,
@@ -1826,7 +1860,7 @@ impl CoreIterationState {
                     let evaluation_start = Instant::now();
                     let raw_batch = self.slot_integrands[slot_index].evaluate_samples_raw(
                         &samples,
-                        &slot_models[slot_index],
+                        slot_models[slot_index],
                         iter,
                         false,
                         true,
@@ -1930,7 +1964,7 @@ fn slot_seed(global_seed: u64, slot_index: usize) -> u64 {
 
 fn apply_iteration_core_states(
     integration_state: &mut IntegrationState,
-    slot_settings: &[RuntimeSettings],
+    slots: &[IntegrationSlot],
     cores: usize,
     cur_points: usize,
     elapsed_seconds: f64,
@@ -2027,10 +2061,12 @@ fn apply_iteration_core_states(
             discrete_axis_labels,
         };
         sampling_state.grid.update(
-            F(slot_settings[actual_slot_index]
+            F(slots[actual_slot_index]
+                .settings
                 .integrator
                 .discrete_dim_learning_rate),
-            F(slot_settings[actual_slot_index]
+            F(slots[actual_slot_index]
+                .settings
                 .integrator
                 .continuous_dim_learning_rate),
         );
@@ -2045,7 +2081,7 @@ fn apply_iteration_core_states(
 
 fn build_preview_integration_state(
     integration_state: &IntegrationState,
-    slot_settings: &[RuntimeSettings],
+    slots: &[IntegrationSlot],
     cores: usize,
     completed_points: usize,
     elapsed_seconds: f64,
@@ -2054,7 +2090,7 @@ fn build_preview_integration_state(
     let mut preview = integration_state.clone();
     apply_iteration_core_states(
         &mut preview,
-        slot_settings,
+        slots,
         cores,
         completed_points,
         elapsed_seconds,
@@ -2065,68 +2101,50 @@ fn build_preview_integration_state(
 
 /// Integrate function used for local runs
 pub fn havana_integrate<S>(
-    slot_settings: Vec<RuntimeSettings>,
-    sampling_correlation_mode: SamplingCorrelationMode,
-    slot_models: Vec<Model>,
-    slot_metas: Vec<SlotMeta>,
-    slot_integrands: Vec<Integrand>,
-    n_cores: usize,
-    targets: Vec<Option<Complex<F<f64>>>>,
-    state: Option<IntegrationState>,
-    workspace: Option<PathBuf>,
-    output_control: WorkspaceSnapshotControl,
-    batching: IterationBatchingSettings,
-    view_options: IntegrationStatusViewOptions,
+    request: HavanaIntegrateRequest,
     mut status_emitter: S,
 ) -> Result<IntegrationResult>
 where
     S: FnMut(StatusUpdate) -> Result<()>,
 {
-    if slot_metas.is_empty() {
+    let HavanaIntegrateRequest {
+        mut slots,
+        sampling_correlation_mode,
+        n_cores,
+        state,
+        workspace,
+        output_control,
+        batching,
+        view_options,
+    } = request;
+
+    if slots.is_empty() {
         return Err(Report::msg(
             "At least one integrand must be selected for integration",
         ));
     }
-    if slot_metas.len() != slot_integrands.len()
-        || slot_metas.len() != slot_settings.len()
-        || slot_metas.len() != slot_models.len()
-        || slot_metas.len() != targets.len()
-    {
-        return Err(Report::msg(
-            "Multi-integrand integration received inconsistent slot metadata, settings, models, integrands, or targets",
-        ));
-    }
 
-    let mut slot_integrands = slot_integrands;
-    let slot0_settings = &slot_settings[0];
+    let slot_metas = slots.iter().map(|slot| slot.meta.clone()).collect_vec();
+    let targets = slots.iter().map(|slot| slot.target).collect_vec();
     let sampling_states = match sampling_correlation_mode {
         SamplingCorrelationMode::Correlated => {
-            vec![SamplingSlotState::from_integrand(&slot_integrands[0])]
+            vec![SamplingSlotState::from_integrand(&slots[0].integrand)]
         }
-        SamplingCorrelationMode::Uncorrelated => slot_integrands
+        SamplingCorrelationMode::Uncorrelated => slots
             .iter()
-            .map(SamplingSlotState::from_integrand)
+            .map(|slot| SamplingSlotState::from_integrand(&slot.integrand))
             .collect_vec(),
     };
-    let (
-        monitored_discrete_path,
-        first_non_trivial_discrete_label,
-        first_non_trivial_discrete_bin_descriptions,
-        label_warning,
-    ) = resolve_monitored_discrete_setup(
-        sampling_correlation_mode,
-        &slot_metas,
-        &slot_integrands,
-        &sampling_states,
-    );
+    let monitored_discrete_setup =
+        resolve_monitored_discrete_setup(sampling_correlation_mode, &slots, &sampling_states);
     let slot_first_non_trivial_discrete_breakdown_metadata =
-        if let Some(path) = monitored_discrete_path.as_deref() {
-            slot_integrands
+        if let Some(path) = monitored_discrete_setup.path.as_deref() {
+            slots
                 .iter()
                 .enumerate()
-                .map(|(slot_index, integrand)| {
+                .map(|(slot_index, slot)| {
                     build_persisted_discrete_breakdown_metadata(
-                        integrand,
+                        &slot.integrand,
                         path,
                         &sampling_states[sampling_correlation_mode.state_index(slot_index)]
                             .discrete_axis_labels,
@@ -2136,7 +2154,7 @@ where
         } else {
             vec![None; slot_metas.len()]
         };
-    if let Some(label_warning) = label_warning.as_ref() {
+    if let Some(label_warning) = monitored_discrete_setup.warning.as_ref() {
         warn!("{label_warning}");
     }
 
@@ -2147,16 +2165,16 @@ where
             sampling_correlation_mode,
             sampling_states.clone(),
             slot_metas.clone(),
-            monitored_discrete_path.clone(),
-            first_non_trivial_discrete_label.clone(),
-            first_non_trivial_discrete_bin_descriptions.clone(),
+            monitored_discrete_setup.path.clone(),
+            monitored_discrete_setup.axis_label.clone(),
+            monitored_discrete_setup.bin_descriptions.clone(),
             slot_first_non_trivial_discrete_breakdown_metadata,
         )
     };
-    integration_state.monitored_discrete_path = monitored_discrete_path;
-    integration_state.first_non_trivial_discrete_label = first_non_trivial_discrete_label;
+    integration_state.monitored_discrete_path = monitored_discrete_setup.path;
+    integration_state.first_non_trivial_discrete_label = monitored_discrete_setup.axis_label;
     integration_state.first_non_trivial_discrete_bin_descriptions =
-        first_non_trivial_discrete_bin_descriptions;
+        monitored_discrete_setup.bin_descriptions;
     if integration_state.slot_metas != slot_metas {
         return Err(Report::msg(
             "Saved integration state slots do not match the currently selected integrands",
@@ -2184,10 +2202,11 @@ where
         ));
     }
 
-    let sampling_str = slot0_settings.sampling.describe_settings();
-    let dimension = slot_integrands[0].get_n_dim();
-    let discrete_depth = slot0_settings.sampling.discrete_depth();
-    let is_tropical_sampling = slot0_settings
+    let sampling_str = slots[0].settings.sampling.describe_settings();
+    let dimension = slots[0].integrand.get_n_dim();
+    let discrete_depth = slots[0].settings.sampling.discrete_depth();
+    let is_tropical_sampling = slots[0]
+        .settings
         .sampling
         .get_parameterization_settings()
         .is_none();
@@ -2226,7 +2245,7 @@ where
 
     info!(
         "Integrating using {} ltd with {} {} over {} ...",
-        if slot0_settings.general.use_ltd {
+        if slots[0].settings.general.use_ltd {
             "naive"
         } else {
             "cff"
@@ -2242,15 +2261,15 @@ where
     let mut n_samples_evaluated = 0;
     let mut emitted_latest_observable_paths = vec![None; n_slots];
     clear_iteration_abort_request();
-    'integrateLoop: while integration_state.num_points < slot0_settings.integrator.n_max {
+    'integrateLoop: while integration_state.num_points < slots[0].settings.integrator.n_max {
         // ensure we do not overshoot
         let cur_points = {
-            let cur_points_not_final_iter = slot0_settings.integrator.n_start
-                + slot0_settings.integrator.n_increase * integration_state.iter;
+            let cur_points_not_final_iter = slots[0].settings.integrator.n_start
+                + slots[0].settings.integrator.n_increase * integration_state.iter;
             if cur_points_not_final_iter + integration_state.num_points
-                > slot0_settings.integrator.n_max
+                > slots[0].settings.integrator.n_max
             {
-                slot0_settings.integrator.n_max - integration_state.num_points
+                slots[0].settings.integrator.n_max - integration_state.num_points
             } else {
                 cur_points_not_final_iter
             }
@@ -2272,22 +2291,22 @@ where
         let mut current_batch_size = initial_batch_size(batching);
         let mut last_live_status = None;
         if batching.emit_initial_status_update && !is_interrupted() {
-            status_emitter(build_status_update(
-                IntegrationStatusKind::Live,
-                &integration_state,
+            status_emitter(build_status_update(StatusUpdateBuildRequest {
+                kind: IntegrationStatusKind::Live,
+                integration_state: &integration_state,
                 cores,
-                t_start.elapsed(),
-                iteration_start.elapsed(),
-                0,
-                integration_state.num_points,
+                elapsed_time: t_start.elapsed(),
+                iteration_elapsed_time: iteration_start.elapsed(),
+                cur_points: 0,
+                total_points_display: integration_state.num_points,
                 n_samples_evaluated,
-                &targets,
-                &view_options,
-                Some(status_update::LiveIterationProgress {
+                targets: &targets,
+                render_options: &view_options,
+                live_progress: Some(status_update::LiveIterationProgress {
                     completed_points: 0,
                     target_points: cur_points,
                 }),
-            ))?;
+            }))?;
         }
 
         let current_max_evals = integration_state
@@ -2301,14 +2320,14 @@ where
             .enumerate()
             .map(|(core_id, &n_points)| {
                 CoreIterationState::new(
-                    slot_integrands.clone(),
+                    slots.iter().map(|slot| slot.integrand.clone()).collect(),
                     integration_state.sampling_correlation_mode,
                     &integration_state
                         .sampling_states
                         .iter()
                         .map(|sampling_state| sampling_state.grid.clone())
                         .collect_vec(),
-                    slot0_settings.integrator.seed + integration_state.iter as u64,
+                    slots[0].settings.integrator.seed + integration_state.iter as u64,
                     target_points_per_core * core_id,
                     n_points,
                 )
@@ -2316,20 +2335,24 @@ where
             .collect_vec();
         while total_remaining_points(&worker_states) > 0 {
             let round_started_at = Instant::now();
-            let processed_per_core: Vec<Result<usize>> = pool.install(|| {
-                worker_states
-                    .par_iter_mut()
-                    .map(|worker_state| {
-                        worker_state.evaluate_chunk(
-                            &slot_settings,
-                            &slot_models,
-                            integration_state.iter,
-                            &current_max_evals,
-                            current_batch_size,
-                        )
-                    })
-                    .collect()
-            });
+            let processed_per_core: Vec<Result<usize>> = {
+                let slot_settings = slots.iter().map(|slot| &slot.settings).collect_vec();
+                let slot_models = slots.iter().map(|slot| &slot.model).collect_vec();
+                pool.install(|| {
+                    worker_states
+                        .par_iter_mut()
+                        .map(|worker_state| {
+                            worker_state.evaluate_chunk(
+                                &slot_settings,
+                                &slot_models,
+                                integration_state.iter,
+                                &current_max_evals,
+                                current_batch_size,
+                            )
+                        })
+                        .collect()
+                })
+            };
             let processed_this_round = processed_per_core
                 .into_iter()
                 .collect::<Result<Vec<_>>>()?
@@ -2354,28 +2377,28 @@ where
                 if should_emit_live_status {
                     let preview_state = build_preview_integration_state(
                         &integration_state,
-                        &slot_settings,
+                        &slots,
                         cores,
                         completed_points,
                         elapsed_seconds_offset + t_start.elapsed().as_secs_f64(),
                         &worker_states,
                     );
-                    status_emitter(build_status_update(
-                        IntegrationStatusKind::Live,
-                        &preview_state,
+                    status_emitter(build_status_update(StatusUpdateBuildRequest {
+                        kind: IntegrationStatusKind::Live,
+                        integration_state: &preview_state,
                         cores,
-                        t_start.elapsed(),
-                        iteration_start.elapsed(),
-                        completed_points,
-                        integration_state.num_points + completed_points,
-                        n_samples_evaluated + completed_points,
-                        &targets,
-                        &view_options,
-                        Some(status_update::LiveIterationProgress {
+                        elapsed_time: t_start.elapsed(),
+                        iteration_elapsed_time: iteration_start.elapsed(),
+                        cur_points: completed_points,
+                        total_points_display: integration_state.num_points + completed_points,
+                        n_samples_evaluated: n_samples_evaluated + completed_points,
+                        targets: &targets,
+                        render_options: &view_options,
+                        live_progress: Some(status_update::LiveIterationProgress {
                             completed_points,
                             target_points: cur_points,
                         }),
-                    ))?;
+                    }))?;
                     last_live_status = Some(now);
                 }
             }
@@ -2427,7 +2450,7 @@ where
         n_samples_evaluated += completed_points;
         apply_iteration_core_states(
             &mut integration_state,
-            &slot_settings,
+            &slots,
             cores,
             completed_points,
             elapsed_seconds_offset + t_start.elapsed().as_secs_f64(),
@@ -2445,18 +2468,21 @@ where
                 owner_slot.merge_runtime_results(other_slot)?;
             }
         }
-        slot_integrands = owner_core.clone();
+        for (slot, integrand) in slots.iter_mut().zip(owner_core.iter()) {
+            slot.integrand = integrand.clone();
+        }
 
         // Update observable accumulators, persist authoritative resume state, then refresh
         // the latest user-facing snapshots.
-        for integrand in slot_integrands.iter_mut() {
-            integrand.update_runtime_results(integration_state.iter);
+        for slot in &mut slots {
+            slot.integrand
+                .update_runtime_results(integration_state.iter);
         }
 
         if let Some(ref workspace_path) = workspace {
-            for (slot_index, integrand) in slot_integrands.iter().enumerate() {
+            for (slot_index, slot) in slots.iter().enumerate() {
                 write_observable_resume_state(
-                    integrand,
+                    &slot.integrand,
                     Some(workspace_path.as_path()),
                     &integration_state.slot_metas[slot_index],
                     integration_state.iter,
@@ -2472,47 +2498,47 @@ where
             )?;
         }
 
-        for (slot_index, integrand) in slot_integrands.iter().enumerate() {
+        for (slot_index, slot) in slots.iter().enumerate() {
             let workspace_path = workspace
                 .as_deref()
                 .map(|root| slot_workspace_path(root, &integration_state.slot_metas[slot_index]));
             emitted_latest_observable_paths[slot_index] =
-                write_latest_observables_output(integrand, workspace_path.as_deref())?;
+                write_latest_observables_output(&slot.integrand, workspace_path.as_deref())?;
             write_observable_snapshot_archive(
-                integrand,
+                &slot.integrand,
                 workspace_path.as_deref(),
                 integration_state.iter,
                 output_control,
             )?;
         }
 
-        status_emitter(build_status_update(
-            IntegrationStatusKind::Iteration,
-            &integration_state,
+        status_emitter(build_status_update(StatusUpdateBuildRequest {
+            kind: IntegrationStatusKind::Iteration,
+            integration_state: &integration_state,
             cores,
-            t_start.elapsed(),
-            iteration_start.elapsed(),
-            completed_points,
-            integration_state.num_points,
+            elapsed_time: t_start.elapsed(),
+            iteration_elapsed_time: iteration_start.elapsed(),
+            cur_points: completed_points,
+            total_points_display: integration_state.num_points,
             n_samples_evaluated,
-            &targets,
-            &view_options,
-            None,
-        ))?;
+            targets: &targets,
+            render_options: &view_options,
+            live_progress: None,
+        }))?;
 
         let target_accuracy_status = evaluate_target_accuracy(
             &integration_state,
             integration_state.num_points,
             t_start.elapsed(),
             &targets,
-            match slot0_settings.integrator.integrated_phase {
+            match slots[0].settings.integrator.integrated_phase {
                 IntegratedPhase::Real | IntegratedPhase::Both => {
                     IntegrationStatusPhaseDisplay::Real
                 }
                 IntegratedPhase::Imag => IntegrationStatusPhaseDisplay::Imag,
             },
-            slot0_settings.integrator.target_relative_accuracy,
-            slot0_settings.integrator.target_absolute_accuracy,
+            slots[0].settings.integrator.target_relative_accuracy,
+            slots[0].settings.integrator.target_absolute_accuracy,
         );
         if target_accuracy_status.is_reached() {
             let reached_target = match (
@@ -2535,19 +2561,20 @@ where
     clear_iteration_abort_request();
 
     if integration_state.num_points > 0 {
-        status_emitter(build_status_update(
-            IntegrationStatusKind::Final,
-            &integration_state,
+        let final_view_options = view_options.for_final();
+        status_emitter(build_status_update(StatusUpdateBuildRequest {
+            kind: IntegrationStatusKind::Final,
+            integration_state: &integration_state,
             cores,
-            t_start.elapsed(),
-            Duration::ZERO,
-            0,
-            integration_state.num_points,
+            elapsed_time: t_start.elapsed(),
+            iteration_elapsed_time: Duration::ZERO,
+            cur_points: 0,
+            total_points_display: integration_state.num_points,
             n_samples_evaluated,
-            &targets,
-            &view_options.for_final(),
-            None,
-        ))?;
+            targets: &targets,
+            render_options: &final_view_options,
+            live_progress: None,
+        }))?;
     } else {
         info!("");
         warn!(
@@ -2557,11 +2584,14 @@ where
         info!("");
     }
 
-    if !slot_integrands.is_empty() {
+    if !slots.is_empty() {
         emit_results_output_summary(
             workspace.as_deref(),
             &integration_state.slot_metas,
-            &slot_integrands,
+            &slots
+                .iter()
+                .map(|slot| slot.integrand.clone())
+                .collect_vec(),
             &emitted_latest_observable_paths,
             output_control,
         );
@@ -3732,63 +3762,19 @@ mod tests {
         }
     }
 
-    fn render_update(
-        kind: IntegrationStatusKind,
-        state: &IntegrationState,
-        cores: usize,
-        elapsed_time: Duration,
-        cur_points: usize,
-        total_points_display: usize,
-        n_samples_evaluated: usize,
-        targets: &[Option<Complex<F<f64>>>],
-        view_options: &IntegrationStatusViewOptions,
-        live_progress: Option<status_update::LiveIterationProgress>,
-    ) -> String {
+    fn render_update(request: StatusUpdateBuildRequest<'_>) -> String {
         render_status_update_tabled(
-            &build_status_update(
-                kind,
-                state,
-                cores,
-                elapsed_time,
-                elapsed_time,
-                cur_points,
-                total_points_display,
-                n_samples_evaluated,
-                targets,
-                view_options,
-                live_progress,
-            ),
-            &tabled_options_for_view(view_options),
+            &build_status_update(request),
+            &tabled_options_for_view(request.render_options),
         )
     }
 
     fn render_ratatui_update(
-        kind: IntegrationStatusKind,
-        state: &IntegrationState,
-        elapsed_time: Duration,
-        iteration_elapsed_time: Duration,
-        cur_points: usize,
-        total_points_display: usize,
-        n_samples_evaluated: usize,
-        targets: &[Option<Complex<F<f64>>>],
-        view_options: &IntegrationStatusViewOptions,
-        live_progress: Option<status_update::LiveIterationProgress>,
+        request: StatusUpdateBuildRequest<'_>,
         configure: impl FnOnce(&mut RatatuiDashboardState),
     ) -> String {
         let mut dashboard = RatatuiDashboardState::new();
-        dashboard.update(build_status_update(
-            kind,
-            state,
-            4,
-            elapsed_time,
-            iteration_elapsed_time,
-            cur_points,
-            total_points_display,
-            n_samples_evaluated,
-            targets,
-            view_options,
-            live_progress,
-        ));
+        dashboard.update(build_status_update(request));
         configure(&mut dashboard);
 
         let backend = TestBackend::new(180, 48);
@@ -3847,24 +3833,28 @@ mod tests {
             vec![None],
         );
         state.all_integrals = vec![accumulator];
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_top_discrete_grid: false,
+            show_discrete_contributions_sum: false,
+            ..default_view_options()
+        };
         let rendered = render_status_update_tabled(
             &build_status_update(
-                IntegrationStatusKind::Iteration,
-                &state,
-                1,
-                Duration::from_secs(0),
-                Duration::from_secs(0),
-                0,
-                0,
-                0,
-                &[None],
-                &IntegrationStatusViewOptions {
-                    show_statistics: false,
-                    show_top_discrete_grid: false,
-                    show_discrete_contributions_sum: false,
-                    ..default_view_options()
-                },
-                None,
+                StatusUpdateBuildRequest::new(
+                    IntegrationStatusKind::Iteration,
+                    &state,
+                    &[None],
+                    &view_options,
+                )
+                .with_timing(
+                    1,
+                    Duration::from_secs(0),
+                    Duration::from_secs(0),
+                    0,
+                    0,
+                    0,
+                ),
             ),
             &default_tabled_options(),
         );
@@ -3885,21 +3875,26 @@ mod tests {
     #[test]
     fn iteration_status_block_uses_compact_header_and_optional_statistics() {
         let state = make_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            ..default_view_options()
+        };
         let rendered = render_update(
-            IntegrationStatusKind::Iteration,
-            &state,
-            4,
-            Duration::from_secs(1),
-            100_000,
-            100_000,
-            100_000,
-            &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
-            &IntegrationStatusViewOptions {
-                show_statistics: false,
-                show_max_weight_details: false,
-                ..default_view_options()
-            },
-            None,
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Iteration,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+                100_000,
+                100_000,
+                100_000,
+            ),
         );
 
         assert!(
@@ -3929,21 +3924,26 @@ mod tests {
     #[test]
     fn iteration_status_block_omits_delta_columns_when_no_target_is_provided() {
         let state = make_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: true,
+            show_max_weight_details: false,
+            ..default_view_options()
+        };
         let rendered = render_update(
-            IntegrationStatusKind::Iteration,
-            &state,
-            4,
-            Duration::from_secs(1),
-            100_000,
-            100_000,
-            100_000,
-            &[None, None],
-            &IntegrationStatusViewOptions {
-                show_statistics: true,
-                show_max_weight_details: false,
-                ..default_view_options()
-            },
-            None,
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Iteration,
+                &state,
+                &[None, None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+                100_000,
+                100_000,
+                100_000,
+            ),
         );
 
         assert!(!rendered.contains("Δ [σ]"), "{rendered}");
@@ -3957,24 +3957,30 @@ mod tests {
         let mut state = make_integration_state();
         state.iter = 2;
         state.num_points = 125_000;
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            ..default_view_options()
+        };
         let rendered = render_update(
-            IntegrationStatusKind::Live,
-            &state,
-            4,
-            Duration::from_secs(1),
-            25_000,
-            125_000,
-            125_000,
-            &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
-            &IntegrationStatusViewOptions {
-                show_statistics: false,
-                show_max_weight_details: false,
-                ..default_view_options()
-            },
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+                25_000,
+                125_000,
+                125_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 25_000,
                 target_points: 100_000,
-            }),
+            })),
         );
 
         assert!(
@@ -3992,25 +3998,30 @@ mod tests {
     #[test]
     fn iteration_status_block_shows_discrete_contributions_and_discrete_max_weights() {
         let state = make_discrete_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: true,
+            show_top_discrete_grid: true,
+            show_discrete_contributions_sum: true,
+            contribution_sort: ContributionSortMode::Index,
+            show_max_weight_info_for_discrete_bins: true,
+            ..default_view_options()
+        };
         let rendered = render_update(
-            IntegrationStatusKind::Iteration,
-            &state,
-            4,
-            Duration::from_secs(2),
-            110_000,
-            210_000,
-            210_000,
-            &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
-            &IntegrationStatusViewOptions {
-                show_statistics: false,
-                show_max_weight_details: true,
-                show_top_discrete_grid: true,
-                show_discrete_contributions_sum: true,
-                contribution_sort: ContributionSortMode::Index,
-                show_max_weight_info_for_discrete_bins: true,
-                ..default_view_options()
-            },
-            None,
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Iteration,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(2),
+                Duration::from_secs(2),
+                110_000,
+                210_000,
+                210_000,
+            ),
         );
 
         assert!(rendered.contains("Sum"), "{rendered}");
@@ -4043,25 +4054,30 @@ mod tests {
     #[test]
     fn iteration_status_block_hides_spanned_metadata_header_separators() {
         let state = make_discrete_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            show_top_discrete_grid: true,
+            show_discrete_contributions_sum: true,
+            contribution_sort: ContributionSortMode::Index,
+            show_max_weight_info_for_discrete_bins: false,
+            ..default_view_options()
+        };
         let rendered = render_update(
-            IntegrationStatusKind::Iteration,
-            &state,
-            4,
-            Duration::from_secs(2),
-            110_000,
-            210_000,
-            210_000,
-            &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
-            &IntegrationStatusViewOptions {
-                show_statistics: false,
-                show_max_weight_details: false,
-                show_top_discrete_grid: true,
-                show_discrete_contributions_sum: true,
-                contribution_sort: ContributionSortMode::Index,
-                show_max_weight_info_for_discrete_bins: false,
-                ..default_view_options()
-            },
-            None,
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Iteration,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(2),
+                Duration::from_secs(2),
+                110_000,
+                210_000,
+                210_000,
+            ),
         );
 
         let header_line = rendered
@@ -4134,17 +4150,20 @@ mod tests {
         };
         let ansi = render_tabled::render_status_update(
             &build_status_update(
-                IntegrationStatusKind::Iteration,
-                &state,
-                1,
-                Duration::from_secs(0),
-                Duration::from_secs(0),
-                0,
-                0,
-                0,
-                &[None, None],
-                &view_options,
-                None,
+                StatusUpdateBuildRequest::new(
+                    IntegrationStatusKind::Iteration,
+                    &state,
+                    &[None, None],
+                    &view_options,
+                )
+                .with_timing(
+                    1,
+                    Duration::from_secs(0),
+                    Duration::from_secs(0),
+                    0,
+                    0,
+                    0,
+                ),
             ),
             &tabled_options_for_view(&view_options),
         );
@@ -4285,24 +4304,30 @@ mod tests {
     #[test]
     fn ratatui_overview_shows_eta_and_all_slot_metrics() {
         let state = make_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            ..default_view_options()
+        };
         let rendered = render_ratatui_update(
-            IntegrationStatusKind::Live,
-            &state,
-            Duration::from_secs(15),
-            Duration::from_secs(10),
-            25_000,
-            125_000,
-            125_000,
-            &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
-            &IntegrationStatusViewOptions {
-                show_statistics: false,
-                show_max_weight_details: false,
-                ..default_view_options()
-            },
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(15),
+                Duration::from_secs(10),
+                25_000,
+                125_000,
+                125_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 25_000,
                 target_points: 100_000,
-            }),
+            })),
             |_| {},
         );
 
@@ -4330,19 +4355,24 @@ mod tests {
             ..default_view_options()
         };
         let rendered = render_ratatui_update(
-            IntegrationStatusKind::Live,
-            &state,
-            Duration::from_secs(15),
-            Duration::from_secs(10),
-            25_000,
-            125_000,
-            125_000,
-            &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
-            &view_options,
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(15),
+                Duration::from_secs(10),
+                25_000,
+                125_000,
+                125_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 25_000,
                 target_points: 100_000,
-            }),
+            })),
             |dashboard| dashboard.toggle_chart_component(),
         );
 
@@ -4355,30 +4385,36 @@ mod tests {
     #[test]
     fn ratatui_integrand_targets_are_trimmed_for_display() {
         let state = make_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            ..default_view_options()
+        };
         let rendered = render_ratatui_update(
-            IntegrationStatusKind::Live,
-            &state,
-            Duration::from_secs(15),
-            Duration::from_secs(10),
-            25_000,
-            125_000,
-            125_000,
-            &[
-                Some(Complex::new(
-                    F(7.600000000000001e-6),
-                    F(7.430000000000004e-5),
-                )),
-                Some(Complex::new(F(6.629999999999999e-5), F(0.0))),
-            ],
-            &IntegrationStatusViewOptions {
-                show_statistics: false,
-                show_max_weight_details: false,
-                ..default_view_options()
-            },
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[
+                    Some(Complex::new(
+                        F(7.600000000000001e-6),
+                        F(7.430000000000004e-5),
+                    )),
+                    Some(Complex::new(F(6.629999999999999e-5), F(0.0))),
+                ],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(15),
+                Duration::from_secs(10),
+                25_000,
+                125_000,
+                125_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 25_000,
                 target_points: 100_000,
-            }),
+            })),
             |_| {},
         );
 
@@ -4392,25 +4428,31 @@ mod tests {
     #[test]
     fn ratatui_overview_shows_eta_to_target_when_configured() {
         let state = make_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            target_relative_accuracy: Some(0.05),
+            show_statistics: false,
+            show_max_weight_details: false,
+            ..default_view_options()
+        };
         let rendered = render_ratatui_update(
-            IntegrationStatusKind::Live,
-            &state,
-            Duration::from_secs(25),
-            Duration::from_secs(10),
-            25_000,
-            125_000,
-            125_000,
-            &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
-            &IntegrationStatusViewOptions {
-                target_relative_accuracy: Some(0.05),
-                show_statistics: false,
-                show_max_weight_details: false,
-                ..default_view_options()
-            },
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(25),
+                Duration::from_secs(10),
+                25_000,
+                125_000,
+                125_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 25_000,
                 target_points: 100_000,
-            }),
+            })),
             |_| {},
         );
 
@@ -4421,97 +4463,117 @@ mod tests {
     #[test]
     fn eta_to_target_specification_formats_relative_and_absolute_targets() {
         let state = make_integration_state();
+        let relative_view_options = IntegrationStatusViewOptions {
+            target_relative_accuracy: Some(0.05),
+            ..default_view_options()
+        };
         let update = build_status_update(
-            IntegrationStatusKind::Live,
-            &state,
-            4,
-            Duration::from_secs(25),
-            Duration::from_secs(10),
-            25_000,
-            125_000,
-            125_000,
-            &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
-            &IntegrationStatusViewOptions {
-                target_relative_accuracy: Some(0.05),
-                ..default_view_options()
-            },
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
+                &relative_view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(25),
+                Duration::from_secs(10),
+                25_000,
+                125_000,
+                125_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 25_000,
                 target_points: 100_000,
-            }),
+            })),
         );
         assert_eq!(
             update.meta.eta_to_target_specification(),
             Some("% err <= 5%")
         );
 
+        let relative_scientific_view_options = IntegrationStatusViewOptions {
+            target_relative_accuracy: Some(1.0e-6),
+            ..default_view_options()
+        };
         let update = build_status_update(
-            IntegrationStatusKind::Live,
-            &state,
-            4,
-            Duration::from_secs(25),
-            Duration::from_secs(10),
-            25_000,
-            125_000,
-            125_000,
-            &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
-            &IntegrationStatusViewOptions {
-                target_relative_accuracy: Some(1.0e-6),
-                ..default_view_options()
-            },
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
+                &relative_scientific_view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(25),
+                Duration::from_secs(10),
+                25_000,
+                125_000,
+                125_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 25_000,
                 target_points: 100_000,
-            }),
+            })),
         );
         assert_eq!(
             update.meta.eta_to_target_specification(),
             Some("% err <= 1e-4%")
         );
 
+        let absolute_view_options = IntegrationStatusViewOptions {
+            target_absolute_accuracy: Some(1.0e-6),
+            ..default_view_options()
+        };
         let update = build_status_update(
-            IntegrationStatusKind::Live,
-            &state,
-            4,
-            Duration::from_secs(25),
-            Duration::from_secs(10),
-            25_000,
-            125_000,
-            125_000,
-            &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
-            &IntegrationStatusViewOptions {
-                target_absolute_accuracy: Some(1.0e-6),
-                ..default_view_options()
-            },
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
+                &absolute_view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(25),
+                Duration::from_secs(10),
+                25_000,
+                125_000,
+                125_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 25_000,
                 target_points: 100_000,
-            }),
+            })),
         );
         assert_eq!(
             update.meta.eta_to_target_specification(),
             Some("err <= 1e-6")
         );
 
+        let combined_view_options = IntegrationStatusViewOptions {
+            target_relative_accuracy: Some(0.05),
+            target_absolute_accuracy: Some(1.0e-6),
+            ..default_view_options()
+        };
         let update = build_status_update(
-            IntegrationStatusKind::Live,
-            &state,
-            4,
-            Duration::from_secs(25),
-            Duration::from_secs(10),
-            25_000,
-            125_000,
-            125_000,
-            &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
-            &IntegrationStatusViewOptions {
-                target_relative_accuracy: Some(0.05),
-                target_absolute_accuracy: Some(1.0e-6),
-                ..default_view_options()
-            },
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
+                &combined_view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(25),
+                Duration::from_secs(10),
+                25_000,
+                125_000,
+                125_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 25_000,
                 target_points: 100_000,
-            }),
+            })),
         );
         assert_eq!(
             update.meta.eta_to_target_specification(),
@@ -4576,54 +4638,66 @@ mod tests {
 
         state.iter = 1;
         dashboard.update(build_status_update(
-            IntegrationStatusKind::Live,
-            &state,
-            4,
-            Duration::from_secs(10),
-            Duration::from_secs(10),
-            500_000,
-            1_000_000,
-            1_000_000,
-            &[None, None],
-            &view_options,
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[None, None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(10),
+                Duration::from_secs(10),
+                500_000,
+                1_000_000,
+                1_000_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 500_000,
                 target_points: 1_000_000,
-            }),
+            })),
         ));
 
         state.iter = 2;
         dashboard.update(build_status_update(
-            IntegrationStatusKind::Live,
-            &state,
-            4,
-            Duration::from_secs(20),
-            Duration::from_secs(5),
-            0,
-            2_000_000,
-            2_000_000,
-            &[None, None],
-            &view_options,
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[None, None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(20),
+                Duration::from_secs(5),
+                0,
+                2_000_000,
+                2_000_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 0,
                 target_points: 1_000_000,
-            }),
+            })),
         ));
         dashboard.update(build_status_update(
-            IntegrationStatusKind::Live,
-            &state,
-            4,
-            Duration::from_secs(25),
-            Duration::from_secs(10),
-            200_000,
-            2_200_000,
-            2_200_000,
-            &[None, None],
-            &view_options,
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[None, None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(25),
+                Duration::from_secs(10),
+                200_000,
+                2_200_000,
+                2_200_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 200_000,
                 target_points: 1_000_000,
-            }),
+            })),
         ));
 
         dashboard.toggle_chart_history_window();
@@ -4651,20 +4725,24 @@ mod tests {
             state.iter = 1 + index / 40;
             let total_points = index * 1_000;
             dashboard.update(build_status_update(
-                IntegrationStatusKind::Live,
-                &state,
-                4,
-                Duration::from_secs(index as u64),
-                Duration::from_secs(10),
-                total_points % 1_000_000,
-                total_points,
-                total_points,
-                &[None, None],
-                &view_options,
-                Some(status_update::LiveIterationProgress {
+                StatusUpdateBuildRequest::new(
+                    IntegrationStatusKind::Live,
+                    &state,
+                    &[None, None],
+                    &view_options,
+                )
+                .with_timing(
+                    4,
+                    Duration::from_secs(index as u64),
+                    Duration::from_secs(10),
+                    total_points % 1_000_000,
+                    total_points,
+                    total_points,
+                )
+                .with_live_progress(Some(status_update::LiveIterationProgress {
                     completed_points: total_points % 1_000_000,
                     target_points: 1_000_000,
-                }),
+                })),
             ));
         }
 
@@ -4672,9 +4750,7 @@ mod tests {
         dashboard.toggle_chart_history_window();
 
         assert_eq!(
-            dashboard
-                .visible_history_sample_bounds()
-                .map(|(start, end)| (start, end)),
+            dashboard.visible_history_sample_bounds(),
             Some((0, 4_299_000))
         );
     }
@@ -4682,24 +4758,30 @@ mod tests {
     #[test]
     fn ratatui_convergence_title_shows_active_y_span() {
         let state = make_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            ..default_view_options()
+        };
         let rendered = render_ratatui_update(
-            IntegrationStatusKind::Live,
-            &state,
-            Duration::from_secs(15),
-            Duration::from_secs(10),
-            25_000,
-            125_000,
-            125_000,
-            &[None, None],
-            &IntegrationStatusViewOptions {
-                show_statistics: false,
-                show_max_weight_details: false,
-                ..default_view_options()
-            },
-            Some(status_update::LiveIterationProgress {
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Live,
+                &state,
+                &[None, None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(15),
+                Duration::from_secs(10),
+                25_000,
+                125_000,
+                125_000,
+            )
+            .with_live_progress(Some(status_update::LiveIterationProgress {
                 completed_points: 25_000,
                 target_points: 100_000,
-            }),
+            })),
             |dashboard| dashboard.widen_chart_y_sigma_span(),
         );
 
@@ -4709,24 +4791,29 @@ mod tests {
     #[test]
     fn ratatui_discrete_tab_renders_selected_bin_detail() {
         let state = make_discrete_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            show_top_discrete_grid: false,
+            show_discrete_contributions_sum: false,
+            show_max_weight_info_for_discrete_bins: false,
+            ..default_view_options()
+        };
         let rendered = render_ratatui_update(
-            IntegrationStatusKind::Iteration,
-            &state,
-            Duration::from_secs(12),
-            Duration::from_secs(12),
-            110_000,
-            210_000,
-            210_000,
-            &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
-            &IntegrationStatusViewOptions {
-                show_statistics: false,
-                show_max_weight_details: false,
-                show_top_discrete_grid: false,
-                show_discrete_contributions_sum: false,
-                show_max_weight_info_for_discrete_bins: false,
-                ..default_view_options()
-            },
-            None,
+            StatusUpdateBuildRequest::new(
+                IntegrationStatusKind::Iteration,
+                &state,
+                &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
+                &view_options,
+            )
+            .with_timing(
+                4,
+                Duration::from_secs(12),
+                Duration::from_secs(12),
+                110_000,
+                210_000,
+                210_000,
+            ),
             |dashboard| dashboard.select_tab(1),
         );
 

--- a/crates/gammalooprs/src/integrate/mod.rs
+++ b/crates/gammalooprs/src/integrate/mod.rs
@@ -2268,6 +2268,28 @@ where
             })
             .collect_vec();
 
+        let iteration_start = Instant::now();
+        let mut current_batch_size = initial_batch_size(batching);
+        let mut last_live_status = None;
+        if batching.emit_initial_status_update && !is_interrupted() {
+            status_emitter(build_status_update(
+                IntegrationStatusKind::Live,
+                &integration_state,
+                cores,
+                t_start.elapsed(),
+                iteration_start.elapsed(),
+                0,
+                integration_state.num_points,
+                n_samples_evaluated,
+                &targets,
+                &view_options,
+                Some(status_update::LiveIterationProgress {
+                    completed_points: 0,
+                    target_points: cur_points,
+                }),
+            ))?;
+        }
+
         let current_max_evals = integration_state
             .all_integrals
             .iter()
@@ -2292,28 +2314,6 @@ where
                 )
             })
             .collect_vec();
-
-        let iteration_start = Instant::now();
-        let mut current_batch_size = initial_batch_size(batching);
-        let mut last_live_status = None;
-        if batching.emit_initial_status_update && !is_interrupted() {
-            status_emitter(build_status_update(
-                IntegrationStatusKind::Live,
-                &integration_state,
-                cores,
-                t_start.elapsed(),
-                iteration_start.elapsed(),
-                0,
-                integration_state.num_points,
-                n_samples_evaluated,
-                &targets,
-                &view_options,
-                Some(status_update::LiveIterationProgress {
-                    completed_points: 0,
-                    target_points: cur_points,
-                }),
-            ))?;
-        }
         while total_remaining_points(&worker_states) > 0 {
             let round_started_at = Instant::now();
             let processed_per_core: Vec<Result<usize>> = pool.install(|| {
@@ -2421,6 +2421,7 @@ where
                 )
                 .yellow()
             );
+            continue;
         }
 
         n_samples_evaluated += completed_points;
@@ -3665,6 +3666,8 @@ mod tests {
             phase_display: IntegrationStatusPhaseDisplay::Both,
             training_phase_display: IntegrationStatusPhaseDisplay::Real,
             training_slot: 0,
+            slot_training_phase_displays: vec![IntegrationStatusPhaseDisplay::Real],
+            per_slot_training_phase: false,
             show_statistics: true,
             show_max_weight_details: true,
             show_top_discrete_grid: false,
@@ -3980,6 +3983,10 @@ mod tests {
 
         assert!(rendered.contains("Sum"), "{rendered}");
         assert!(rendered.contains("Contribution (idx=graph)"), "{rendered}");
+        assert!(
+            !rendered.contains("│             (idx=graph)             │"),
+            "{rendered}"
+        );
         assert!(rendered.contains("#0: GL0"), "{rendered}");
         assert!(rendered.contains("75.0%"), "{rendered}");
         assert!(rendered.contains("25.0%"), "{rendered}");
@@ -4267,16 +4274,229 @@ mod tests {
             |_| {},
         );
 
-        assert!(rendered.contains("iter ETA 30s"), "{rendered}");
         assert!(rendered.contains("Iteration progress"), "{rendered}");
-        assert!(rendered.contains("rate 2.50K/s"), "{rendered}");
+        assert!(rendered.contains("ETA 30s"), "{rendered}");
+        assert!(rendered.contains("25.00K / 100.00K (25.0%)"), "{rendered}");
+        assert!(rendered.contains("# samples total 125.00K"), "{rendered}");
+        assert!(rendered.contains("#samples/s"), "{rendered}");
+        assert!(rendered.contains("Integrands"), "{rendered}");
+        assert!(rendered.contains("Focused integrand"), "{rendered}");
+        assert!(rendered.contains("Results summary"), "{rendered}");
+        assert!(rendered.contains("% err"), "{rendered}");
+        assert!(rendered.contains("chi^2"), "{rendered}");
+        assert!(rendered.contains("m.w.i"), "{rendered}");
+        assert!(rendered.contains("Timing composition"), "{rendered}");
+        assert!(rendered.contains("Precision mix"), "{rendered}");
+    }
+
+    #[test]
+    fn ratatui_overview_chart_phase_toggle_updates_convergence_label() {
+        let state = make_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            ..default_view_options()
+        };
+        let rendered = render_ratatui_update(
+            IntegrationStatusKind::Live,
+            &state,
+            Duration::from_secs(15),
+            Duration::from_secs(10),
+            25_000,
+            125_000,
+            125_000,
+            &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
+            &view_options,
+            Some(status_update::LiveIterationProgress {
+                completed_points: 25_000,
+                target_points: 100_000,
+            }),
+            |dashboard| dashboard.toggle_chart_component(),
+        );
+
         assert!(
-            rendered.contains("All-slot metrics [metrics density]"),
+            rendered.contains("Convergence : imag (not selected for training)"),
             "{rendered}"
         );
-        assert!(rendered.contains("rel err"), "{rendered}");
-        assert!(rendered.contains("chi^2"), "{rendered}");
-        assert!(rendered.contains("mwi"), "{rendered}");
+    }
+
+    #[test]
+    fn ratatui_integrand_targets_are_trimmed_for_display() {
+        let state = make_integration_state();
+        let rendered = render_ratatui_update(
+            IntegrationStatusKind::Live,
+            &state,
+            Duration::from_secs(15),
+            Duration::from_secs(10),
+            25_000,
+            125_000,
+            125_000,
+            &[
+                Some(Complex::new(
+                    F(7.600000000000001e-6),
+                    F(7.430000000000004e-5),
+                )),
+                Some(Complex::new(F(6.629999999999999e-5), F(0.0))),
+            ],
+            &IntegrationStatusViewOptions {
+                show_statistics: false,
+                show_max_weight_details: false,
+                ..default_view_options()
+            },
+            Some(status_update::LiveIterationProgress {
+                completed_points: 25_000,
+                target_points: 100_000,
+            }),
+            |_| {},
+        );
+
+        assert!(rendered.contains("trgt"), "{rendered}");
+        assert!(rendered.contains("+7.6e-6"), "{rendered}");
+        assert!(rendered.contains("+7.43e-5"), "{rendered}");
+        assert!(rendered.contains("+6.63e-5"), "{rendered}");
+        assert!(rendered.contains("+0e0"), "{rendered}");
+    }
+
+    #[test]
+    fn ratatui_recent_history_window_tracks_current_iteration_points() {
+        let mut dashboard = RatatuiDashboardState::new();
+        let mut state = make_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            ..default_view_options()
+        };
+
+        state.iter = 1;
+        dashboard.update(build_status_update(
+            IntegrationStatusKind::Live,
+            &state,
+            4,
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+            500_000,
+            1_000_000,
+            1_000_000,
+            &[None, None],
+            &view_options,
+            Some(status_update::LiveIterationProgress {
+                completed_points: 500_000,
+                target_points: 1_000_000,
+            }),
+        ));
+
+        state.iter = 2;
+        dashboard.update(build_status_update(
+            IntegrationStatusKind::Live,
+            &state,
+            4,
+            Duration::from_secs(20),
+            Duration::from_secs(5),
+            0,
+            2_000_000,
+            2_000_000,
+            &[None, None],
+            &view_options,
+            Some(status_update::LiveIterationProgress {
+                completed_points: 0,
+                target_points: 1_000_000,
+            }),
+        ));
+        dashboard.update(build_status_update(
+            IntegrationStatusKind::Live,
+            &state,
+            4,
+            Duration::from_secs(25),
+            Duration::from_secs(10),
+            200_000,
+            2_200_000,
+            2_200_000,
+            &[None, None],
+            &view_options,
+            Some(status_update::LiveIterationProgress {
+                completed_points: 200_000,
+                target_points: 1_000_000,
+            }),
+        ));
+
+        dashboard.toggle_chart_history_window();
+        for _ in 0..5 {
+            dashboard.narrow_chart_history_window();
+        }
+
+        assert_eq!(
+            dashboard.visible_history_sample_bounds(),
+            Some((2_000_000, 2_200_000))
+        );
+    }
+
+    #[test]
+    fn ratatui_full_history_preserves_origin_after_compaction() {
+        let mut dashboard = RatatuiDashboardState::new();
+        let mut state = make_integration_state();
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            ..default_view_options()
+        };
+
+        for index in 0..4_300 {
+            state.iter = 1 + index / 40;
+            let total_points = index * 1_000;
+            dashboard.update(build_status_update(
+                IntegrationStatusKind::Live,
+                &state,
+                4,
+                Duration::from_secs(index as u64),
+                Duration::from_secs(10),
+                total_points % 1_000_000,
+                total_points,
+                total_points,
+                &[None, None],
+                &view_options,
+                Some(status_update::LiveIterationProgress {
+                    completed_points: total_points % 1_000_000,
+                    target_points: 1_000_000,
+                }),
+            ));
+        }
+
+        dashboard.toggle_chart_history_window();
+        dashboard.toggle_chart_history_window();
+
+        assert_eq!(
+            dashboard
+                .visible_history_sample_bounds()
+                .map(|(start, end)| (start, end)),
+            Some((0, 4_299_000))
+        );
+    }
+
+    #[test]
+    fn ratatui_convergence_title_shows_active_y_span() {
+        let state = make_integration_state();
+        let rendered = render_ratatui_update(
+            IntegrationStatusKind::Live,
+            &state,
+            Duration::from_secs(15),
+            Duration::from_secs(10),
+            25_000,
+            125_000,
+            125_000,
+            &[None, None],
+            &IntegrationStatusViewOptions {
+                show_statistics: false,
+                show_max_weight_details: false,
+                ..default_view_options()
+            },
+            Some(status_update::LiveIterationProgress {
+                completed_points: 25_000,
+                target_points: 100_000,
+            }),
+            |dashboard| dashboard.widen_chart_y_sigma_span(),
+        );
+
+        assert!(rendered.contains("y ±5σ"), "{rendered}");
     }
 
     #[test]
@@ -4303,15 +4523,17 @@ mod tests {
             |dashboard| dashboard.select_tab(1),
         );
 
-        assert!(rendered.contains("Selected bin detail"), "{rendered}");
+        assert!(rendered.contains("Selected bin"), "{rendered}");
         assert!(
-            rendered.contains("Discrete bins (sort: Error desc)"),
+            rendered.contains("Discrete bins for focused integrand"),
             "{rendered}"
         );
+        assert!(rendered.contains("sample %"), "{rendered}");
         assert!(rendered.contains("GL0"), "{rendered}");
         assert!(rendered.contains("GL1"), "{rendered}");
         assert!(rendered.contains("pdf"), "{rendered}");
-        assert!(rendered.contains("Selected bin detail"), "{rendered}");
+        assert!(rendered.contains("Per integrand details"), "{rendered}");
+        assert!(rendered.contains("# samples"), "{rendered}");
     }
 }
 

--- a/crates/gammalooprs/src/integrate/mod.rs
+++ b/crates/gammalooprs/src/integrate/mod.rs
@@ -2202,14 +2202,23 @@ where
         ));
     }
 
-    let sampling_str = slots[0].settings.sampling.describe_settings();
-    let dimension = slots[0].integrand.get_n_dim();
-    let discrete_depth = slots[0].settings.sampling.discrete_depth();
-    let is_tropical_sampling = slots[0]
+    let primary = &slots[0];
+    let sampling_str = primary.settings.sampling.describe_settings();
+    let dimension = primary.integrand.get_n_dim();
+    let discrete_depth = primary.settings.sampling.discrete_depth();
+    let is_tropical_sampling = primary
         .settings
         .sampling
         .get_parameterization_settings()
         .is_none();
+    let use_ltd = primary.settings.general.use_ltd;
+    let integration_seed = primary.settings.integrator.seed;
+    let integrated_phase = primary.settings.integrator.integrated_phase;
+    let target_relative_accuracy = primary.settings.integrator.target_relative_accuracy;
+    let target_absolute_accuracy = primary.settings.integrator.target_absolute_accuracy;
+    let n_start = primary.settings.integrator.n_start;
+    let n_increase = primary.settings.integrator.n_increase;
+    let n_max = primary.settings.integrator.n_max;
 
     let cont_dim_str = if is_tropical_sampling {
         format!("a median continious dimension of {}", dimension)
@@ -2245,11 +2254,7 @@ where
 
     info!(
         "Integrating using {} ltd with {} {} over {} ...",
-        if slots[0].settings.general.use_ltd {
-            "naive"
-        } else {
-            "cff"
-        },
+        if use_ltd { "naive" } else { "cff" },
         cores,
         if cores > 1 { "cores" } else { "core" },
         grid_str
@@ -2261,15 +2266,12 @@ where
     let mut n_samples_evaluated = 0;
     let mut emitted_latest_observable_paths = vec![None; n_slots];
     clear_iteration_abort_request();
-    'integrateLoop: while integration_state.num_points < slots[0].settings.integrator.n_max {
+    'integrateLoop: while integration_state.num_points < n_max {
         // ensure we do not overshoot
         let cur_points = {
-            let cur_points_not_final_iter = slots[0].settings.integrator.n_start
-                + slots[0].settings.integrator.n_increase * integration_state.iter;
-            if cur_points_not_final_iter + integration_state.num_points
-                > slots[0].settings.integrator.n_max
-            {
-                slots[0].settings.integrator.n_max - integration_state.num_points
+            let cur_points_not_final_iter = n_start + n_increase * integration_state.iter;
+            if cur_points_not_final_iter + integration_state.num_points > n_max {
+                n_max - integration_state.num_points
             } else {
                 cur_points_not_final_iter
             }
@@ -2327,7 +2329,7 @@ where
                         .iter()
                         .map(|sampling_state| sampling_state.grid.clone())
                         .collect_vec(),
-                    slots[0].settings.integrator.seed + integration_state.iter as u64,
+                    integration_seed + integration_state.iter as u64,
                     target_points_per_core * core_id,
                     n_points,
                 )
@@ -2531,14 +2533,14 @@ where
             integration_state.num_points,
             t_start.elapsed(),
             &targets,
-            match slots[0].settings.integrator.integrated_phase {
+            match integrated_phase {
                 IntegratedPhase::Real | IntegratedPhase::Both => {
                     IntegrationStatusPhaseDisplay::Real
                 }
                 IntegratedPhase::Imag => IntegrationStatusPhaseDisplay::Imag,
             },
-            slots[0].settings.integrator.target_relative_accuracy,
-            slots[0].settings.integrator.target_absolute_accuracy,
+            target_relative_accuracy,
+            target_absolute_accuracy,
         );
         if target_accuracy_status.is_reached() {
             let reached_target = match (
@@ -2587,11 +2589,7 @@ where
     if !slots.is_empty() {
         emit_results_output_summary(
             workspace.as_deref(),
-            &integration_state.slot_metas,
-            &slots
-                .iter()
-                .map(|slot| slot.integrand.clone())
-                .collect_vec(),
+            &slots,
             &emitted_latest_observable_paths,
             output_control,
         );
@@ -2967,21 +2965,16 @@ fn workspace_relative_display_path(root: &Path, path: &Path) -> String {
 
 fn emit_results_output_summary(
     workspace: Option<&Path>,
-    slot_metas: &[SlotMeta],
-    slot_integrands: &[Integrand],
+    slots: &[IntegrationSlot],
     emitted_paths: &[Option<PathBuf>],
     output_control: WorkspaceSnapshotControl,
 ) {
     let mut summary_rows = Vec::new();
-    for ((slot_meta, integrand), emitted_path) in slot_metas
-        .iter()
-        .zip(slot_integrands.iter())
-        .zip(emitted_paths.iter())
-    {
+    for (slot, emitted_path) in slots.iter().zip(emitted_paths.iter()) {
         let Some(final_path) = emitted_path else {
             continue;
         };
-        let Integrand::ProcessIntegrand(process_integrand) = integrand else {
+        let Integrand::ProcessIntegrand(process_integrand) = &slot.integrand else {
             continue;
         };
         let format = process_integrand
@@ -2998,7 +2991,7 @@ fn emit_results_output_summary(
                 )
             })
             .flatten();
-        summary_rows.push((slot_meta, final_path, iteration_pattern));
+        summary_rows.push((&slot.meta, final_path, iteration_pattern));
     }
 
     if summary_rows.is_empty() && workspace.is_none() {

--- a/crates/gammalooprs/src/integrate/mod.rs
+++ b/crates/gammalooprs/src/integrate/mod.rs
@@ -54,7 +54,7 @@ pub use status_update::{
     ContributionSortMode, IntegrationStatusKind, IntegrationStatusPhaseDisplay,
     IntegrationStatusViewOptions, StatusUpdate,
 };
-use status_update::{build_saved_status_update, build_status_update};
+use status_update::{build_saved_status_update, build_status_update, evaluate_target_accuracy};
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -2499,6 +2499,36 @@ where
             &view_options,
             None,
         ))?;
+
+        let target_accuracy_status = evaluate_target_accuracy(
+            &integration_state,
+            integration_state.num_points,
+            t_start.elapsed(),
+            &targets,
+            match slot0_settings.integrator.integrated_phase {
+                IntegratedPhase::Real | IntegratedPhase::Both => {
+                    IntegrationStatusPhaseDisplay::Real
+                }
+                IntegratedPhase::Imag => IntegrationStatusPhaseDisplay::Imag,
+            },
+            slot0_settings.integrator.target_relative_accuracy,
+            slot0_settings.integrator.target_absolute_accuracy,
+        );
+        if target_accuracy_status.is_reached() {
+            let reached_target = match (
+                target_accuracy_status.relative_reached,
+                target_accuracy_status.absolute_reached,
+            ) {
+                (true, true) => "relative and absolute",
+                (true, false) => "relative",
+                (false, true) => "absolute",
+                (false, false) => unreachable!(),
+            };
+            info!(
+                "Stopping integration after reaching the configured {reached_target} accuracy target."
+            );
+            break;
+        }
     }
     // Reset the interrupted flag
     set_interrupted(false);
@@ -3668,6 +3698,8 @@ mod tests {
             training_slot: 0,
             slot_training_phase_displays: vec![IntegrationStatusPhaseDisplay::Real],
             per_slot_training_phase: false,
+            target_relative_accuracy: None,
+            target_absolute_accuracy: None,
             show_statistics: true,
             show_max_weight_details: true,
             show_top_discrete_grid: false,
@@ -4355,6 +4387,181 @@ mod tests {
         assert!(rendered.contains("+7.43e-5"), "{rendered}");
         assert!(rendered.contains("+6.63e-5"), "{rendered}");
         assert!(rendered.contains("+0e0"), "{rendered}");
+    }
+
+    #[test]
+    fn ratatui_overview_shows_eta_to_target_when_configured() {
+        let state = make_integration_state();
+        let rendered = render_ratatui_update(
+            IntegrationStatusKind::Live,
+            &state,
+            Duration::from_secs(25),
+            Duration::from_secs(10),
+            25_000,
+            125_000,
+            125_000,
+            &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
+            &IntegrationStatusViewOptions {
+                target_relative_accuracy: Some(0.05),
+                show_statistics: false,
+                show_max_weight_details: false,
+                ..default_view_options()
+            },
+            Some(status_update::LiveIterationProgress {
+                completed_points: 25_000,
+                target_points: 100_000,
+            }),
+            |_| {},
+        );
+
+        assert!(rendered.contains("ETA to target"), "{rendered}");
+        assert!(rendered.contains("(% err <= 5%)"), "{rendered}");
+    }
+
+    #[test]
+    fn eta_to_target_specification_formats_relative_and_absolute_targets() {
+        let state = make_integration_state();
+        let update = build_status_update(
+            IntegrationStatusKind::Live,
+            &state,
+            4,
+            Duration::from_secs(25),
+            Duration::from_secs(10),
+            25_000,
+            125_000,
+            125_000,
+            &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
+            &IntegrationStatusViewOptions {
+                target_relative_accuracy: Some(0.05),
+                ..default_view_options()
+            },
+            Some(status_update::LiveIterationProgress {
+                completed_points: 25_000,
+                target_points: 100_000,
+            }),
+        );
+        assert_eq!(
+            update.meta.eta_to_target_specification(),
+            Some("% err <= 5%")
+        );
+
+        let update = build_status_update(
+            IntegrationStatusKind::Live,
+            &state,
+            4,
+            Duration::from_secs(25),
+            Duration::from_secs(10),
+            25_000,
+            125_000,
+            125_000,
+            &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
+            &IntegrationStatusViewOptions {
+                target_relative_accuracy: Some(1.0e-6),
+                ..default_view_options()
+            },
+            Some(status_update::LiveIterationProgress {
+                completed_points: 25_000,
+                target_points: 100_000,
+            }),
+        );
+        assert_eq!(
+            update.meta.eta_to_target_specification(),
+            Some("% err <= 1e-4%")
+        );
+
+        let update = build_status_update(
+            IntegrationStatusKind::Live,
+            &state,
+            4,
+            Duration::from_secs(25),
+            Duration::from_secs(10),
+            25_000,
+            125_000,
+            125_000,
+            &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
+            &IntegrationStatusViewOptions {
+                target_absolute_accuracy: Some(1.0e-6),
+                ..default_view_options()
+            },
+            Some(status_update::LiveIterationProgress {
+                completed_points: 25_000,
+                target_points: 100_000,
+            }),
+        );
+        assert_eq!(
+            update.meta.eta_to_target_specification(),
+            Some("err <= 1e-6")
+        );
+
+        let update = build_status_update(
+            IntegrationStatusKind::Live,
+            &state,
+            4,
+            Duration::from_secs(25),
+            Duration::from_secs(10),
+            25_000,
+            125_000,
+            125_000,
+            &[Some(Complex::new(F(1.0e-4), F(0.0))), None],
+            &IntegrationStatusViewOptions {
+                target_relative_accuracy: Some(0.05),
+                target_absolute_accuracy: Some(1.0e-6),
+                ..default_view_options()
+            },
+            Some(status_update::LiveIterationProgress {
+                completed_points: 25_000,
+                target_points: 100_000,
+            }),
+        );
+        assert_eq!(
+            update.meta.eta_to_target_specification(),
+            Some("% err <= 5% or err <= 1e-6")
+        );
+    }
+
+    #[test]
+    fn target_accuracy_status_uses_either_absolute_or_relative_condition() {
+        let state = make_integration_state();
+
+        let reached_by_absolute = status_update::evaluate_target_accuracy(
+            &state,
+            100_000,
+            Duration::from_secs(10),
+            &[None, None],
+            IntegrationStatusPhaseDisplay::Real,
+            None,
+            Some(1.0e-4),
+        );
+        assert!(reached_by_absolute.is_reached());
+
+        let reached_by_relative = status_update::evaluate_target_accuracy(
+            &state,
+            100_000,
+            Duration::from_secs(10),
+            &[Some(Complex::new(F(1.0e-3), F(0.0))), None],
+            IntegrationStatusPhaseDisplay::Real,
+            Some(0.1),
+            None,
+        );
+        assert!(reached_by_relative.is_reached());
+    }
+
+    #[test]
+    fn target_accuracy_status_treats_zero_relative_reference_as_inactive() {
+        let state = make_integration_state();
+        let status = status_update::evaluate_target_accuracy(
+            &state,
+            100_000,
+            Duration::from_secs(10),
+            &[Some(Complex::new(F(0.0), F(0.0))), None],
+            IntegrationStatusPhaseDisplay::Real,
+            Some(0.05),
+            None,
+        );
+
+        assert!(!status.relative_reached);
+        assert!(!status.absolute_reached);
+        assert_eq!(status.eta_to_target, None);
     }
 
     #[test]

--- a/crates/gammalooprs/src/integrate/mod.rs
+++ b/crates/gammalooprs/src/integrate/mod.rs
@@ -6,6 +6,7 @@
 //! The master node in combination with batch_integrate is for distributed runs.
 
 mod display;
+mod render_ratatui;
 mod render_tabled;
 mod status_update;
 
@@ -25,7 +26,6 @@ use symbolica::numerical_integration::{
     DiscreteGrid, Grid, MonteCarloRng, Sample, StatisticsAccumulator,
 };
 
-use crate::INTERRUPTED;
 use crate::Integrand;
 use crate::graph::{GroupId, LoopMomentumBasis};
 use crate::integrands::HasIntegrand;
@@ -43,8 +43,11 @@ use crate::settings::runtime::{
 };
 use crate::utils;
 use crate::utils::F;
-use crate::{is_interrupted, set_interrupted};
+use crate::{
+    clear_iteration_abort_request, is_interrupted, is_iteration_abort_requested, set_interrupted,
+};
 use rayon::prelude::*;
+pub use render_ratatui::RatatuiDashboardState;
 pub use render_tabled::TabledRenderOptions;
 use spenso::algebra::complex::Complex;
 pub use status_update::{
@@ -72,6 +75,7 @@ pub struct IterationBatchingSettings {
     pub batch_timing_seconds: f64,
     pub min_time_between_status_updates_seconds: f64,
     pub emit_live_status_updates: bool,
+    pub emit_initial_status_update: bool,
 }
 
 impl Default for IterationBatchingSettings {
@@ -81,6 +85,7 @@ impl Default for IterationBatchingSettings {
             batch_timing_seconds: 5.0,
             min_time_between_status_updates_seconds: 0.0,
             emit_live_status_updates: true,
+            emit_initial_status_update: true,
         }
     }
 }
@@ -1711,7 +1716,7 @@ impl CoreIterationState {
             SamplingCorrelationMode::Correlated => {
                 let mut samples = Vec::with_capacity(n_points);
                 for _ in 0..n_points {
-                    if INTERRUPTED.load(std::sync::atomic::Ordering::Relaxed) {
+                    if is_interrupted() {
                         break;
                     }
 
@@ -1737,8 +1742,12 @@ impl CoreIterationState {
                         &slot_models[slot_index],
                         iter,
                         false,
+                        true,
                         current_max_evals[slot_index],
                     )?;
+                    if raw_batch.samples.len() < samples.len() {
+                        return Ok(0);
+                    }
                     batch_evaluation_time += evaluation_start.elapsed();
                     total_sample_evaluations += raw_batch.samples.len();
                     batch_stats = batch_stats.merged(&raw_batch.statistics);
@@ -1790,7 +1799,7 @@ impl CoreIterationState {
                 for slot_index in 0..self.slot_integrands.len() {
                     let mut samples = Vec::with_capacity(n_points);
                     for _ in 0..n_points {
-                        if INTERRUPTED.load(std::sync::atomic::Ordering::Relaxed) {
+                        if is_interrupted() {
                             break;
                         }
 
@@ -1820,8 +1829,12 @@ impl CoreIterationState {
                         &slot_models[slot_index],
                         iter,
                         false,
+                        true,
                         current_max_evals[slot_index],
                     )?;
+                    if raw_batch.samples.len() < samples.len() {
+                        return Ok(0);
+                    }
                     batch_evaluation_time += evaluation_start.elapsed();
                     total_sample_evaluations += raw_batch.samples.len();
                     batch_stats = batch_stats.merged(&raw_batch.statistics);
@@ -2228,6 +2241,7 @@ where
 
     let mut n_samples_evaluated = 0;
     let mut emitted_latest_observable_paths = vec![None; n_slots];
+    clear_iteration_abort_request();
     'integrateLoop: while integration_state.num_points < slot0_settings.integrator.n_max {
         // ensure we do not overshoot
         let cur_points = {
@@ -2279,8 +2293,27 @@ where
             })
             .collect_vec();
 
+        let iteration_start = Instant::now();
         let mut current_batch_size = initial_batch_size(batching);
         let mut last_live_status = None;
+        if batching.emit_initial_status_update && !is_interrupted() {
+            status_emitter(build_status_update(
+                IntegrationStatusKind::Live,
+                &integration_state,
+                cores,
+                t_start.elapsed(),
+                iteration_start.elapsed(),
+                0,
+                integration_state.num_points,
+                n_samples_evaluated,
+                &targets,
+                &view_options,
+                Some(status_update::LiveIterationProgress {
+                    completed_points: 0,
+                    target_points: cur_points,
+                }),
+            ))?;
+        }
         while total_remaining_points(&worker_states) > 0 {
             let round_started_at = Instant::now();
             let processed_per_core: Vec<Result<usize>> = pool.install(|| {
@@ -2311,6 +2344,7 @@ where
             if batching.emit_live_status_updates
                 && completed_points < cur_points
                 && !is_interrupted()
+                && !is_iteration_abort_requested()
             {
                 let now = Instant::now();
                 let should_emit_live_status = last_live_status.is_none_or(|previous| {
@@ -2331,6 +2365,7 @@ where
                         &preview_state,
                         cores,
                         t_start.elapsed(),
+                        iteration_start.elapsed(),
                         completed_points,
                         integration_state.num_points + completed_points,
                         n_samples_evaluated + completed_points,
@@ -2346,8 +2381,12 @@ where
             }
 
             if is_interrupted() {
-                warn!("{}", "Integration iterrupted by user".yellow());
+                warn!("{}", "Integration interrupted by user".yellow());
                 break 'integrateLoop;
+            }
+
+            if is_iteration_abort_requested() {
+                break;
             }
 
             if total_remaining_points(&worker_states) > 0 {
@@ -2356,17 +2395,40 @@ where
             }
         }
 
+        let abort_current_iteration = is_iteration_abort_requested();
+        clear_iteration_abort_request();
+
         if is_interrupted() {
-            warn!("{}", "Integration iterrupted by user".yellow());
+            warn!("{}", "Integration interrupted by user".yellow());
             break 'integrateLoop;
         }
 
-        n_samples_evaluated += cur_points;
+        let completed_points = total_completed_points(&worker_states);
+        if abort_current_iteration && completed_points < cur_points {
+            if completed_points == 0 {
+                warn!(
+                    "{}",
+                    "Current iteration abort requested before any samples completed; restarting the iteration."
+                        .yellow()
+                );
+                continue;
+            }
+            warn!(
+                "{}",
+                format!(
+                    "Current iteration aborted by user after {} completed samples.",
+                    completed_points
+                )
+                .yellow()
+            );
+        }
+
+        n_samples_evaluated += completed_points;
         apply_iteration_core_states(
             &mut integration_state,
             &slot_settings,
             cores,
-            cur_points,
+            completed_points,
             elapsed_seconds_offset + t_start.elapsed().as_secs_f64(),
             &worker_states,
         );
@@ -2428,7 +2490,8 @@ where
             &integration_state,
             cores,
             t_start.elapsed(),
-            cur_points,
+            iteration_start.elapsed(),
+            completed_points,
             integration_state.num_points,
             n_samples_evaluated,
             &targets,
@@ -2438,6 +2501,7 @@ where
     }
     // Reset the interrupted flag
     set_interrupted(false);
+    clear_iteration_abort_request();
 
     if integration_state.num_points > 0 {
         status_emitter(build_status_update(
@@ -2445,6 +2509,7 @@ where
             &integration_state,
             cores,
             t_start.elapsed(),
+            Duration::ZERO,
             0,
             integration_state.num_points,
             n_samples_evaluated,
@@ -2939,7 +3004,8 @@ fn evaluate_sample_list(
     > = sample_chunks
         .zip(integrands)
         .map(|(chunk, mut integrand)| {
-            let raw_batch = integrand.evaluate_samples_raw(chunk, model, iter, false, max_eval)?;
+            let raw_batch =
+                integrand.evaluate_samples_raw(chunk, model, iter, false, false, max_eval)?;
             Ok((raw_batch.samples, raw_batch.statistics, integrand))
         })
         .collect();
@@ -3452,6 +3518,7 @@ fn render_integral_result(
 mod tests {
     use super::*;
     use colored::control;
+    use ratatui::{Terminal, backend::TestBackend};
     use symbolica::numerical_integration::ContinuousGrid;
 
     fn make_accumulator(
@@ -3596,6 +3663,8 @@ mod tests {
     fn default_view_options() -> IntegrationStatusViewOptions {
         IntegrationStatusViewOptions {
             phase_display: IntegrationStatusPhaseDisplay::Both,
+            training_phase_display: IntegrationStatusPhaseDisplay::Real,
+            training_slot: 0,
             show_statistics: true,
             show_max_weight_details: true,
             show_top_discrete_grid: false,
@@ -3608,6 +3677,23 @@ mod tests {
     fn default_tabled_options() -> TabledRenderOptions {
         TabledRenderOptions {
             max_table_width: DEFAULT_MAX_SHARED_TABLE_WIDTH,
+            show_statistics: true,
+            show_max_weight_details: true,
+            show_top_discrete_grid: false,
+            show_discrete_contributions_sum: false,
+            show_max_weight_info_for_discrete_bins: false,
+        }
+    }
+
+    fn tabled_options_for_view(view_options: &IntegrationStatusViewOptions) -> TabledRenderOptions {
+        TabledRenderOptions {
+            show_statistics: view_options.show_statistics,
+            show_max_weight_details: view_options.show_max_weight_details,
+            show_top_discrete_grid: view_options.show_top_discrete_grid,
+            show_discrete_contributions_sum: view_options.show_discrete_contributions_sum,
+            show_max_weight_info_for_discrete_bins: view_options
+                .show_max_weight_info_for_discrete_bins,
+            ..default_tabled_options()
         }
     }
 
@@ -3629,6 +3715,7 @@ mod tests {
                 state,
                 cores,
                 elapsed_time,
+                elapsed_time,
                 cur_points,
                 total_points_display,
                 n_samples_evaluated,
@@ -3636,8 +3723,56 @@ mod tests {
                 view_options,
                 live_progress,
             ),
-            &default_tabled_options(),
+            &tabled_options_for_view(view_options),
         )
+    }
+
+    fn render_ratatui_update(
+        kind: IntegrationStatusKind,
+        state: &IntegrationState,
+        elapsed_time: Duration,
+        iteration_elapsed_time: Duration,
+        cur_points: usize,
+        total_points_display: usize,
+        n_samples_evaluated: usize,
+        targets: &[Option<Complex<F<f64>>>],
+        view_options: &IntegrationStatusViewOptions,
+        live_progress: Option<status_update::LiveIterationProgress>,
+        configure: impl FnOnce(&mut RatatuiDashboardState),
+    ) -> String {
+        let mut dashboard = RatatuiDashboardState::new();
+        dashboard.update(build_status_update(
+            kind,
+            state,
+            4,
+            elapsed_time,
+            iteration_elapsed_time,
+            cur_points,
+            total_points_display,
+            n_samples_evaluated,
+            targets,
+            view_options,
+            live_progress,
+        ));
+        configure(&mut dashboard);
+
+        let backend = TestBackend::new(180, 48);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| dashboard.draw(frame))
+            .expect("ratatui draw");
+
+        let buffer = terminal.backend().buffer();
+        (0..buffer.area.height)
+            .map(|y| {
+                let mut line = String::new();
+                for x in 0..buffer.area.width {
+                    line.push_str(buffer[(x, y)].symbol());
+                }
+                line.trim_end().to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     #[test]
@@ -3682,6 +3817,7 @@ mod tests {
                 IntegrationStatusKind::Iteration,
                 &state,
                 1,
+                Duration::from_secs(0),
                 Duration::from_secs(0),
                 0,
                 0,
@@ -3933,34 +4069,47 @@ mod tests {
 
     #[test]
     fn orientation_descriptions_use_colored_signs() {
+        let mut state = make_discrete_integration_state();
+        state.first_non_trivial_discrete_label = Some("orientation".to_string());
+        state.first_non_trivial_discrete_bin_descriptions =
+            Some(vec!["+-0".to_string(), "0++".to_string()]);
+        for metadata in &mut state.slot_first_non_trivial_discrete_breakdown_metadata {
+            if let Some(metadata) = metadata.as_mut() {
+                metadata.axis_label = "orientation".to_string();
+                metadata.bin_labels = vec!["+-0".to_string(), "0++".to_string()];
+            }
+        }
+
         control::set_override(true);
         let expected_plus = "+".green().bold().to_string();
         let expected_minus = "-".red().bold().to_string();
-        control::set_override(false);
 
+        let view_options = IntegrationStatusViewOptions {
+            show_statistics: false,
+            show_max_weight_details: false,
+            show_top_discrete_grid: true,
+            show_discrete_contributions_sum: false,
+            contribution_sort: ContributionSortMode::Index,
+            show_max_weight_info_for_discrete_bins: false,
+            ..default_view_options()
+        };
         let ansi = render_tabled::render_status_update(
             &build_status_update(
                 IntegrationStatusKind::Iteration,
-                &make_discrete_integration_state(),
+                &state,
                 1,
+                Duration::from_secs(0),
                 Duration::from_secs(0),
                 0,
                 0,
                 0,
                 &[None, None],
-                &IntegrationStatusViewOptions {
-                    show_statistics: false,
-                    show_max_weight_details: false,
-                    show_top_discrete_grid: true,
-                    show_discrete_contributions_sum: false,
-                    contribution_sort: ContributionSortMode::Index,
-                    show_max_weight_info_for_discrete_bins: false,
-                    ..default_view_options()
-                },
+                &view_options,
                 None,
             ),
-            &default_tabled_options(),
+            &tabled_options_for_view(&view_options),
         );
+        control::set_override(false);
 
         assert!(ansi.contains(&expected_plus), "{ansi}");
         assert!(ansi.contains(&expected_minus), "{ansi}");
@@ -4092,6 +4241,77 @@ mod tests {
             !rendered.contains("# samples per iteration = 0"),
             "{rendered}"
         );
+    }
+
+    #[test]
+    fn ratatui_overview_shows_eta_and_all_slot_metrics() {
+        let state = make_integration_state();
+        let rendered = render_ratatui_update(
+            IntegrationStatusKind::Live,
+            &state,
+            Duration::from_secs(15),
+            Duration::from_secs(10),
+            25_000,
+            125_000,
+            125_000,
+            &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
+            &IntegrationStatusViewOptions {
+                show_statistics: false,
+                show_max_weight_details: false,
+                ..default_view_options()
+            },
+            Some(status_update::LiveIterationProgress {
+                completed_points: 25_000,
+                target_points: 100_000,
+            }),
+            |_| {},
+        );
+
+        assert!(rendered.contains("iter ETA 30s"), "{rendered}");
+        assert!(rendered.contains("Iteration progress"), "{rendered}");
+        assert!(rendered.contains("rate 2.50K/s"), "{rendered}");
+        assert!(
+            rendered.contains("All-slot metrics [metrics density]"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("rel err"), "{rendered}");
+        assert!(rendered.contains("chi^2"), "{rendered}");
+        assert!(rendered.contains("mwi"), "{rendered}");
+    }
+
+    #[test]
+    fn ratatui_discrete_tab_renders_selected_bin_detail() {
+        let state = make_discrete_integration_state();
+        let rendered = render_ratatui_update(
+            IntegrationStatusKind::Iteration,
+            &state,
+            Duration::from_secs(12),
+            Duration::from_secs(12),
+            110_000,
+            210_000,
+            210_000,
+            &[Some(Complex::new(F(1.0e-4), F(2.0e-5))), None],
+            &IntegrationStatusViewOptions {
+                show_statistics: false,
+                show_max_weight_details: false,
+                show_top_discrete_grid: false,
+                show_discrete_contributions_sum: false,
+                show_max_weight_info_for_discrete_bins: false,
+                ..default_view_options()
+            },
+            None,
+            |dashboard| dashboard.select_tab(1),
+        );
+
+        assert!(rendered.contains("Selected bin detail"), "{rendered}");
+        assert!(
+            rendered.contains("Discrete bins (sort: Error desc)"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("GL0"), "{rendered}");
+        assert!(rendered.contains("GL1"), "{rendered}");
+        assert!(rendered.contains("pdf"), "{rendered}");
+        assert!(rendered.contains("Selected bin detail"), "{rendered}");
     }
 }
 

--- a/crates/gammalooprs/src/integrate/render_ratatui.rs
+++ b/crates/gammalooprs/src/integrate/render_ratatui.rs
@@ -697,6 +697,23 @@ impl RatatuiDashboardState {
                     .unwrap_or_else(|| "warming up".to_string()),
                 TextStyle::PLAIN,
             );
+            if update.meta.show_eta_to_target {
+                left.push_text(" | ", TextStyle::PLAIN);
+                left.push_text("ETA to target ", TextStyle::green().bold());
+                if let Some(specification) = update.meta.eta_to_target_specification() {
+                    left.push_text("(", TextStyle::green().bold());
+                    left.push_text(specification, TextStyle::green().bold());
+                    left.push_text(") ", TextStyle::green().bold());
+                }
+                left.push_text(
+                    update
+                        .meta
+                        .eta_to_target()
+                        .map(|duration| utils::format_wdhms(duration.as_secs() as usize))
+                        .unwrap_or_else(|| "N/A".to_string()),
+                    TextStyle::PLAIN,
+                );
+            }
         }
 
         let mut right = StyledText::new();

--- a/crates/gammalooprs/src/integrate/render_ratatui.rs
+++ b/crates/gammalooprs/src/integrate/render_ratatui.rs
@@ -1,0 +1,1586 @@
+use std::cmp::Ordering;
+
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    prelude::{Color, Line, Modifier, Span, Style},
+    symbols::Marker,
+    text::Text,
+    widgets::{
+        Axis, Block, Borders, Cell, Chart, Clear, Dataset, Gauge, Paragraph, Row, Table,
+        TableState, Tabs, Wrap,
+    },
+};
+
+use crate::{settings::runtime::IntegrationStatisticsSnapshot, utils};
+
+use super::{
+    StatusUpdate,
+    display::{StyledText, TextColor, TextStyle},
+    status_update::{
+        ComponentKind, ContributionKind, ContributionSortMode, MainResultsRow,
+        MainResultsRowGroupKind, MainTableSlotCells,
+    },
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DashboardTab {
+    Overview,
+    Discrete,
+    MaxWeight,
+}
+
+impl DashboardTab {
+    fn all() -> [Self; 3] {
+        [Self::Overview, Self::Discrete, Self::MaxWeight]
+    }
+
+    fn index(self) -> usize {
+        match self {
+            Self::Overview => 0,
+            Self::Discrete => 1,
+            Self::MaxWeight => 2,
+        }
+    }
+
+    fn title(self) -> &'static str {
+        match self {
+            Self::Overview => "Overview",
+            Self::Discrete => "Discrete",
+            Self::MaxWeight => "Max Weight",
+        }
+    }
+
+    fn from_index(index: usize) -> Self {
+        Self::all().get(index).copied().unwrap_or(Self::Overview)
+    }
+
+    fn next(self) -> Self {
+        Self::from_index((self.index() + 1) % Self::all().len())
+    }
+
+    fn previous(self) -> Self {
+        Self::from_index((self.index() + Self::all().len() - 1) % Self::all().len())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DensityMode {
+    Compact,
+    Metrics,
+    Full,
+}
+
+impl DensityMode {
+    fn next(self) -> Self {
+        match self {
+            Self::Compact => Self::Metrics,
+            Self::Metrics => Self::Full,
+            Self::Full => Self::Compact,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Compact => "compact",
+            Self::Metrics => "metrics",
+            Self::Full => "full",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SlotMetricVisibility {
+    relative_error: bool,
+    chi_sq: bool,
+    max_weight_impact: bool,
+}
+
+impl Default for SlotMetricVisibility {
+    fn default() -> Self {
+        Self {
+            relative_error: true,
+            chi_sq: true,
+            max_weight_impact: true,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct HistoryPoint {
+    samples: usize,
+    central: f64,
+    error: f64,
+    completed_iteration: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct DiscreteRowRef<'a> {
+    row: &'a MainResultsRow,
+}
+
+impl<'a> DiscreteRowRef<'a> {
+    fn component(self) -> ComponentKind {
+        self.row.component.raw
+    }
+
+    fn contribution(self) -> ContributionKind {
+        self.row.contribution.raw
+    }
+
+    fn sort_value(self, mode: ContributionSortMode) -> f64 {
+        let Some(cell) = self.row.slot_cell(0) else {
+            return 0.0;
+        };
+        match mode {
+            ContributionSortMode::Index => match self.contribution() {
+                ContributionKind::Bin(index) => index as f64,
+                ContributionKind::All => -1.0,
+                ContributionKind::Sum => -0.5,
+            },
+            ContributionSortMode::Integral => cell
+                .value
+                .as_ref()
+                .map(|value| value.raw.0.abs().0)
+                .unwrap_or_default(),
+            ContributionSortMode::Error => cell
+                .value
+                .as_ref()
+                .map(|value| value.raw.1.abs().0)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+pub struct RatatuiDashboardState {
+    latest_update: Option<StatusUpdate>,
+    active_tab: DashboardTab,
+    density: DensityMode,
+    metric_visibility: SlotMetricVisibility,
+    focused_slot: usize,
+    selected_discrete_row: usize,
+    discrete_sort: ContributionSortMode,
+    discrete_descending: bool,
+    show_help: bool,
+    history: Vec<HistoryPoint>,
+}
+
+impl Default for RatatuiDashboardState {
+    fn default() -> Self {
+        Self {
+            latest_update: None,
+            active_tab: DashboardTab::Overview,
+            density: DensityMode::Metrics,
+            metric_visibility: SlotMetricVisibility::default(),
+            focused_slot: 0,
+            selected_discrete_row: 0,
+            discrete_sort: ContributionSortMode::Error,
+            discrete_descending: true,
+            show_help: false,
+            history: Vec::new(),
+        }
+    }
+}
+
+impl RatatuiDashboardState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn has_update(&self) -> bool {
+        self.latest_update.is_some()
+    }
+
+    pub fn update(&mut self, update: StatusUpdate) {
+        self.push_history_point(&update);
+        self.latest_update = Some(update);
+        self.clamp_state();
+    }
+
+    pub fn next_tab(&mut self) {
+        self.active_tab = self.active_tab.next();
+    }
+
+    pub fn previous_tab(&mut self) {
+        self.active_tab = self.active_tab.previous();
+    }
+
+    pub fn select_tab(&mut self, index: usize) {
+        self.active_tab = DashboardTab::from_index(index);
+    }
+
+    pub fn cycle_density(&mut self) {
+        self.density = self.density.next();
+    }
+
+    pub fn toggle_help(&mut self) {
+        self.show_help = !self.show_help;
+    }
+
+    pub fn toggle_relative_error(&mut self) {
+        self.metric_visibility.relative_error = !self.metric_visibility.relative_error;
+    }
+
+    pub fn toggle_chi_sq(&mut self) {
+        self.metric_visibility.chi_sq = !self.metric_visibility.chi_sq;
+    }
+
+    pub fn toggle_max_weight_impact(&mut self) {
+        self.metric_visibility.max_weight_impact = !self.metric_visibility.max_weight_impact;
+    }
+
+    pub fn focus_next_slot(&mut self) {
+        let slot_count = self
+            .latest_update
+            .as_ref()
+            .map(|update| update.main_results.slot_headers.len())
+            .unwrap_or_default();
+        if slot_count > 0 {
+            self.focused_slot = (self.focused_slot + 1) % slot_count;
+        }
+    }
+
+    pub fn focus_previous_slot(&mut self) {
+        let slot_count = self
+            .latest_update
+            .as_ref()
+            .map(|update| update.main_results.slot_headers.len())
+            .unwrap_or_default();
+        if slot_count > 0 {
+            self.focused_slot = (self.focused_slot + slot_count - 1) % slot_count;
+        }
+    }
+
+    pub fn select_next_discrete_row(&mut self) {
+        let row_count = self.discrete_rows().len();
+        if row_count > 0 {
+            self.selected_discrete_row = (self.selected_discrete_row + 1) % row_count;
+        }
+    }
+
+    pub fn select_previous_discrete_row(&mut self) {
+        let row_count = self.discrete_rows().len();
+        if row_count > 0 {
+            self.selected_discrete_row = (self.selected_discrete_row + row_count - 1) % row_count;
+        }
+    }
+
+    pub fn cycle_discrete_sort(&mut self) {
+        self.discrete_sort = match self.discrete_sort {
+            ContributionSortMode::Index => ContributionSortMode::Integral,
+            ContributionSortMode::Integral => ContributionSortMode::Error,
+            ContributionSortMode::Error => ContributionSortMode::Index,
+        };
+        self.clamp_state();
+    }
+
+    pub fn toggle_discrete_sort_direction(&mut self) {
+        self.discrete_descending = !self.discrete_descending;
+    }
+
+    pub fn draw(&self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        if let Some(update) = self.latest_update.as_ref() {
+            self.draw_dashboard(frame, area, update);
+            if self.show_help {
+                self.draw_help_overlay(frame, area);
+            }
+        } else {
+            frame.render_widget(
+                Paragraph::new("Waiting for integration status updates...")
+                    .block(titled_block("Integration dashboard")),
+                area,
+            );
+        }
+    }
+
+    fn clamp_state(&mut self) {
+        if let Some(update) = self.latest_update.as_ref() {
+            let slot_count = update.main_results.slot_headers.len();
+            if slot_count == 0 {
+                self.focused_slot = 0;
+            } else {
+                self.focused_slot = self.focused_slot.min(slot_count - 1);
+            }
+        } else {
+            self.focused_slot = 0;
+        }
+
+        let row_count = self.discrete_rows().len();
+        if row_count == 0 {
+            self.selected_discrete_row = 0;
+        } else {
+            self.selected_discrete_row = self.selected_discrete_row.min(row_count - 1);
+        }
+    }
+
+    fn push_history_point(&mut self, update: &StatusUpdate) {
+        let Some(component) = update.training_component() else {
+            return;
+        };
+        let Some(row) = update
+            .main_results
+            .find_row(ContributionKind::All, component)
+        else {
+            return;
+        };
+        let Some(value) = row
+            .slot_cell(update.meta.training_slot)
+            .and_then(|cell| cell.value.as_ref())
+        else {
+            return;
+        };
+
+        let point = HistoryPoint {
+            samples: update.meta.total_points,
+            central: value.raw.0.0,
+            error: value.raw.1.0.abs(),
+            completed_iteration: !matches!(update.kind(), super::IntegrationStatusKind::Live),
+        };
+
+        if self
+            .history
+            .last()
+            .is_some_and(|previous| previous.samples == point.samples)
+        {
+            let _ = self.history.pop();
+        }
+        if self
+            .history
+            .last()
+            .is_some_and(|previous| previous.samples > point.samples)
+        {
+            self.history.clear();
+        }
+        self.history.push(point);
+        if self.history.len() > 4096 {
+            let drain = self.history.len() - 4096;
+            self.history.drain(0..drain);
+        }
+    }
+
+    fn draw_dashboard(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let vertical = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Length(4),
+                Constraint::Length(if update.main_results.slot_headers.len() > 3 {
+                    4
+                } else {
+                    3
+                }),
+                Constraint::Min(12),
+                Constraint::Length(2),
+            ])
+            .split(area);
+
+        self.draw_tabs(frame, vertical[0]);
+        self.draw_progress(frame, vertical[1], update);
+        self.draw_slot_ribbon(frame, vertical[2], update);
+
+        match self.active_tab {
+            DashboardTab::Overview => self.draw_overview_tab(frame, vertical[3], update),
+            DashboardTab::Discrete => self.draw_discrete_tab(frame, vertical[3], update),
+            DashboardTab::MaxWeight => self.draw_max_weight_tab(frame, vertical[3], update),
+        }
+
+        self.draw_footer(frame, vertical[4], update);
+    }
+
+    fn draw_tabs(&self, frame: &mut Frame<'_>, area: Rect) {
+        let titles = DashboardTab::all()
+            .into_iter()
+            .map(|tab| {
+                Line::from(vec![Span::styled(
+                    format!(" {} ", tab.title()),
+                    Style::default().add_modifier(Modifier::BOLD),
+                )])
+            })
+            .collect::<Vec<_>>();
+
+        let tabs = Tabs::new(titles)
+            .block(titled_block("GammaLoop status"))
+            .select(self.active_tab.index())
+            .highlight_style(
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            );
+        frame.render_widget(tabs, area);
+    }
+
+    fn draw_progress(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let inner = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Length(2)])
+            .split(area);
+
+        let eta = update
+            .meta
+            .iteration_eta()
+            .map(|duration| utils::format_wdhms(duration.as_secs() as usize))
+            .unwrap_or_else(|| "warming up".to_string());
+        let throughput = format_rate(update.meta.live_progress.map(|progress| {
+            if update.meta.iteration_elapsed_time.is_zero() {
+                0.0
+            } else {
+                progress.completed_points as f64 / update.meta.iteration_elapsed_time.as_secs_f64()
+            }
+        }));
+        let per_sample_core = if update.meta.n_samples_evaluated == 0 {
+            "N/A".to_string()
+        } else {
+            utils::format_evaluation_time_from_f64(
+                update.meta.elapsed_time.as_secs_f64() / update.meta.n_samples_evaluated as f64
+                    * update.meta.cores as f64,
+            )
+        };
+        let header = Line::from(vec![
+            Span::styled(
+                format!(" Iteration #{} ", update.meta.iteration),
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                format!(
+                    "elapsed {}",
+                    utils::format_wdhms(update.meta.elapsed_time.as_secs() as usize)
+                ),
+                Style::default().fg(Color::Blue),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                format!("iter ETA {eta}"),
+                Style::default().fg(Color::Yellow),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                format!("rate {throughput}"),
+                Style::default().fg(Color::Blue),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                format!("{} /sample/core", per_sample_core),
+                Style::default().fg(Color::Blue),
+            ),
+        ]);
+        frame.render_widget(Paragraph::new(header), inner[0]);
+
+        let progress = update.meta.iteration_progress_ratio().unwrap_or_else(|| {
+            if matches!(update.kind(), super::IntegrationStatusKind::Live) {
+                0.0
+            } else {
+                1.0
+            }
+        });
+        let gauge = Gauge::default()
+            .block(titled_block("Iteration progress"))
+            .gauge_style(
+                Style::default()
+                    .fg(Color::Green)
+                    .bg(Color::Black)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .ratio(progress.clamp(0.0, 1.0))
+            .label(format!(
+                "{} / {} ({:.1}%)",
+                abbreviate_count(
+                    update
+                        .meta
+                        .live_progress
+                        .map(|progress| progress.completed_points)
+                        .unwrap_or(update.meta.current_iteration_points),
+                ),
+                abbreviate_count(
+                    update
+                        .meta
+                        .live_progress
+                        .map(|progress| progress.target_points)
+                        .unwrap_or(update.meta.current_iteration_points),
+                ),
+                progress * 100.0
+            ));
+        frame.render_widget(gauge, inner[1]);
+    }
+
+    fn draw_slot_ribbon(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let mut lines = Vec::new();
+        let focused = self.focused_slot;
+        for slot_index in 0..update.main_results.slot_headers.len() {
+            let title = update.main_results.slot_headers[slot_index].to_plain_string();
+            let value = self
+                .overview_value_text(update, slot_index)
+                .lines
+                .first()
+                .cloned()
+                .unwrap_or_else(|| Line::from("N/A"));
+            let mut spans = vec![Span::styled(
+                if slot_index == focused {
+                    format!("> {title}")
+                } else {
+                    format!("  {title}")
+                },
+                if slot_index == focused {
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Green)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                        .fg(Color::Blue)
+                        .add_modifier(Modifier::BOLD)
+                },
+            )];
+            spans.push(Span::raw("  "));
+            spans.extend(value.spans.iter().cloned());
+            lines.push(Line::from(spans));
+        }
+
+        frame.render_widget(
+            Paragraph::new(Text::from(lines))
+                .block(titled_block("Slots"))
+                .wrap(Wrap { trim: false }),
+            area,
+        );
+    }
+
+    fn draw_overview_tab(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let vertical = if area.width >= 120 {
+            Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(12), Constraint::Min(10)])
+                .split(area)
+        } else {
+            Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(10),
+                    Constraint::Length(10),
+                    Constraint::Min(8),
+                ])
+                .split(area)
+        };
+
+        if area.width >= 120 {
+            let top = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(62), Constraint::Percentage(38)])
+                .split(vertical[0]);
+            self.draw_chart(frame, top[0], update);
+            self.draw_focused_slot_detail(frame, top[1], update);
+
+            let bottom = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(56), Constraint::Percentage(44)])
+                .split(vertical[1]);
+            self.draw_slot_metrics_table(frame, bottom[0], update);
+            self.draw_statistics_panel(frame, bottom[1], update);
+        } else {
+            self.draw_chart(frame, vertical[0], update);
+            self.draw_focused_slot_detail(frame, vertical[1], update);
+            let bottom = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+                .split(vertical[2]);
+            self.draw_slot_metrics_table(frame, bottom[0], update);
+            self.draw_statistics_panel(frame, bottom[1], update);
+        }
+    }
+
+    fn draw_chart(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let Some(component) = update.training_component() else {
+            frame.render_widget(
+                Paragraph::new("Training phase is not a single component.")
+                    .block(titled_block("Convergence")),
+                area,
+            );
+            return;
+        };
+
+        if self.history.is_empty() {
+            frame.render_widget(
+                Paragraph::new("Waiting for history points...").block(titled_block("Convergence")),
+                area,
+            );
+            return;
+        }
+
+        let central_points = self
+            .history
+            .iter()
+            .map(|point| (point.samples as f64, point.central))
+            .collect::<Vec<_>>();
+        let upper_points = self
+            .history
+            .iter()
+            .map(|point| (point.samples as f64, point.central + point.error))
+            .collect::<Vec<_>>();
+        let lower_points = self
+            .history
+            .iter()
+            .map(|point| (point.samples as f64, point.central - point.error))
+            .collect::<Vec<_>>();
+        let completed_points = self
+            .history
+            .iter()
+            .filter(|point| point.completed_iteration)
+            .map(|point| (point.samples as f64, point.central))
+            .collect::<Vec<_>>();
+
+        let x_min = self
+            .history
+            .first()
+            .map(|point| point.samples as f64)
+            .unwrap_or(0.0);
+        let x_max = self
+            .history
+            .last()
+            .map(|point| point.samples as f64)
+            .unwrap_or(1.0);
+        let mut y_min = lower_points
+            .iter()
+            .map(|(_, y)| *y)
+            .fold(f64::INFINITY, f64::min);
+        let mut y_max = upper_points
+            .iter()
+            .map(|(_, y)| *y)
+            .fold(f64::NEG_INFINITY, f64::max);
+        if let Some(target) = update.training_target() {
+            y_min = y_min.min(target.0);
+            y_max = y_max.max(target.0);
+        }
+        if !y_min.is_finite() || !y_max.is_finite() || (y_max - y_min).abs() < 1.0e-14 {
+            y_min -= 1.0;
+            y_max += 1.0;
+        } else {
+            let padding = (y_max - y_min).abs() * 0.08;
+            y_min -= padding;
+            y_max += padding;
+        }
+
+        let mut datasets = vec![
+            Dataset::default()
+                .name("central")
+                .marker(Marker::Braille)
+                .graph_type(ratatui::widgets::GraphType::Line)
+                .style(
+                    Style::default()
+                        .fg(Color::Blue)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .data(&central_points),
+            Dataset::default()
+                .name("upper")
+                .graph_type(ratatui::widgets::GraphType::Line)
+                .style(Style::default().fg(Color::Cyan))
+                .data(&upper_points),
+            Dataset::default()
+                .name("lower")
+                .graph_type(ratatui::widgets::GraphType::Line)
+                .style(Style::default().fg(Color::Cyan))
+                .data(&lower_points),
+            Dataset::default()
+                .name("iter")
+                .marker(Marker::Dot)
+                .graph_type(ratatui::widgets::GraphType::Scatter)
+                .style(Style::default().fg(Color::Green))
+                .data(&completed_points),
+        ];
+
+        let target_points = update
+            .training_target()
+            .map(|target| vec![(x_min, target.0), (x_max.max(x_min + 1.0), target.0)]);
+        if let Some(target_points) = target_points.as_ref() {
+            datasets.push(
+                Dataset::default()
+                    .name("target")
+                    .graph_type(ratatui::widgets::GraphType::Line)
+                    .style(Style::default().fg(Color::Yellow))
+                    .data(target_points),
+            );
+        }
+
+        let title = format!(
+            "Convergence ({})",
+            match component {
+                ComponentKind::Real => "training re",
+                ComponentKind::Imag => "training im",
+            }
+        );
+        let chart = Chart::new(datasets)
+            .block(titled_block(title))
+            .x_axis(
+                Axis::default()
+                    .title("samples")
+                    .bounds([x_min, x_max.max(x_min + 1.0)])
+                    .labels(vec![
+                        Span::raw(abbreviate_count(x_min.max(0.0) as usize)),
+                        Span::raw(abbreviate_count(x_max.max(0.0) as usize)),
+                    ]),
+            )
+            .y_axis(
+                Axis::default()
+                    .title("central value")
+                    .bounds([y_min, y_max])
+                    .labels(vec![
+                        Span::raw(format!("{y_min:.3e}")),
+                        Span::raw(format!("{y_max:.3e}")),
+                    ]),
+            );
+        frame.render_widget(chart, area);
+    }
+
+    fn draw_focused_slot_detail(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let focused_slot = self
+            .focused_slot
+            .min(update.main_results.slot_headers.len().saturating_sub(1));
+        let slot_name = update.main_results.slot_headers[focused_slot].to_plain_string();
+        let rows = update
+            .main_results
+            .row_groups_of_kind(MainResultsRowGroupKind::All)
+            .flat_map(|group| group.rows.iter())
+            .collect::<Vec<_>>();
+
+        let mut lines = vec![Line::from(vec![Span::styled(
+            slot_name,
+            Style::default()
+                .fg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        )])];
+        for row in rows {
+            let component = match row.component.raw {
+                ComponentKind::Real => "re",
+                ComponentKind::Imag => "im",
+            };
+            let Some(cell) = row.slot_cell(focused_slot) else {
+                continue;
+            };
+            let value = cell
+                .value
+                .as_ref()
+                .map(|value| spans_from_styled_text(&value.display))
+                .unwrap_or_else(|| vec![Span::raw("N/A")]);
+            let rel = cell
+                .relative_error
+                .as_ref()
+                .map(|value| value.display.to_plain_string())
+                .unwrap_or_else(|| "N/A".to_string());
+            let chi_sq = cell
+                .chi_sq
+                .as_ref()
+                .map(|value| value.display.to_plain_string())
+                .unwrap_or_else(|| "N/A".to_string());
+            let mwi = cell
+                .max_weight_impact
+                .as_ref()
+                .map(|value| value.display.to_plain_string())
+                .unwrap_or_else(|| "N/A".to_string());
+
+            let mut line_spans = vec![Span::styled(
+                format!("{component}: "),
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            )];
+            line_spans.extend(value);
+            lines.push(Line::from(line_spans));
+            lines.push(Line::from(format!(
+                "   rel err {rel}   chi^2 {chi_sq}   mwi {mwi}"
+            )));
+        }
+
+        if focused_slot == 0 {
+            let deltas = update
+                .main_results
+                .row_groups_of_kind(MainResultsRowGroupKind::All)
+                .flat_map(|group| group.rows.iter())
+                .filter_map(|row| {
+                    row.delta_sigma
+                        .as_ref()
+                        .map(|delta| (row.component.raw, delta.display.to_plain_string()))
+                })
+                .collect::<Vec<_>>();
+            if !deltas.is_empty() {
+                lines.push(Line::from(""));
+                for (component, delta) in deltas {
+                    let label = match component {
+                        ComponentKind::Real => "target re",
+                        ComponentKind::Imag => "target im",
+                    };
+                    lines.push(Line::from(format!("{label}: {delta}")));
+                }
+            }
+        }
+
+        frame.render_widget(
+            Paragraph::new(Text::from(lines))
+                .block(titled_block("Focused slot"))
+                .wrap(Wrap { trim: false }),
+            area,
+        );
+    }
+
+    fn draw_slot_metrics_table(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let mut header = vec![Cell::from("slot"), Cell::from("value")];
+        if self.metric_visibility.relative_error {
+            header.push(Cell::from("rel err"));
+        }
+        if self.metric_visibility.chi_sq {
+            header.push(Cell::from("chi^2"));
+        }
+        if self.metric_visibility.max_weight_impact {
+            header.push(Cell::from("mwi"));
+        }
+
+        let rows = (0..update.main_results.slot_headers.len())
+            .map(|slot_index| {
+                let mut cells = vec![
+                    Cell::from(if slot_index == self.focused_slot {
+                        format!(
+                            "> {}",
+                            update.main_results.slot_headers[slot_index].to_plain_string()
+                        )
+                    } else {
+                        update.main_results.slot_headers[slot_index].to_plain_string()
+                    }),
+                    Cell::from(self.overview_value_text(update, slot_index)),
+                ];
+                if self.metric_visibility.relative_error {
+                    cells.push(Cell::from(self.overview_metric_text(
+                        update,
+                        slot_index,
+                        |cell| cell.relative_error.as_ref().map(|field| &field.display),
+                    )));
+                }
+                if self.metric_visibility.chi_sq {
+                    cells.push(Cell::from(self.overview_metric_text(
+                        update,
+                        slot_index,
+                        |cell| cell.chi_sq.as_ref().map(|field| &field.display),
+                    )));
+                }
+                if self.metric_visibility.max_weight_impact {
+                    cells.push(Cell::from(self.overview_metric_text(
+                        update,
+                        slot_index,
+                        |cell| cell.max_weight_impact.as_ref().map(|field| &field.display),
+                    )));
+                }
+                Row::new(cells)
+            })
+            .collect::<Vec<_>>();
+
+        let widths = match header.len() {
+            2 => vec![Constraint::Length(24), Constraint::Min(20)],
+            3 => vec![
+                Constraint::Length(24),
+                Constraint::Min(20),
+                Constraint::Length(16),
+            ],
+            4 => vec![
+                Constraint::Length(24),
+                Constraint::Min(20),
+                Constraint::Length(16),
+                Constraint::Length(14),
+            ],
+            _ => vec![
+                Constraint::Length(24),
+                Constraint::Min(20),
+                Constraint::Length(16),
+                Constraint::Length(14),
+                Constraint::Length(14),
+            ],
+        };
+        let table = Table::new(rows, widths)
+            .header(
+                Row::new(header).style(
+                    Style::default()
+                        .fg(Color::Blue)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            )
+            .block(titled_block(format!(
+                "All-slot metrics [{} density]",
+                self.density.label()
+            )))
+            .column_spacing(1);
+        frame.render_widget(table, area);
+    }
+
+    fn draw_statistics_panel(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let Some(snapshot) = update.statistics_snapshot() else {
+            frame.render_widget(
+                Paragraph::new("Statistics unavailable.").block(titled_block("Statistics")),
+                area,
+            );
+            return;
+        };
+
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(5),
+                Constraint::Length(3),
+                Constraint::Length(3),
+                Constraint::Min(3),
+            ])
+            .split(area);
+
+        let summary = vec![
+            Line::from(format!("evals: {}", abbreviate_count(snapshot.num_evals))),
+            Line::from(format!(
+                "avg total {}   param {}   integ {}   eval {}",
+                utils::format_evaluation_time_from_f64(snapshot.average_total_time_seconds),
+                utils::format_evaluation_time_from_f64(
+                    snapshot.average_parameterization_time_seconds
+                ),
+                utils::format_evaluation_time_from_f64(snapshot.average_integrand_time_seconds),
+                utils::format_evaluation_time_from_f64(snapshot.average_evaluator_time_seconds),
+            )),
+            Line::from(format!(
+                "obs {}   integrator {}   selection {}",
+                utils::format_evaluation_time_from_f64(snapshot.average_observable_time_seconds),
+                utils::format_evaluation_time_from_f64(snapshot.average_integrator_time_seconds),
+                snapshot
+                    .selection_efficiency_percentage
+                    .map(|value| format!("{value:.2}%"))
+                    .unwrap_or_else(|| "N/A".to_string()),
+            )),
+        ];
+        frame.render_widget(
+            Paragraph::new(Text::from(summary)).block(titled_block("Statistics")),
+            layout[0],
+        );
+
+        frame.render_widget(
+            Paragraph::new(Text::from(vec![stacked_percentage_line(
+                "timings",
+                &timing_percentages(&snapshot),
+                area.width.saturating_sub(4) as usize,
+            )]))
+            .block(titled_block("Timing composition")),
+            layout[1],
+        );
+        frame.render_widget(
+            Paragraph::new(Text::from(vec![stacked_percentage_line(
+                "precision",
+                &precision_percentages(&snapshot),
+                area.width.saturating_sub(4) as usize,
+            )]))
+            .block(titled_block("Precision mix")),
+            layout[2],
+        );
+        frame.render_widget(
+            Paragraph::new(Text::from(vec![stacked_percentage_line(
+                "stability",
+                &stability_percentages(&snapshot),
+                area.width.saturating_sub(4) as usize,
+            )]))
+            .block(titled_block("Stability mix")),
+            layout[3],
+        );
+    }
+
+    fn draw_discrete_tab(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let discrete_rows = self.discrete_rows();
+        if discrete_rows.is_empty() {
+            frame.render_widget(
+                Paragraph::new("No monitored discrete breakdown is available for this run.")
+                    .block(titled_block("Discrete breakdown"))
+                    .wrap(Wrap { trim: false }),
+                area,
+            );
+            return;
+        }
+
+        let horizontal = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+            .split(area);
+
+        let header = Row::new(["contribution", "cmp", "value", "rel err", "samples", "pdf"]).style(
+            Style::default()
+                .fg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        );
+        let rows = discrete_rows
+            .iter()
+            .map(|entry| {
+                let cell = entry.row.slot_cell(0);
+                Row::new(vec![
+                    Cell::from(entry.row.contribution.display.to_plain_string()),
+                    Cell::from(entry.row.component.display.to_plain_string()),
+                    Cell::from(
+                        cell.and_then(|cell| cell.value.as_ref())
+                            .map(|value| value.display.to_plain_string())
+                            .unwrap_or_default(),
+                    ),
+                    Cell::from(
+                        cell.and_then(|cell| cell.relative_error.as_ref())
+                            .map(|value| value.display.to_plain_string())
+                            .unwrap_or_default(),
+                    ),
+                    Cell::from(
+                        cell.and_then(|cell| cell.sample_count.as_ref())
+                            .map(|value| value.display.to_plain_string())
+                            .unwrap_or_default(),
+                    ),
+                    Cell::from(
+                        cell.and_then(|cell| cell.target_pdf.as_ref())
+                            .map(|value| value.display.to_plain_string())
+                            .unwrap_or_default(),
+                    ),
+                ])
+            })
+            .collect::<Vec<_>>();
+
+        let mut state = TableState::default().with_selected(Some(self.selected_discrete_row));
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Length(24),
+                Constraint::Length(6),
+                Constraint::Min(18),
+                Constraint::Length(12),
+                Constraint::Length(10),
+                Constraint::Length(9),
+            ],
+        )
+        .header(header)
+        .row_highlight_style(Style::default().bg(Color::Blue).fg(Color::Black))
+        .block(titled_block(format!(
+            "Discrete bins (sort: {:?} {})",
+            self.discrete_sort,
+            if self.discrete_descending {
+                "desc"
+            } else {
+                "asc"
+            }
+        )));
+        frame.render_stateful_widget(table, horizontal[0], &mut state);
+
+        let selected = discrete_rows
+            .get(self.selected_discrete_row)
+            .copied()
+            .unwrap_or(discrete_rows[0]);
+        self.draw_selected_discrete_detail(frame, horizontal[1], update, selected.row);
+    }
+
+    fn draw_selected_discrete_detail(
+        &self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        update: &StatusUpdate,
+        row: &MainResultsRow,
+    ) {
+        let mut lines = vec![Line::from(vec![
+            Span::styled(
+                "selected: ",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(row.contribution.display.to_plain_string()),
+            Span::raw(" "),
+            Span::raw(row.component.display.to_plain_string()),
+        ])];
+
+        for slot_index in 0..update.main_results.slot_headers.len() {
+            let slot_name = update.main_results.slot_headers[slot_index].to_plain_string();
+            let Some(cell) = row.slot_cell(slot_index) else {
+                continue;
+            };
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![Span::styled(
+                slot_name,
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            )]));
+            if let Some(value) = cell.value.as_ref() {
+                lines.push(Line::from(format!(
+                    "value    {}",
+                    value.display.to_plain_string()
+                )));
+            }
+            if let Some(value) = cell.relative_error.as_ref() {
+                lines.push(Line::from(format!(
+                    "rel err  {}",
+                    value.display.to_plain_string()
+                )));
+            }
+            if let Some(value) = cell.chi_sq.as_ref() {
+                lines.push(Line::from(format!(
+                    "chi^2    {}",
+                    value.display.to_plain_string()
+                )));
+            }
+            if let Some(value) = cell.max_weight_impact.as_ref() {
+                lines.push(Line::from(format!(
+                    "mwi      {}",
+                    value.display.to_plain_string()
+                )));
+            }
+            if let Some(value) = cell.sample_fraction.as_ref() {
+                lines.push(Line::from(format!(
+                    "samples  {}",
+                    value.display.to_plain_string()
+                )));
+            }
+            if let Some(value) = cell.target_pdf.as_ref() {
+                lines.push(Line::from(format!(
+                    "pdf      {}",
+                    value.display.to_plain_string()
+                )));
+            }
+        }
+
+        frame.render_widget(
+            Paragraph::new(Text::from(lines))
+                .block(titled_block("Selected bin detail"))
+                .wrap(Wrap { trim: false }),
+            area,
+        );
+    }
+
+    fn draw_max_weight_tab(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+            .split(area);
+
+        if let Some(section) = update.max_weight_details.as_ref() {
+            let rows = section
+                .rows_by_slot
+                .iter()
+                .flat_map(|group| group.iter())
+                .map(|row| {
+                    Row::new(vec![
+                        Cell::from(row.slot.display.to_plain_string()),
+                        Cell::from(row.component_sign.display.to_plain_string()),
+                        Cell::from(row.max_eval.display.to_plain_string()),
+                        Cell::from(row.coordinates.display.to_plain_string()),
+                    ])
+                })
+                .collect::<Vec<_>>();
+            let table = Table::new(
+                rows,
+                [
+                    Constraint::Length(24),
+                    Constraint::Length(10),
+                    Constraint::Length(20),
+                    Constraint::Min(24),
+                ],
+            )
+            .header(
+                Row::new(["slot", "cmp", "max eval", "coordinates"]).style(
+                    Style::default()
+                        .fg(Color::Blue)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            )
+            .block(titled_block("Overall max weight"));
+            frame.render_widget(table, layout[0]);
+        } else {
+            frame.render_widget(
+                Paragraph::new("No overall max-weight data.")
+                    .block(titled_block("Overall max weight")),
+                layout[0],
+            );
+        }
+
+        if let Some(section) = update.discrete_max_weight_details.as_ref() {
+            let rows = section
+                .row_groups
+                .iter()
+                .flat_map(|group| group.iter())
+                .map(|row| {
+                    let values = row
+                        .slot_values
+                        .iter()
+                        .map(|value| {
+                            value
+                                .as_ref()
+                                .map(|field| field.display.to_plain_string())
+                                .unwrap_or_default()
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" | ");
+                    let coordinates = row
+                        .slot_coordinates
+                        .iter()
+                        .map(|entry| {
+                            format!(
+                                "{}: {}",
+                                entry.slot.display.to_plain_string(),
+                                entry.coordinates.display.to_plain_string()
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    Row::new(vec![
+                        Cell::from(row.contribution.display.to_plain_string()),
+                        Cell::from(row.component_sign.display.to_plain_string()),
+                        Cell::from(values),
+                        Cell::from(coordinates),
+                    ])
+                })
+                .collect::<Vec<_>>();
+            let table = Table::new(
+                rows,
+                [
+                    Constraint::Length(24),
+                    Constraint::Length(10),
+                    Constraint::Min(18),
+                    Constraint::Min(28),
+                ],
+            )
+            .header(
+                Row::new(["contribution", "cmp", "slot values", "coordinates"]).style(
+                    Style::default()
+                        .fg(Color::Blue)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            )
+            .block(titled_block("Per-bin max weight"));
+            frame.render_widget(table, layout[1]);
+        } else {
+            frame.render_widget(
+                Paragraph::new("No per-bin max-weight data.")
+                    .block(titled_block("Per-bin max weight")),
+                layout[1],
+            );
+        }
+    }
+
+    fn draw_footer(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let phase = update
+            .training_component()
+            .map(|component| match component {
+                ComponentKind::Real => "re",
+                ComponentKind::Imag => "im",
+            })
+            .unwrap_or("n/a");
+        let footer = Paragraph::new(Line::from(vec![
+            Span::styled(
+                "Tabs",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" 1/2/3 or <- ->  "),
+            Span::styled(
+                "Slot",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" [ / ]  "),
+            Span::styled(
+                "Bins",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" j/k  "),
+            Span::styled(
+                "Metrics",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" r c w  "),
+            Span::styled(
+                "Sort",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" s/v  "),
+            Span::styled(
+                "Density",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" m  "),
+            Span::styled(
+                "Help",
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" ?  "),
+            Span::styled(
+                "Abort",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(" x / Ctrl-C   training {phase}")),
+        ]))
+        .alignment(Alignment::Left)
+        .block(Block::default().borders(Borders::TOP));
+        frame.render_widget(footer, area);
+    }
+
+    fn draw_help_overlay(&self, frame: &mut Frame<'_>, area: Rect) {
+        let popup = centered_rect(72, 65, area);
+        frame.render_widget(Clear, popup);
+        frame.render_widget(
+            Paragraph::new(Text::from(vec![
+                Line::from("1/2/3 or Left/Right  switch tabs"),
+                Line::from("[ and ]             change focused slot"),
+                Line::from("j / k               move selected discrete row"),
+                Line::from("s                   cycle discrete sort"),
+                Line::from("v                   reverse discrete sort order"),
+                Line::from("r / c / w           toggle rel err, chi^2, mwi columns"),
+                Line::from("m                   cycle density mode"),
+                Line::from("x                   abort the current iteration"),
+                Line::from("Ctrl-C              stop the integration"),
+                Line::from("?                   close help"),
+            ]))
+            .block(titled_block("Dashboard controls"))
+            .alignment(Alignment::Left)
+            .wrap(Wrap { trim: false }),
+            popup,
+        );
+    }
+
+    fn discrete_rows(&self) -> Vec<DiscreteRowRef<'_>> {
+        let Some(update) = self.latest_update.as_ref() else {
+            return Vec::new();
+        };
+
+        let mut rows = update
+            .main_results
+            .row_groups_of_kind(MainResultsRowGroupKind::Bins)
+            .flat_map(|group| group.rows.iter())
+            .map(|row| DiscreteRowRef { row })
+            .collect::<Vec<_>>();
+
+        rows.sort_by(|lhs, rhs| {
+            let lhs_key = lhs.sort_value(self.discrete_sort);
+            let rhs_key = rhs.sort_value(self.discrete_sort);
+            let ordering = match self.discrete_sort {
+                ContributionSortMode::Index => match (lhs.contribution(), rhs.contribution()) {
+                    (ContributionKind::Bin(lhs_index), ContributionKind::Bin(rhs_index)) => {
+                        lhs_index
+                            .cmp(&rhs_index)
+                            .then(lhs.component().cmp(&rhs.component()))
+                    }
+                    _ => Ordering::Equal,
+                },
+                ContributionSortMode::Integral | ContributionSortMode::Error => rhs_key
+                    .partial_cmp(&lhs_key)
+                    .unwrap_or(Ordering::Equal)
+                    .then(lhs.component().cmp(&rhs.component())),
+            };
+            if self.discrete_descending {
+                ordering
+            } else {
+                ordering.reverse()
+            }
+        });
+        rows
+    }
+
+    fn overview_value_text(&self, update: &StatusUpdate, slot_index: usize) -> Text<'static> {
+        overview_metric_text(update, slot_index, |cell| {
+            cell.value.as_ref().map(|value| &value.display)
+        })
+    }
+
+    fn overview_metric_text(
+        &self,
+        update: &StatusUpdate,
+        slot_index: usize,
+        select: impl Fn(&MainTableSlotCells) -> Option<&StyledText>,
+    ) -> Text<'static> {
+        overview_metric_text(update, slot_index, select)
+    }
+}
+
+fn overview_metric_text(
+    update: &StatusUpdate,
+    slot_index: usize,
+    select: impl Fn(&MainTableSlotCells) -> Option<&StyledText>,
+) -> Text<'static> {
+    let select = &select;
+    let lines = update
+        .main_results
+        .row_groups_of_kind(MainResultsRowGroupKind::All)
+        .flat_map(|group| group.rows.iter())
+        .filter_map(|row| {
+            let component = match row.component.raw {
+                ComponentKind::Real => "re",
+                ComponentKind::Imag => "im",
+            };
+            let text = row.slot_cell(slot_index).and_then(select)?;
+            let mut spans = vec![Span::styled(
+                format!("{component}: "),
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            )];
+            spans.extend(spans_from_styled_text(text));
+            Some(Line::from(spans))
+        })
+        .collect::<Vec<_>>();
+
+    if lines.is_empty() {
+        Text::from("N/A")
+    } else {
+        Text::from(lines)
+    }
+}
+
+fn style_from_text_style(style: TextStyle) -> Style {
+    let mut rendered = Style::default();
+    rendered = match style.color {
+        Some(TextColor::Green) => rendered.fg(Color::Green),
+        Some(TextColor::Blue) => rendered.fg(Color::Blue),
+        Some(TextColor::Red) => rendered.fg(Color::Red),
+        None => rendered,
+    };
+    if style.bold {
+        rendered = rendered.add_modifier(Modifier::BOLD);
+    }
+    if style.dimmed {
+        rendered = rendered.add_modifier(Modifier::DIM);
+    }
+    rendered
+}
+
+fn spans_from_styled_text(text: &StyledText) -> Vec<Span<'static>> {
+    text.spans
+        .iter()
+        .map(|span| Span::styled(span.text.clone(), style_from_text_style(span.style)))
+        .collect()
+}
+
+fn titled_block(title: impl Into<String>) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .title(title.into())
+        .border_style(Style::default().fg(Color::Blue))
+}
+
+fn abbreviate_count(value: usize) -> String {
+    super::display::format_abbreviated_count(value)
+}
+
+fn format_rate(value: Option<f64>) -> String {
+    let Some(value) = value else {
+        return "N/A".to_string();
+    };
+    if !value.is_finite() || value <= 0.0 {
+        return "N/A".to_string();
+    }
+    format!("{}/s", abbreviate_count(value.round() as usize))
+}
+
+fn stacked_percentage_line(
+    label: &str,
+    segments: &[(String, f64, Color)],
+    width: usize,
+) -> Line<'static> {
+    let prefix = format!("{label:<10}");
+    let bar_width = width.saturating_sub(prefix.len() + 12).max(8);
+    let mut spans = vec![Span::styled(
+        prefix,
+        Style::default()
+            .fg(Color::Blue)
+            .add_modifier(Modifier::BOLD),
+    )];
+    let mut used = 0usize;
+    for (index, (_, percentage, color)) in segments.iter().enumerate() {
+        let width = if index + 1 == segments.len() {
+            bar_width.saturating_sub(used)
+        } else {
+            let segment = ((*percentage / 100.0) * bar_width as f64).round() as usize;
+            used += segment;
+            segment
+        };
+        spans.push(Span::styled("█".repeat(width), Style::default().fg(*color)));
+    }
+    spans.push(Span::raw(" "));
+    spans.push(Span::raw(
+        segments
+            .iter()
+            .map(|(name, percentage, _)| format!("{name}:{percentage:.1}%"))
+            .collect::<Vec<_>>()
+            .join(" "),
+    ));
+    Line::from(spans)
+}
+
+fn timing_percentages(snapshot: &IntegrationStatisticsSnapshot) -> Vec<(String, f64, Color)> {
+    let total = snapshot.average_total_time_seconds.max(f64::EPSILON);
+    vec![
+        (
+            "param".to_string(),
+            snapshot.average_parameterization_time_seconds / total * 100.0,
+            Color::Cyan,
+        ),
+        (
+            "integrand".to_string(),
+            snapshot.average_integrand_time_seconds / total * 100.0,
+            Color::Green,
+        ),
+        (
+            "evaluator".to_string(),
+            snapshot.average_evaluator_time_seconds / total * 100.0,
+            Color::Blue,
+        ),
+        (
+            "obs".to_string(),
+            snapshot.average_observable_time_seconds / total * 100.0,
+            Color::Magenta,
+        ),
+        (
+            "overhead".to_string(),
+            snapshot.average_integrator_time_seconds / total * 100.0,
+            Color::Yellow,
+        ),
+    ]
+}
+
+fn precision_percentages(snapshot: &IntegrationStatisticsSnapshot) -> Vec<(String, f64, Color)> {
+    vec![
+        ("f64".to_string(), snapshot.f64_percentage, Color::Green),
+        ("f128".to_string(), snapshot.f128_percentage, Color::Blue),
+        ("arb".to_string(), snapshot.arb_percentage, Color::Yellow),
+    ]
+}
+
+fn stability_percentages(snapshot: &IntegrationStatisticsSnapshot) -> Vec<(String, f64, Color)> {
+    let unstable = (snapshot.nan_or_unstable_percentage - snapshot.nan_percentage).max(0.0);
+    let stable = (100.0 - snapshot.nan_or_unstable_percentage).max(0.0);
+    vec![
+        ("stable".to_string(), stable, Color::Green),
+        ("unstable".to_string(), unstable, Color::Yellow),
+        ("nan".to_string(), snapshot.nan_percentage, Color::Red),
+    ]
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}

--- a/crates/gammalooprs/src/integrate/render_ratatui.rs
+++ b/crates/gammalooprs/src/integrate/render_ratatui.rs
@@ -71,19 +71,14 @@ enum DensityMode {
     Full,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 enum ChartHistoryWindow {
+    #[default]
     Full,
     RecentIterations(usize),
 }
 
 const MAX_HISTORY_POINTS: usize = 4096;
-
-impl Default for ChartHistoryWindow {
-    fn default() -> Self {
-        Self::Full
-    }
-}
 
 impl ChartHistoryWindow {
     fn description(self) -> String {

--- a/crates/gammalooprs/src/integrate/render_ratatui.rs
+++ b/crates/gammalooprs/src/integrate/render_ratatui.rs
@@ -12,14 +12,14 @@ use ratatui::{
     },
 };
 
-use crate::{settings::runtime::IntegrationStatisticsSnapshot, utils};
+use crate::utils;
 
 use super::{
     StatusUpdate,
     display::{StyledText, TextColor, TextStyle},
     status_update::{
         ComponentKind, ContributionKind, ContributionSortMode, MainResultsRow,
-        MainResultsRowGroupKind, MainTableSlotCells,
+        MainResultsRowGroupKind, MainTableSlotCells, StatisticsMixSegment,
     },
 };
 
@@ -71,6 +71,50 @@ enum DensityMode {
     Full,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ChartHistoryWindow {
+    Full,
+    RecentIterations(usize),
+}
+
+const MAX_HISTORY_POINTS: usize = 4096;
+
+impl Default for ChartHistoryWindow {
+    fn default() -> Self {
+        Self::Full
+    }
+}
+
+impl ChartHistoryWindow {
+    fn description(self) -> String {
+        match self {
+            Self::Full => "full".to_string(),
+            Self::RecentIterations(count) => format!("last {count} iters"),
+        }
+    }
+
+    fn toggle(self) -> Self {
+        match self {
+            Self::Full => Self::RecentIterations(6),
+            Self::RecentIterations(_) => Self::Full,
+        }
+    }
+
+    fn widen(self) -> Self {
+        match self {
+            Self::Full => Self::RecentIterations(6),
+            Self::RecentIterations(count) => Self::RecentIterations((count + 1).min(128)),
+        }
+    }
+
+    fn narrow(self) -> Self {
+        match self {
+            Self::Full => Self::RecentIterations(6),
+            Self::RecentIterations(count) => Self::RecentIterations(count.saturating_sub(1).max(1)),
+        }
+    }
+}
+
 impl DensityMode {
     fn next(self) -> Self {
         match self {
@@ -106,12 +150,22 @@ impl Default for SlotMetricVisibility {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct HistoryPoint {
+    iteration: usize,
     samples: usize,
-    central: f64,
-    error: f64,
+    real_slot_values: Vec<Option<(f64, f64)>>,
+    imag_slot_values: Vec<Option<(f64, f64)>>,
     completed_iteration: bool,
+}
+
+impl HistoryPoint {
+    fn slot_values(&self, component: ComponentKind) -> &[Option<(f64, f64)>] {
+        match component {
+            ComponentKind::Real => &self.real_slot_values,
+            ComponentKind::Imag => &self.imag_slot_values,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -128,8 +182,8 @@ impl<'a> DiscreteRowRef<'a> {
         self.row.contribution.raw
     }
 
-    fn sort_value(self, mode: ContributionSortMode) -> f64 {
-        let Some(cell) = self.row.slot_cell(0) else {
+    fn sort_value(self, mode: ContributionSortMode, slot_index: usize) -> f64 {
+        let Some(cell) = self.row.slot_cell(slot_index) else {
             return 0.0;
         };
         match mode {
@@ -163,6 +217,9 @@ pub struct RatatuiDashboardState {
     discrete_descending: bool,
     show_help: bool,
     history: Vec<HistoryPoint>,
+    chart_history_window: ChartHistoryWindow,
+    chart_y_sigma_span: usize,
+    chart_component: Option<ComponentKind>,
 }
 
 impl Default for RatatuiDashboardState {
@@ -178,6 +235,9 @@ impl Default for RatatuiDashboardState {
             discrete_descending: true,
             show_help: false,
             history: Vec::new(),
+            chart_history_window: ChartHistoryWindow::default(),
+            chart_y_sigma_span: 4,
+            chart_component: None,
         }
     }
 }
@@ -238,6 +298,7 @@ impl RatatuiDashboardState {
         if slot_count > 0 {
             self.focused_slot = (self.focused_slot + 1) % slot_count;
         }
+        self.clamp_state();
     }
 
     pub fn focus_previous_slot(&mut self) {
@@ -249,6 +310,7 @@ impl RatatuiDashboardState {
         if slot_count > 0 {
             self.focused_slot = (self.focused_slot + slot_count - 1) % slot_count;
         }
+        self.clamp_state();
     }
 
     pub fn select_next_discrete_row(&mut self) {
@@ -276,6 +338,51 @@ impl RatatuiDashboardState {
 
     pub fn toggle_discrete_sort_direction(&mut self) {
         self.discrete_descending = !self.discrete_descending;
+    }
+
+    pub fn toggle_chart_history_window(&mut self) {
+        self.chart_history_window = self.chart_history_window.toggle();
+    }
+
+    pub fn widen_chart_history_window(&mut self) {
+        self.chart_history_window = self.chart_history_window.widen();
+    }
+
+    pub fn narrow_chart_history_window(&mut self) {
+        self.chart_history_window = self.chart_history_window.narrow();
+    }
+
+    pub fn widen_chart_y_sigma_span(&mut self) {
+        self.chart_y_sigma_span = (self.chart_y_sigma_span + 1).min(128);
+    }
+
+    pub fn narrow_chart_y_sigma_span(&mut self) {
+        self.chart_y_sigma_span = self.chart_y_sigma_span.saturating_sub(1).max(1);
+    }
+
+    pub fn reset_chart_y_sigma_span(&mut self) {
+        self.chart_y_sigma_span = 4;
+    }
+
+    pub fn toggle_chart_component(&mut self) {
+        let Some(update) = self.latest_update.as_ref() else {
+            return;
+        };
+        let available = self.available_chart_components(update);
+        if available.len() < 2 {
+            return;
+        }
+
+        let current = self.chart_component(update);
+        self.chart_component = match current {
+            Some(ComponentKind::Real) if available.contains(&ComponentKind::Imag) => {
+                Some(ComponentKind::Imag)
+            }
+            Some(ComponentKind::Imag) if available.contains(&ComponentKind::Real) => {
+                Some(ComponentKind::Real)
+            }
+            _ => available.first().copied(),
+        };
     }
 
     pub fn draw(&self, frame: &mut Frame<'_>) {
@@ -306,6 +413,21 @@ impl RatatuiDashboardState {
             self.focused_slot = 0;
         }
 
+        if let Some(update) = self.latest_update.as_ref() {
+            let available = self.available_chart_components(update);
+            if available.is_empty() {
+                self.chart_component = None;
+            } else if !self
+                .chart_component
+                .is_some_and(|component| available.contains(&component))
+            {
+                self.chart_component = update
+                    .training_component()
+                    .filter(|component| available.contains(component))
+                    .or_else(|| available.first().copied());
+            }
+        }
+
         let row_count = self.discrete_rows().len();
         if row_count == 0 {
             self.selected_discrete_row = 0;
@@ -315,26 +437,19 @@ impl RatatuiDashboardState {
     }
 
     fn push_history_point(&mut self, update: &StatusUpdate) {
-        let Some(component) = update.training_component() else {
+        let real_slot_values = self.collect_history_slot_values(update, ComponentKind::Real);
+        let imag_slot_values = self.collect_history_slot_values(update, ComponentKind::Imag);
+        if real_slot_values.iter().all(Option::is_none)
+            && imag_slot_values.iter().all(Option::is_none)
+        {
             return;
-        };
-        let Some(row) = update
-            .main_results
-            .find_row(ContributionKind::All, component)
-        else {
-            return;
-        };
-        let Some(value) = row
-            .slot_cell(update.meta.training_slot)
-            .and_then(|cell| cell.value.as_ref())
-        else {
-            return;
-        };
+        }
 
         let point = HistoryPoint {
+            iteration: update.meta.iteration,
             samples: update.meta.total_points,
-            central: value.raw.0.0,
-            error: value.raw.1.0.abs(),
+            real_slot_values,
+            imag_slot_values,
             completed_iteration: !matches!(update.kind(), super::IntegrationStatusKind::Live),
         };
 
@@ -343,7 +458,14 @@ impl RatatuiDashboardState {
             .last()
             .is_some_and(|previous| previous.samples == point.samples)
         {
-            let _ = self.history.pop();
+            let preserve_completed_point = self.history.last().is_some_and(|previous| {
+                previous.completed_iteration
+                    && !point.completed_iteration
+                    && update.is_initial_live_status()
+            });
+            if !preserve_completed_point {
+                let _ = self.history.pop();
+            }
         }
         if self
             .history
@@ -353,10 +475,125 @@ impl RatatuiDashboardState {
             self.history.clear();
         }
         self.history.push(point);
-        if self.history.len() > 4096 {
-            let drain = self.history.len() - 4096;
-            self.history.drain(0..drain);
+        while self.history.len() > MAX_HISTORY_POINTS {
+            self.compact_history_preserving_span();
         }
+    }
+
+    fn compact_history_preserving_span(&mut self) {
+        if self.history.len() <= MAX_HISTORY_POINTS {
+            return;
+        }
+
+        let retain_recent = MAX_HISTORY_POINTS / 2;
+        let split_index = self.history.len().saturating_sub(retain_recent);
+        if split_index == 0 {
+            return;
+        }
+
+        let older = &self.history[..split_index];
+        let recent = &self.history[split_index..];
+        let max_older_points = MAX_HISTORY_POINTS.saturating_sub(recent.len()).max(2);
+        let step = older.len().div_ceil(max_older_points);
+
+        let mut compacted = Vec::with_capacity(MAX_HISTORY_POINTS);
+        for (index, point) in older.iter().enumerate() {
+            if index == 0 || index + 1 == older.len() || index % step == 0 {
+                compacted.push(point.clone());
+            }
+        }
+        compacted.extend(recent.iter().cloned());
+
+        if compacted.len() > MAX_HISTORY_POINTS {
+            let keep_from_older = compacted.len().saturating_sub(recent.len());
+            let extra = compacted.len() - MAX_HISTORY_POINTS;
+            if keep_from_older > extra + 1 {
+                compacted.drain(1..=extra);
+            } else {
+                compacted.truncate(MAX_HISTORY_POINTS);
+            }
+        }
+
+        self.history = compacted;
+    }
+
+    fn collect_history_slot_values(
+        &self,
+        update: &StatusUpdate,
+        component: ComponentKind,
+    ) -> Vec<Option<(f64, f64)>> {
+        let Some(row) = update
+            .main_results
+            .find_row(ContributionKind::All, component)
+        else {
+            return vec![None; update.main_results.slot_headers.len()];
+        };
+        (0..update.main_results.slot_headers.len())
+            .map(|slot_index| {
+                row.slot_cell(slot_index)
+                    .and_then(|cell| cell.value.as_ref())
+                    .map(|value| (value.raw.0.0, value.raw.1.0.abs()))
+            })
+            .collect()
+    }
+
+    fn visible_history(&self) -> Vec<&HistoryPoint> {
+        match self.chart_history_window {
+            ChartHistoryWindow::Full => self.history.iter().collect(),
+            ChartHistoryWindow::RecentIterations(iterations) => {
+                if iterations == 0 || self.history.is_empty() {
+                    return self.history.iter().collect();
+                }
+                let latest_iteration = self
+                    .history
+                    .last()
+                    .map(|point| point.iteration)
+                    .unwrap_or_default();
+                let start_iteration = latest_iteration
+                    .saturating_add(1)
+                    .saturating_sub(iterations);
+                self.history
+                    .iter()
+                    .filter(|point| point.iteration >= start_iteration)
+                    .collect()
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn visible_history_sample_bounds(&self) -> Option<(usize, usize)> {
+        let visible = self.visible_history();
+        Some((visible.first()?.samples, visible.last()?.samples))
+    }
+
+    fn available_chart_components(&self, update: &StatusUpdate) -> Vec<ComponentKind> {
+        [ComponentKind::Real, ComponentKind::Imag]
+            .into_iter()
+            .filter(|component| {
+                update
+                    .main_results
+                    .find_row(ContributionKind::All, *component)
+                    .and_then(|row| row.slot_cell(self.focused_slot))
+                    .and_then(|cell| cell.value.as_ref())
+                    .is_some()
+            })
+            .collect()
+    }
+
+    fn chart_component(&self, update: &StatusUpdate) -> Option<ComponentKind> {
+        let available = self.available_chart_components(update);
+        if available.is_empty() {
+            return None;
+        }
+
+        self.chart_component
+            .filter(|component| available.contains(component))
+            .or_else(|| {
+                update
+                    .training_component_for_slot(self.focused_slot)
+                    .filter(|component| available.contains(component))
+            })
+            .or_else(|| available.first().copied())
     }
 
     fn draw_dashboard(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
@@ -364,12 +601,8 @@ impl RatatuiDashboardState {
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Length(3),
-                Constraint::Length(4),
-                Constraint::Length(if update.main_results.slot_headers.len() > 3 {
-                    4
-                } else {
-                    3
-                }),
+                Constraint::Length(6),
+                Constraint::Length(update.main_results.slot_headers.len().max(1) as u16 + 2),
                 Constraint::Min(12),
                 Constraint::Length(2),
             ])
@@ -402,73 +635,99 @@ impl RatatuiDashboardState {
         let tabs = Tabs::new(titles)
             .block(titled_block("GammaLoop status"))
             .select(self.active_tab.index())
-            .highlight_style(
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            );
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD));
         frame.render_widget(tabs, area);
     }
 
     fn draw_progress(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let block = titled_block("Iteration progress");
         let inner = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(1), Constraint::Length(2)])
-            .split(area);
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+            ])
+            .split(block.inner(area));
+        frame.render_widget(block, area);
 
-        let eta = update
-            .meta
-            .iteration_eta()
-            .map(|duration| utils::format_wdhms(duration.as_secs() as usize))
-            .unwrap_or_else(|| "warming up".to_string());
-        let throughput = format_rate(update.meta.live_progress.map(|progress| {
-            if update.meta.iteration_elapsed_time.is_zero() {
-                0.0
-            } else {
-                progress.completed_points as f64 / update.meta.iteration_elapsed_time.as_secs_f64()
-            }
-        }));
-        let per_sample_core = if update.meta.n_samples_evaluated == 0 {
-            "N/A".to_string()
+        frame.render_widget(Paragraph::new(""), inner[0]);
+
+        let mut left = StyledText::new();
+        left.push_text(" ", TextStyle::PLAIN);
+        left.push_text(
+            format!(
+                "[ {:^7} ]",
+                utils::format_wdhms(update.meta.elapsed_time.as_secs() as usize)
+            ),
+            TextStyle::PLAIN.bold(),
+        );
+        left.push_text(" | ", TextStyle::PLAIN);
+        left.push_text("# samples total ", TextStyle::green().bold());
+        left.push_text(
+            super::display::format_total_points(update.meta.total_points),
+            TextStyle::PLAIN.bold(),
+        );
+        left.push_text(" | ", TextStyle::PLAIN);
+        left.push_text("Iteration ", TextStyle::green().bold());
+        left.push_text(
+            format!("#{}", update.meta.iteration),
+            TextStyle::PLAIN.bold(),
+        );
+        left.push_text(
+            format!(
+                " ({})",
+                if matches!(update.kind(), super::IntegrationStatusKind::Live) {
+                    "running"
+                } else {
+                    "completed"
+                }
+            ),
+            TextStyle::green().bold(),
+        );
+        if matches!(update.kind(), super::IntegrationStatusKind::Live) {
+            left.push_text(" | ", TextStyle::PLAIN);
+            left.push_text("ETA ", TextStyle::green().bold());
+            left.push_text(
+                update
+                    .meta
+                    .iteration_eta()
+                    .map(|duration| utils::format_wdhms(duration.as_secs() as usize))
+                    .unwrap_or_else(|| "warming up".to_string()),
+                TextStyle::PLAIN,
+            );
+        }
+
+        let mut right = StyledText::new();
+        right.push_text(
+            update
+                .meta
+                .total_sample_rate_per_second()
+                .map(format_samples_per_second)
+                .unwrap_or_else(|| "N/A".to_string()),
+            TextStyle::PLAIN.bold(),
+        );
+        right.push_text(" ", TextStyle::PLAIN);
+        right.push_text("#samples/s", TextStyle::green().bold());
+        right.push_text(" | ", TextStyle::PLAIN);
+        if let Some(sample_core_time) = update.meta.sample_core_time() {
+            right.push_text(sample_core_time, TextStyle::PLAIN.bold());
         } else {
-            utils::format_evaluation_time_from_f64(
-                update.meta.elapsed_time.as_secs_f64() / update.meta.n_samples_evaluated as f64
-                    * update.meta.cores as f64,
-            )
-        };
-        let header = Line::from(vec![
-            Span::styled(
-                format!(" Iteration #{} ", update.meta.iteration),
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::raw("  "),
-            Span::styled(
-                format!(
-                    "elapsed {}",
-                    utils::format_wdhms(update.meta.elapsed_time.as_secs() as usize)
-                ),
-                Style::default().fg(Color::Blue),
-            ),
-            Span::raw("  "),
-            Span::styled(
-                format!("iter ETA {eta}"),
-                Style::default().fg(Color::Yellow),
-            ),
-            Span::raw("  "),
-            Span::styled(
-                format!("rate {throughput}"),
-                Style::default().fg(Color::Blue),
-            ),
-            Span::raw("  "),
-            Span::styled(
-                format!("{} /sample/core", per_sample_core),
-                Style::default().fg(Color::Blue),
-            ),
-        ]);
-        frame.render_widget(Paragraph::new(header), inner[0]);
+            right.push_text("N/A", TextStyle::red());
+        }
+        right.push_text(" /sample/core", TextStyle::green().bold());
+        right.push_text(" ", TextStyle::PLAIN);
+
+        let header = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(68), Constraint::Percentage(32)])
+            .split(inner[1]);
+        frame.render_widget(Paragraph::new(text_from_styled_text(&left)), header[0]);
+        frame.render_widget(
+            Paragraph::new(text_from_styled_text(&right)).alignment(Alignment::Right),
+            header[1],
+        );
 
         let progress = update.meta.iteration_progress_ratio().unwrap_or_else(|| {
             if matches!(update.kind(), super::IntegrationStatusKind::Live) {
@@ -478,72 +737,164 @@ impl RatatuiDashboardState {
             }
         });
         let gauge = Gauge::default()
-            .block(titled_block("Iteration progress"))
             .gauge_style(
                 Style::default()
                     .fg(Color::Green)
-                    .bg(Color::Black)
+                    .bg(Color::Rgb(70, 70, 70))
                     .add_modifier(Modifier::BOLD),
             )
             .ratio(progress.clamp(0.0, 1.0))
-            .label(format!(
-                "{} / {} ({:.1}%)",
-                abbreviate_count(
-                    update
-                        .meta
-                        .live_progress
-                        .map(|progress| progress.completed_points)
-                        .unwrap_or(update.meta.current_iteration_points),
+            .label(Span::styled(
+                format!(
+                    "{} / {} ({:.1}%)",
+                    abbreviate_count(
+                        update
+                            .meta
+                            .live_progress
+                            .map(|progress| progress.completed_points)
+                            .unwrap_or(update.meta.current_iteration_points),
+                    ),
+                    abbreviate_count(
+                        update
+                            .meta
+                            .live_progress
+                            .map(|progress| progress.target_points)
+                            .unwrap_or(update.meta.current_iteration_points),
+                    ),
+                    progress * 100.0
                 ),
-                abbreviate_count(
-                    update
-                        .meta
-                        .live_progress
-                        .map(|progress| progress.target_points)
-                        .unwrap_or(update.meta.current_iteration_points),
-                ),
-                progress * 100.0
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
             ));
-        frame.render_widget(gauge, inner[1]);
+        frame.render_widget(gauge, inner[2]);
+        frame.render_widget(Paragraph::new(""), inner[3]);
     }
 
     fn draw_slot_ribbon(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
-        let mut lines = Vec::new();
-        let focused = self.focused_slot;
-        for slot_index in 0..update.main_results.slot_headers.len() {
-            let title = update.main_results.slot_headers[slot_index].to_plain_string();
-            let value = self
-                .overview_value_text(update, slot_index)
-                .lines
-                .first()
-                .cloned()
-                .unwrap_or_else(|| Line::from("N/A"));
-            let mut spans = vec![Span::styled(
-                if slot_index == focused {
-                    format!("> {title}")
-                } else {
-                    format!("  {title}")
-                },
-                if slot_index == focused {
-                    Style::default()
-                        .fg(Color::Black)
-                        .bg(Color::Green)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default()
-                        .fg(Color::Blue)
-                        .add_modifier(Modifier::BOLD)
-                },
-            )];
-            spans.push(Span::raw("  "));
-            spans.extend(value.spans.iter().cloned());
-            lines.push(Line::from(spans));
+        let slot_name_width = update
+            .main_results
+            .slot_headers
+            .iter()
+            .map(|header| header.to_plain_string().chars().count())
+            .max()
+            .unwrap_or(10)
+            .max(10) as u16;
+        let value_width = (0..update.main_results.slot_headers.len())
+            .flat_map(|slot_index| {
+                [ComponentKind::Real, ComponentKind::Imag]
+                    .into_iter()
+                    .filter_map(move |component| {
+                        update
+                            .main_results
+                            .find_row(ContributionKind::All, component)
+                            .and_then(|row| row.slot_cell(slot_index))
+                            .and_then(|cell| cell.value.as_ref())
+                            .map(|value| value.display.to_plain_string().chars().count())
+                    })
+            })
+            .max()
+            .unwrap_or(16)
+            .max(16) as u16;
+        let has_targets = (0..update.main_results.slot_headers.len()).any(|slot_index| {
+            update
+                .target_display_for_slot_component(slot_index, ComponentKind::Real)
+                .is_some()
+                || update
+                    .target_display_for_slot_component(slot_index, ComponentKind::Imag)
+                    .is_some()
+        });
+        let target_value_width = (0..update.main_results.slot_headers.len())
+            .flat_map(|slot_index| {
+                [ComponentKind::Real, ComponentKind::Imag]
+                    .into_iter()
+                    .filter_map(move |component| {
+                        update
+                            .target_display_for_slot_component(slot_index, component)
+                            .map(|value| value.to_plain_string().chars().count())
+                    })
+            })
+            .max()
+            .unwrap_or(16)
+            .max(16) as u16;
+        let rows = (0..update.main_results.slot_headers.len())
+            .map(|slot_index| {
+                let re_value = update
+                    .main_results
+                    .find_row(ContributionKind::All, ComponentKind::Real)
+                    .and_then(|row| row.slot_cell(slot_index))
+                    .and_then(|cell| cell.value.as_ref())
+                    .map(|value| &value.display);
+                let im_value = update
+                    .main_results
+                    .find_row(ContributionKind::All, ComponentKind::Imag)
+                    .and_then(|row| row.slot_cell(slot_index))
+                    .and_then(|cell| cell.value.as_ref())
+                    .map(|value| &value.display);
+                let target_re =
+                    update.target_display_for_slot_component(slot_index, ComponentKind::Real);
+                let target_im =
+                    update.target_display_for_slot_component(slot_index, ComponentKind::Imag);
+                let mut cells = vec![
+                    Cell::from(Span::styled(
+                        if slot_index == self.focused_slot {
+                            ">"
+                        } else {
+                            " "
+                        },
+                        if slot_index == self.focused_slot {
+                            Style::default()
+                                .fg(Color::White)
+                                .add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default()
+                        },
+                    )),
+                    cell_from_styled_text(&update.main_results.slot_headers[slot_index]),
+                    cell_from_styled_text(&component_label_with_colon(ComponentKind::Real)),
+                    cell_from_optional_styled_text(re_value),
+                    cell_from_styled_text(&component_label_with_colon(ComponentKind::Imag)),
+                    cell_from_optional_styled_text(im_value),
+                ];
+                if has_targets {
+                    cells.push(cell_from_styled_text(&StyledText::plain("|")));
+                    cells.push(plain_header_cell("trgt"));
+                    cells.push(cell_from_styled_text(&component_label_with_colon(
+                        ComponentKind::Real,
+                    )));
+                    cells.push(cell_from_optional_styled_text(target_re.as_ref()));
+                    cells.push(cell_from_styled_text(&component_label_with_colon(
+                        ComponentKind::Imag,
+                    )));
+                    cells.push(cell_from_optional_styled_text(target_im.as_ref()));
+                }
+                Row::new(cells)
+            })
+            .collect::<Vec<_>>();
+
+        let mut widths = vec![
+            Constraint::Length(1),
+            Constraint::Length(slot_name_width),
+            Constraint::Length(3),
+            Constraint::Length(value_width),
+            Constraint::Length(3),
+            Constraint::Length(value_width),
+        ];
+        if has_targets {
+            widths.extend([
+                Constraint::Length(1),
+                Constraint::Length(5),
+                Constraint::Length(3),
+                Constraint::Length(target_value_width),
+                Constraint::Length(3),
+                Constraint::Min(target_value_width),
+            ]);
         }
 
         frame.render_widget(
-            Paragraph::new(Text::from(lines))
-                .block(titled_block("Slots"))
-                .wrap(Wrap { trim: false }),
+            Table::new(rows, widths)
+                .block(titled_block("Integrands"))
+                .column_spacing(1),
             area,
         );
     }
@@ -552,15 +903,15 @@ impl RatatuiDashboardState {
         let vertical = if area.width >= 120 {
             Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([Constraint::Length(12), Constraint::Min(10)])
+                .constraints([Constraint::Percentage(66), Constraint::Percentage(34)])
                 .split(area)
         } else {
             Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Length(10),
-                    Constraint::Length(10),
-                    Constraint::Min(8),
+                    Constraint::Percentage(48),
+                    Constraint::Length(11),
+                    Constraint::Min(10),
                 ])
                 .split(area)
         };
@@ -577,7 +928,7 @@ impl RatatuiDashboardState {
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(56), Constraint::Percentage(44)])
                 .split(vertical[1]);
-            self.draw_slot_metrics_table(frame, bottom[0], update);
+            self.draw_results_summary_table(frame, bottom[0], update);
             self.draw_statistics_panel(frame, bottom[1], update);
         } else {
             self.draw_chart(frame, vertical[0], update);
@@ -586,13 +937,13 @@ impl RatatuiDashboardState {
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
                 .split(vertical[2]);
-            self.draw_slot_metrics_table(frame, bottom[0], update);
+            self.draw_results_summary_table(frame, bottom[0], update);
             self.draw_statistics_panel(frame, bottom[1], update);
         }
     }
 
     fn draw_chart(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
-        let Some(component) = update.training_component() else {
+        let Some(component) = self.chart_component(update) else {
             frame.render_widget(
                 Paragraph::new("Training phase is not a single component.")
                     .block(titled_block("Convergence")),
@@ -601,7 +952,11 @@ impl RatatuiDashboardState {
             return;
         };
 
-        if self.history.is_empty() {
+        let focused_slot = self
+            .focused_slot
+            .min(update.main_results.slot_headers.len().saturating_sub(1));
+        let visible_history = self.visible_history();
+        if visible_history.is_empty() {
             frame.render_widget(
                 Paragraph::new("Waiting for history points...").block(titled_block("Convergence")),
                 area,
@@ -609,58 +964,91 @@ impl RatatuiDashboardState {
             return;
         }
 
-        let central_points = self
-            .history
+        let central_points = visible_history
             .iter()
-            .map(|point| (point.samples as f64, point.central))
+            .filter_map(|point| {
+                (*point)
+                    .slot_values(component)
+                    .get(focused_slot)
+                    .copied()
+                    .flatten()
+                    .map(|(central, _)| (point.samples as f64, central))
+            })
             .collect::<Vec<_>>();
-        let upper_points = self
-            .history
+        let upper_points = visible_history
             .iter()
-            .map(|point| (point.samples as f64, point.central + point.error))
+            .filter_map(|point| {
+                (*point)
+                    .slot_values(component)
+                    .get(focused_slot)
+                    .copied()
+                    .flatten()
+                    .map(|(central, error)| (point.samples as f64, central + error))
+            })
             .collect::<Vec<_>>();
-        let lower_points = self
-            .history
+        let lower_points = visible_history
             .iter()
-            .map(|point| (point.samples as f64, point.central - point.error))
+            .filter_map(|point| {
+                (*point)
+                    .slot_values(component)
+                    .get(focused_slot)
+                    .copied()
+                    .flatten()
+                    .map(|(central, error)| (point.samples as f64, central - error))
+            })
             .collect::<Vec<_>>();
-        let completed_points = self
-            .history
+        let completed_points = visible_history
             .iter()
             .filter(|point| point.completed_iteration)
-            .map(|point| (point.samples as f64, point.central))
+            .filter_map(|point| {
+                (*point)
+                    .slot_values(component)
+                    .get(focused_slot)
+                    .copied()
+                    .flatten()
+                    .map(|(central, _)| (point.samples as f64, central))
+            })
             .collect::<Vec<_>>();
+        if central_points.is_empty() {
+            frame.render_widget(
+                Paragraph::new("Waiting for focused-integrand history...").block(titled_block(
+                    format!("Convergence ({})", component.phase_name()),
+                )),
+                area,
+            );
+            return;
+        }
 
-        let x_min = self
-            .history
+        let x_min = visible_history
             .first()
             .map(|point| point.samples as f64)
             .unwrap_or(0.0);
-        let x_max = self
-            .history
+        let x_max = visible_history
             .last()
             .map(|point| point.samples as f64)
             .unwrap_or(1.0);
-        let mut y_min = lower_points
-            .iter()
-            .map(|(_, y)| *y)
-            .fold(f64::INFINITY, f64::min);
-        let mut y_max = upper_points
-            .iter()
-            .map(|(_, y)| *y)
-            .fold(f64::NEG_INFINITY, f64::max);
-        if let Some(target) = update.training_target() {
-            y_min = y_min.min(target.0);
-            y_max = y_max.max(target.0);
-        }
-        if !y_min.is_finite() || !y_max.is_finite() || (y_max - y_min).abs() < 1.0e-14 {
-            y_min -= 1.0;
-            y_max += 1.0;
-        } else {
-            let padding = (y_max - y_min).abs() * 0.08;
-            y_min -= padding;
-            y_max += padding;
-        }
+        let current_value = update
+            .main_results
+            .find_row(ContributionKind::All, component)
+            .and_then(|row| row.slot_cell(focused_slot))
+            .and_then(|cell| cell.value.as_ref())
+            .map(|value| (value.raw.0.0, value.raw.1.0.abs()))
+            .or_else(|| {
+                self.history.last().and_then(|point| {
+                    point
+                        .slot_values(component)
+                        .get(focused_slot)
+                        .copied()
+                        .flatten()
+                })
+            })
+            .unwrap_or((0.0, 1.0));
+        let sigma = current_value
+            .1
+            .max(current_value.0.abs().max(1.0) * 1.0e-12);
+        let y_span = self.chart_y_sigma_span as f64;
+        let y_min = current_value.0 - y_span * sigma;
+        let y_max = current_value.0 + y_span * sigma;
 
         let mut datasets = vec![
             Dataset::default()
@@ -669,30 +1057,30 @@ impl RatatuiDashboardState {
                 .graph_type(ratatui::widgets::GraphType::Line)
                 .style(
                     Style::default()
-                        .fg(Color::Blue)
+                        .fg(Color::Green)
                         .add_modifier(Modifier::BOLD),
                 )
                 .data(&central_points),
             Dataset::default()
                 .name("upper")
                 .graph_type(ratatui::widgets::GraphType::Line)
-                .style(Style::default().fg(Color::Cyan))
+                .style(Style::default().fg(Color::Blue))
                 .data(&upper_points),
             Dataset::default()
                 .name("lower")
                 .graph_type(ratatui::widgets::GraphType::Line)
-                .style(Style::default().fg(Color::Cyan))
+                .style(Style::default().fg(Color::Blue))
                 .data(&lower_points),
             Dataset::default()
                 .name("iter")
-                .marker(Marker::Dot)
+                .marker(Marker::Bar)
                 .graph_type(ratatui::widgets::GraphType::Scatter)
-                .style(Style::default().fg(Color::Green))
+                .style(Style::default().fg(Color::LightMagenta))
                 .data(&completed_points),
         ];
 
         let target_points = update
-            .training_target()
+            .target_for_slot_component(focused_slot, component)
             .map(|target| vec![(x_min, target.0), (x_max.max(x_min + 1.0), target.0)]);
         if let Some(target_points) = target_points.as_ref() {
             datasets.push(
@@ -704,32 +1092,42 @@ impl RatatuiDashboardState {
             );
         }
 
-        let title = format!(
-            "Convergence ({})",
-            match component {
-                ComponentKind::Real => "training re",
-                ComponentKind::Imag => "training im",
-            }
+        let selected_for_training =
+            update.slot_component_selected_for_training(focused_slot, component);
+        let mut title = StyledText::styled("Convergence : ", TextStyle::green().bold());
+        title.push_text(component.phase_name(), component.text_style());
+        title.push_text(
+            if selected_for_training {
+                " (selected for training)"
+            } else {
+                " (not selected for training)"
+            },
+            TextStyle::green().bold(),
         );
+        title.push_text(" [", TextStyle::green().bold());
+        title.append(update.main_results.slot_headers[focused_slot].clone());
+        title.push_text(
+            format!(
+                " | {} | y ±{}σ]",
+                self.chart_history_window.description(),
+                self.chart_y_sigma_span
+            ),
+            TextStyle::green().bold(),
+        );
+        let x_bounds = [x_min, x_max.max(x_min + 1.0)];
         let chart = Chart::new(datasets)
-            .block(titled_block(title))
+            .block(titled_block_styled(&title))
             .x_axis(
                 Axis::default()
                     .title("samples")
-                    .bounds([x_min, x_max.max(x_min + 1.0)])
-                    .labels(vec![
-                        Span::raw(abbreviate_count(x_min.max(0.0) as usize)),
-                        Span::raw(abbreviate_count(x_max.max(0.0) as usize)),
-                    ]),
+                    .bounds(x_bounds)
+                    .labels(count_axis_labels(x_bounds[0], x_bounds[1])),
             )
             .y_axis(
                 Axis::default()
                     .title("central value")
                     .bounds([y_min, y_max])
-                    .labels(vec![
-                        Span::raw(format!("{y_min:.3e}")),
-                        Span::raw(format!("{y_max:.3e}")),
-                    ]),
+                    .labels(value_axis_labels(y_min, y_max)),
             );
         frame.render_widget(chart, area);
     }
@@ -738,250 +1136,279 @@ impl RatatuiDashboardState {
         let focused_slot = self
             .focused_slot
             .min(update.main_results.slot_headers.len().saturating_sub(1));
-        let slot_name = update.main_results.slot_headers[focused_slot].to_plain_string();
-        let rows = update
-            .main_results
-            .row_groups_of_kind(MainResultsRowGroupKind::All)
-            .flat_map(|group| group.rows.iter())
-            .collect::<Vec<_>>();
+        let rows = self.overview_summary_rows(update);
+        let show_target_columns = rows.iter().any(|row| {
+            update
+                .target_deltas_for_row_slot(row, focused_slot)
+                .0
+                .is_some()
+        });
+        let focused_column_count = 5 + if show_target_columns { 2 } else { 0 };
 
-        let mut lines = vec![Line::from(vec![Span::styled(
-            slot_name,
-            Style::default()
-                .fg(Color::Blue)
-                .add_modifier(Modifier::BOLD),
-        )])];
+        let mut table_rows = vec![blank_table_row(focused_column_count)];
+        let mut inserted_sum_gap = false;
         for row in rows {
-            let component = match row.component.raw {
-                ComponentKind::Real => "re",
-                ComponentKind::Imag => "im",
-            };
+            if matches!(row.contribution.raw, ContributionKind::Sum) && !inserted_sum_gap {
+                table_rows.push(blank_table_row(focused_column_count));
+                inserted_sum_gap = true;
+            }
             let Some(cell) = row.slot_cell(focused_slot) else {
                 continue;
             };
-            let value = cell
-                .value
-                .as_ref()
-                .map(|value| spans_from_styled_text(&value.display))
-                .unwrap_or_else(|| vec![Span::raw("N/A")]);
-            let rel = cell
-                .relative_error
-                .as_ref()
-                .map(|value| value.display.to_plain_string())
-                .unwrap_or_else(|| "N/A".to_string());
-            let chi_sq = cell
-                .chi_sq
-                .as_ref()
-                .map(|value| value.display.to_plain_string())
-                .unwrap_or_else(|| "N/A".to_string());
-            let mwi = cell
-                .max_weight_impact
-                .as_ref()
-                .map(|value| value.display.to_plain_string())
-                .unwrap_or_else(|| "N/A".to_string());
-
-            let mut line_spans = vec![Span::styled(
-                format!("{component}: "),
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            )];
-            line_spans.extend(value);
-            lines.push(Line::from(line_spans));
-            lines.push(Line::from(format!(
-                "   rel err {rel}   chi^2 {chi_sq}   mwi {mwi}"
-            )));
-        }
-
-        if focused_slot == 0 {
-            let deltas = update
-                .main_results
-                .row_groups_of_kind(MainResultsRowGroupKind::All)
-                .flat_map(|group| group.rows.iter())
-                .filter_map(|row| {
-                    row.delta_sigma
-                        .as_ref()
-                        .map(|delta| (row.component.raw, delta.display.to_plain_string()))
-                })
-                .collect::<Vec<_>>();
-            if !deltas.is_empty() {
-                lines.push(Line::from(""));
-                for (component, delta) in deltas {
-                    let label = match component {
-                        ComponentKind::Real => "target re",
-                        ComponentKind::Imag => "target im",
-                    };
-                    lines.push(Line::from(format!("{label}: {delta}")));
-                }
-            }
-        }
-
-        frame.render_widget(
-            Paragraph::new(Text::from(lines))
-                .block(titled_block("Focused slot"))
-                .wrap(Wrap { trim: false }),
-            area,
-        );
-    }
-
-    fn draw_slot_metrics_table(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
-        let mut header = vec![Cell::from("slot"), Cell::from("value")];
-        if self.metric_visibility.relative_error {
-            header.push(Cell::from("rel err"));
-        }
-        if self.metric_visibility.chi_sq {
-            header.push(Cell::from("chi^2"));
-        }
-        if self.metric_visibility.max_weight_impact {
-            header.push(Cell::from("mwi"));
-        }
-
-        let rows = (0..update.main_results.slot_headers.len())
-            .map(|slot_index| {
-                let mut cells = vec![
-                    Cell::from(if slot_index == self.focused_slot {
-                        format!(
-                            "> {}",
-                            update.main_results.slot_headers[slot_index].to_plain_string()
-                        )
-                    } else {
-                        update.main_results.slot_headers[slot_index].to_plain_string()
-                    }),
-                    Cell::from(self.overview_value_text(update, slot_index)),
-                ];
-                if self.metric_visibility.relative_error {
-                    cells.push(Cell::from(self.overview_metric_text(
-                        update,
-                        slot_index,
-                        |cell| cell.relative_error.as_ref().map(|field| &field.display),
-                    )));
-                }
-                if self.metric_visibility.chi_sq {
-                    cells.push(Cell::from(self.overview_metric_text(
-                        update,
-                        slot_index,
-                        |cell| cell.chi_sq.as_ref().map(|field| &field.display),
-                    )));
-                }
-                if self.metric_visibility.max_weight_impact {
-                    cells.push(Cell::from(self.overview_metric_text(
-                        update,
-                        slot_index,
-                        |cell| cell.max_weight_impact.as_ref().map(|field| &field.display),
-                    )));
-                }
-                Row::new(cells)
-            })
-            .collect::<Vec<_>>();
-
-        let widths = match header.len() {
-            2 => vec![Constraint::Length(24), Constraint::Min(20)],
-            3 => vec![
-                Constraint::Length(24),
-                Constraint::Min(20),
-                Constraint::Length(16),
-            ],
-            4 => vec![
-                Constraint::Length(24),
-                Constraint::Min(20),
-                Constraint::Length(16),
-                Constraint::Length(14),
-            ],
-            _ => vec![
-                Constraint::Length(24),
-                Constraint::Min(20),
-                Constraint::Length(16),
-                Constraint::Length(14),
-                Constraint::Length(14),
-            ],
-        };
-        let table = Table::new(rows, widths)
-            .header(
-                Row::new(header).style(
-                    Style::default()
-                        .fg(Color::Blue)
-                        .add_modifier(Modifier::BOLD),
+            let (delta_sigma, delta_percent) = update.target_deltas_for_row_slot(row, focused_slot);
+            let mut label = row.contribution.display.clone();
+            label.push_text(" ", TextStyle::PLAIN);
+            label.append(row.component.display.clone());
+            let mut cells = vec![
+                cell_from_styled_text(&label),
+                cell_from_optional_styled_text(cell.value.as_ref().map(|value| &value.display)),
+                cell_from_optional_styled_text(
+                    cell.relative_error.as_ref().map(|value| &value.display),
                 ),
-            )
-            .block(titled_block(format!(
-                "All-slot metrics [{} density]",
-                self.density.label()
+                cell_from_optional_styled_text(cell.chi_sq.as_ref().map(|value| &value.display)),
+                cell_from_optional_styled_text(
+                    cell.max_weight_impact.as_ref().map(|value| &value.display),
+                ),
+            ];
+            if show_target_columns {
+                cells.push(cell_from_optional_styled_text(
+                    delta_sigma.as_ref().map(|value| &value.display),
+                ));
+                cells.push(cell_from_optional_styled_text(
+                    delta_percent.as_ref().map(|value| &value.display),
+                ));
+            }
+            table_rows.push(Row::new(cells));
+        }
+
+        let mut headers = vec![
+            plain_header_cell(""),
+            plain_header_cell("integral"),
+            plain_header_cell("% err"),
+            plain_header_cell("chi^2"),
+            plain_header_cell("m.w.i"),
+        ];
+        if show_target_columns {
+            headers.push(plain_header_cell("Δ [σ]"));
+            headers.push(plain_header_cell("Δ [%]"));
+        }
+
+        let mut widths = vec![
+            Constraint::Length(9),
+            Constraint::Length(16),
+            Constraint::Length(8),
+            Constraint::Length(8),
+            Constraint::Length(10),
+        ];
+        if show_target_columns {
+            widths.push(Constraint::Length(8));
+            widths.push(Constraint::Length(8));
+        }
+
+        let table = Table::new(table_rows, widths)
+            .header(Row::new(headers))
+            .block(titled_block_styled(&scoped_integrand_title(
+                "Focused integrand ",
+                &update.main_results.slot_headers[focused_slot],
+                "",
             )))
             .column_spacing(1);
         frame.render_widget(table, area);
     }
 
-    fn draw_statistics_panel(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
-        let Some(snapshot) = update.statistics_snapshot() else {
+    fn draw_results_summary_table(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let rows = self.overview_summary_rows(update);
+        if rows.is_empty() {
             frame.render_widget(
-                Paragraph::new("Statistics unavailable.").block(titled_block("Statistics")),
+                Paragraph::new("No overview summary rows are available.")
+                    .block(titled_block("Results summary")),
+                area,
+            );
+            return;
+        }
+
+        let contribution_width = update
+            .main_results
+            .row_groups
+            .iter()
+            .flat_map(|group| group.rows.iter())
+            .map(|row| row.contribution.display.to_plain_string().chars().count())
+            .chain(std::iter::once(
+                update
+                    .main_results
+                    .contribution_header
+                    .to_plain_string()
+                    .chars()
+                    .count(),
+            ))
+            .max()
+            .unwrap_or(18)
+            .max(18) as u16;
+        let contribution_title = styled_text_line(&update.main_results.contribution_header, 0);
+        let contribution_detail = styled_text_line(&update.main_results.contribution_header, 1);
+        let mut header_top = vec![cell_from_styled_text(&contribution_title), blank_cell()];
+        let mut header_bottom = vec![cell_from_styled_text(&contribution_detail), blank_cell()];
+        let mut widths = vec![
+            Constraint::Length(contribution_width),
+            Constraint::Length(3),
+        ];
+        for (slot_index, slot_header) in update.main_results.slot_headers.iter().enumerate() {
+            let integral_width = rows
+                .iter()
+                .filter_map(|row| {
+                    row.slot_cell(slot_index)
+                        .and_then(|cell| cell.value.as_ref())
+                        .map(|value| value.display.to_plain_string().chars().count())
+                })
+                .chain(std::iter::once(
+                    slot_header.to_plain_string().chars().count(),
+                ))
+                .chain(std::iter::once("integral".chars().count()))
+                .max()
+                .unwrap_or(16)
+                .max(16) as u16;
+            header_top.push(cell_from_styled_text(slot_header));
+            header_bottom.push(plain_header_cell("integral"));
+            widths.push(Constraint::Length(integral_width));
+            if self.metric_visibility.relative_error {
+                header_top.push(blank_cell());
+                header_bottom.push(plain_header_cell("% err"));
+                widths.push(Constraint::Length(8));
+            }
+            if self.metric_visibility.chi_sq {
+                header_top.push(blank_cell());
+                header_bottom.push(plain_header_cell("chi^2"));
+                widths.push(Constraint::Length(8));
+            }
+            if self.metric_visibility.max_weight_impact {
+                header_top.push(blank_cell());
+                header_bottom.push(plain_header_cell("m.w.i"));
+                widths.push(Constraint::Length(10));
+            }
+        }
+
+        let mut table_rows = vec![
+            blank_table_row(widths.len()),
+            Row::new(header_top),
+            Row::new(header_bottom),
+            blank_table_row(widths.len()),
+        ];
+        for group in [MainResultsRowGroupKind::All, MainResultsRowGroupKind::Sum] {
+            let group_rows = update
+                .main_results
+                .row_groups_of_kind(group)
+                .flat_map(|row_group| row_group.rows.iter())
+                .collect::<Vec<_>>();
+            if group_rows.is_empty() {
+                continue;
+            }
+            if table_rows.len() > 1 {
+                table_rows.push(blank_table_row(widths.len()));
+            }
+            for row in group_rows {
+                let mut cells = vec![
+                    cell_from_styled_text(&row.contribution.display),
+                    cell_from_styled_text(&row.component.display),
+                ];
+                for slot_index in 0..update.main_results.slot_headers.len() {
+                    let cell = row.slot_cell(slot_index);
+                    cells.push(cell_from_optional_styled_text(
+                        cell.and_then(|cell| cell.value.as_ref())
+                            .map(|value| &value.display),
+                    ));
+                    if self.metric_visibility.relative_error {
+                        cells.push(cell_from_optional_styled_text(
+                            cell.and_then(|cell| cell.relative_error.as_ref())
+                                .map(|value| &value.display),
+                        ));
+                    }
+                    if self.metric_visibility.chi_sq {
+                        cells.push(cell_from_optional_styled_text(
+                            cell.and_then(|cell| cell.chi_sq.as_ref())
+                                .map(|value| &value.display),
+                        ));
+                    }
+                    if self.metric_visibility.max_weight_impact {
+                        cells.push(cell_from_optional_styled_text(
+                            cell.and_then(|cell| cell.max_weight_impact.as_ref())
+                                .map(|value| &value.display),
+                        ));
+                    }
+                }
+                table_rows.push(Row::new(cells));
+            }
+        }
+
+        let table = Table::new(table_rows, widths)
+            .block(titled_block("Results summary"))
+            .column_spacing(1);
+        frame.render_widget(table, area);
+    }
+
+    fn draw_statistics_panel(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let Some(statistics) = update.statistics.as_ref() else {
+            frame.render_widget(
+                Paragraph::new("Statistics unavailable.")
+                    .block(titled_block("Integration statistics")),
                 area,
             );
             return;
         };
-
         let layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(5),
-                Constraint::Length(3),
-                Constraint::Length(3),
-                Constraint::Min(3),
+                Constraint::Percentage(38),
+                Constraint::Percentage(31),
+                Constraint::Percentage(31),
             ])
             .split(area);
 
-        let summary = vec![
-            Line::from(format!("evals: {}", abbreviate_count(snapshot.num_evals))),
-            Line::from(format!(
-                "avg total {}   param {}   integ {}   eval {}",
-                utils::format_evaluation_time_from_f64(snapshot.average_total_time_seconds),
-                utils::format_evaluation_time_from_f64(
-                    snapshot.average_parameterization_time_seconds
-                ),
-                utils::format_evaluation_time_from_f64(snapshot.average_integrand_time_seconds),
-                utils::format_evaluation_time_from_f64(snapshot.average_evaluator_time_seconds),
-            )),
-            Line::from(format!(
-                "obs {}   integrator {}   selection {}",
-                utils::format_evaluation_time_from_f64(snapshot.average_observable_time_seconds),
-                utils::format_evaluation_time_from_f64(snapshot.average_integrator_time_seconds),
-                snapshot
-                    .selection_efficiency_percentage
-                    .map(|value| format!("{value:.2}%"))
-                    .unwrap_or_else(|| "N/A".to_string()),
-            )),
-        ];
-        frame.render_widget(
-            Paragraph::new(Text::from(summary)).block(titled_block("Statistics")),
-            layout[0],
+        let mut summary_rows = vec![blank_table_row(9)];
+        summary_rows.extend(
+            statistics
+                .table_rows()
+                .into_iter()
+                .map(|row| {
+                    let mut cells = vec![cell_from_styled_text(&row.row_label)];
+                    for entry in row.entries {
+                        cells.push(cell_from_styled_text(&entry.label));
+                        cells.push(cell_from_styled_text(&entry.value));
+                    }
+                    Row::new(cells)
+                })
+                .collect::<Vec<_>>(),
         );
+        summary_rows.push(blank_table_row(9));
+        let title = statistics.title();
+        let summary_table = Table::new(
+            summary_rows,
+            [
+                Constraint::Length(10),
+                Constraint::Length(12),
+                Constraint::Length(12),
+                Constraint::Length(12),
+                Constraint::Length(12),
+                Constraint::Length(12),
+                Constraint::Length(12),
+                Constraint::Length(13),
+                Constraint::Min(12),
+            ],
+        )
+        .block(titled_block_styled(&title))
+        .column_spacing(1);
+        frame.render_widget(summary_table, layout[0]);
 
-        frame.render_widget(
-            Paragraph::new(Text::from(vec![stacked_percentage_line(
-                "timings",
-                &timing_percentages(&snapshot),
-                area.width.saturating_sub(4) as usize,
-            )]))
-            .block(titled_block("Timing composition")),
+        self.draw_mix_panel(
+            frame,
             layout[1],
+            "Timing composition",
+            &statistics.timing_mix_segments(),
         );
-        frame.render_widget(
-            Paragraph::new(Text::from(vec![stacked_percentage_line(
-                "precision",
-                &precision_percentages(&snapshot),
-                area.width.saturating_sub(4) as usize,
-            )]))
-            .block(titled_block("Precision mix")),
+        self.draw_mix_panel(
+            frame,
             layout[2],
-        );
-        frame.render_widget(
-            Paragraph::new(Text::from(vec![stacked_percentage_line(
-                "stability",
-                &stability_percentages(&snapshot),
-                area.width.saturating_sub(4) as usize,
-            )]))
-            .block(titled_block("Stability mix")),
-            layout[3],
+            "Precision mix",
+            &statistics.precision_mix_segments(),
         );
     }
 
@@ -997,69 +1424,121 @@ impl RatatuiDashboardState {
             return;
         }
 
+        let focused_slot = self
+            .focused_slot
+            .min(update.main_results.slot_headers.len().saturating_sub(1));
         let horizontal = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
             .split(area);
 
-        let header = Row::new(["contribution", "cmp", "value", "rel err", "samples", "pdf"]).style(
-            Style::default()
-                .fg(Color::Blue)
-                .add_modifier(Modifier::BOLD),
-        );
-        let rows = discrete_rows
+        let contribution_header = update.main_results.contribution_header.to_plain_string();
+        let contribution_width = discrete_rows
             .iter()
             .map(|entry| {
-                let cell = entry.row.slot_cell(0);
-                Row::new(vec![
-                    Cell::from(entry.row.contribution.display.to_plain_string()),
-                    Cell::from(entry.row.component.display.to_plain_string()),
-                    Cell::from(
-                        cell.and_then(|cell| cell.value.as_ref())
-                            .map(|value| value.display.to_plain_string())
-                            .unwrap_or_default(),
-                    ),
-                    Cell::from(
-                        cell.and_then(|cell| cell.relative_error.as_ref())
-                            .map(|value| value.display.to_plain_string())
-                            .unwrap_or_default(),
-                    ),
-                    Cell::from(
-                        cell.and_then(|cell| cell.sample_count.as_ref())
-                            .map(|value| value.display.to_plain_string())
-                            .unwrap_or_default(),
-                    ),
-                    Cell::from(
-                        cell.and_then(|cell| cell.target_pdf.as_ref())
-                            .map(|value| value.display.to_plain_string())
-                            .unwrap_or_default(),
-                    ),
-                ])
+                entry
+                    .row
+                    .contribution
+                    .display
+                    .to_plain_string()
+                    .chars()
+                    .count()
             })
-            .collect::<Vec<_>>();
+            .chain(std::iter::once(contribution_header.chars().count()))
+            .max()
+            .unwrap_or(24)
+            .max(24) as u16;
+        let integral_width = discrete_rows
+            .iter()
+            .filter_map(|entry| {
+                entry
+                    .row
+                    .slot_cell(focused_slot)
+                    .and_then(|cell| cell.value.as_ref())
+                    .map(|value| value.display.to_plain_string().chars().count())
+            })
+            .chain(std::iter::once("integral".chars().count()))
+            .max()
+            .unwrap_or(14)
+            .max(14) as u16;
+        let mut rows = vec![blank_table_row(9)];
+        rows.extend(
+            discrete_rows
+                .iter()
+                .map(|entry| {
+                    let cell = entry.row.slot_cell(focused_slot);
+                    Row::new(vec![
+                        cell_from_styled_text(&entry.row.contribution.display),
+                        cell_from_styled_text(&entry.row.component.display),
+                        cell_from_optional_styled_text(
+                            cell.and_then(|cell| cell.value.as_ref())
+                                .map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.and_then(|cell| cell.relative_error.as_ref())
+                                .map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.and_then(|cell| cell.chi_sq.as_ref())
+                                .map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.and_then(|cell| cell.max_weight_impact.as_ref())
+                                .map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.and_then(|cell| cell.sample_fraction.as_ref())
+                                .map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.and_then(|cell| cell.sample_count.as_ref())
+                                .map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.and_then(|cell| cell.target_pdf.as_ref())
+                                .map(|value| &value.display),
+                        ),
+                    ])
+                })
+                .collect::<Vec<_>>(),
+        );
 
-        let mut state = TableState::default().with_selected(Some(self.selected_discrete_row));
+        let mut state = TableState::default().with_selected(Some(self.selected_discrete_row + 1));
         let table = Table::new(
             rows,
             [
-                Constraint::Length(24),
-                Constraint::Length(6),
-                Constraint::Min(18),
-                Constraint::Length(12),
+                Constraint::Length(contribution_width),
+                Constraint::Length(3),
+                Constraint::Length(integral_width),
+                Constraint::Length(8),
+                Constraint::Length(8),
                 Constraint::Length(10),
-                Constraint::Length(9),
+                Constraint::Length(8),
+                Constraint::Length(10),
+                Constraint::Min(8),
             ],
         )
-        .header(header)
-        .row_highlight_style(Style::default().bg(Color::Blue).fg(Color::Black))
-        .block(titled_block(format!(
-            "Discrete bins (sort: {:?} {})",
-            self.discrete_sort,
-            if self.discrete_descending {
-                "desc"
-            } else {
-                "asc"
-            }
+        .header(Row::new(
+            update
+                .main_results
+                .discrete_headers()
+                .iter()
+                .map(cell_from_styled_text)
+                .collect::<Vec<_>>(),
+        ))
+        .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .block(titled_block_styled(&scoped_integrand_title(
+            "Discrete bins for focused integrand ",
+            &update.main_results.slot_headers[focused_slot],
+            &format!(
+                " (sort: {} {})",
+                discrete_sort_label(self.discrete_sort),
+                if self.discrete_descending {
+                    "desc"
+                } else {
+                    "asc"
+                }
+            ),
         )));
         frame.render_stateful_widget(table, horizontal[0], &mut state);
 
@@ -1077,96 +1556,145 @@ impl RatatuiDashboardState {
         update: &StatusUpdate,
         row: &MainResultsRow,
     ) {
-        let mut lines = vec![Line::from(vec![
-            Span::styled(
-                "selected: ",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::raw(row.contribution.display.to_plain_string()),
-            Span::raw(" "),
-            Span::raw(row.component.display.to_plain_string()),
-        ])];
-
-        for slot_index in 0..update.main_results.slot_headers.len() {
-            let slot_name = update.main_results.slot_headers[slot_index].to_plain_string();
-            let Some(cell) = row.slot_cell(slot_index) else {
-                continue;
-            };
-            lines.push(Line::from(""));
-            lines.push(Line::from(vec![Span::styled(
-                slot_name,
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            )]));
-            if let Some(value) = cell.value.as_ref() {
-                lines.push(Line::from(format!(
-                    "value    {}",
-                    value.display.to_plain_string()
-                )));
-            }
-            if let Some(value) = cell.relative_error.as_ref() {
-                lines.push(Line::from(format!(
-                    "rel err  {}",
-                    value.display.to_plain_string()
-                )));
-            }
-            if let Some(value) = cell.chi_sq.as_ref() {
-                lines.push(Line::from(format!(
-                    "chi^2    {}",
-                    value.display.to_plain_string()
-                )));
-            }
-            if let Some(value) = cell.max_weight_impact.as_ref() {
-                lines.push(Line::from(format!(
-                    "mwi      {}",
-                    value.display.to_plain_string()
-                )));
-            }
-            if let Some(value) = cell.sample_fraction.as_ref() {
-                lines.push(Line::from(format!(
-                    "samples  {}",
-                    value.display.to_plain_string()
-                )));
-            }
-            if let Some(value) = cell.target_pdf.as_ref() {
-                lines.push(Line::from(format!(
-                    "pdf      {}",
-                    value.display.to_plain_string()
-                )));
-            }
-        }
-
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(3), Constraint::Min(6)])
+            .split(area);
+        let mut selected_line = vec![Span::raw("selected: ")];
+        selected_line.extend(spans_from_styled_text(&row.contribution.display));
+        selected_line.push(Span::raw(" "));
+        selected_line.extend(spans_from_styled_text(&row.component.display));
         frame.render_widget(
-            Paragraph::new(Text::from(lines))
-                .block(titled_block("Selected bin detail"))
-                .wrap(Wrap { trim: false }),
-            area,
+            Paragraph::new(Line::from(selected_line)).block(titled_block("Selected bin")),
+            layout[0],
         );
+
+        let slot_width = update
+            .main_results
+            .slot_headers
+            .iter()
+            .map(|slot| slot.to_plain_string().chars().count())
+            .max()
+            .unwrap_or(8)
+            .max(8) as u16;
+        let integral_width = (0..update.main_results.slot_headers.len())
+            .filter_map(|slot_index| {
+                row.slot_cell(slot_index)
+                    .and_then(|cell| cell.value.as_ref())
+                    .map(|value| value.display.to_plain_string().chars().count())
+            })
+            .chain(std::iter::once("integral".chars().count()))
+            .max()
+            .unwrap_or(14)
+            .max(14) as u16;
+        let mut rows = vec![blank_table_row(8)];
+        rows.extend(
+            (0..update.main_results.slot_headers.len())
+                .filter_map(|slot_index| {
+                    let cell = row.slot_cell(slot_index)?;
+                    Some(Row::new(vec![
+                        cell_from_styled_text(&update.main_results.slot_headers[slot_index]),
+                        cell_from_optional_styled_text(
+                            cell.value.as_ref().map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.relative_error.as_ref().map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.chi_sq.as_ref().map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.max_weight_impact.as_ref().map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.sample_fraction.as_ref().map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.sample_count.as_ref().map(|value| &value.display),
+                        ),
+                        cell_from_optional_styled_text(
+                            cell.target_pdf.as_ref().map(|value| &value.display),
+                        ),
+                    ]))
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Length(slot_width),
+                Constraint::Length(integral_width),
+                Constraint::Length(10),
+                Constraint::Length(8),
+                Constraint::Length(10),
+                Constraint::Length(10),
+                Constraint::Length(10),
+                Constraint::Min(8),
+            ],
+        )
+        .header(Row::new(
+            update
+                .main_results
+                .selected_bin_detail_headers()
+                .iter()
+                .map(cell_from_styled_text)
+                .collect::<Vec<_>>(),
+        ))
+        .block(titled_block("Per integrand details"))
+        .column_spacing(1);
+        frame.render_widget(table, layout[1]);
     }
 
     fn draw_max_weight_tab(&self, frame: &mut Frame<'_>, area: Rect, update: &StatusUpdate) {
+        let focused_slot = self
+            .focused_slot
+            .min(update.main_results.slot_headers.len().saturating_sub(1));
+        let focused_slot_name = update.main_results.slot_headers[focused_slot].to_plain_string();
+        let top_height = if area.height > 18 {
+            update
+                .max_weight_details
+                .as_ref()
+                .map(|section| {
+                    let row_count = section
+                        .rows_by_slot
+                        .iter()
+                        .map(|rows| rows.len())
+                        .sum::<usize>() as u16;
+                    row_count
+                        .saturating_add(6)
+                        .clamp(8, area.height.saturating_sub(10))
+                })
+                .unwrap_or(area.height.saturating_mul(2) / 5)
+        } else {
+            area.height.saturating_mul(2) / 5
+        };
         let layout = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+            .constraints([Constraint::Length(top_height), Constraint::Min(8)])
             .split(area);
 
         if let Some(section) = update.max_weight_details.as_ref() {
-            let rows = section
-                .rows_by_slot
-                .iter()
-                .flat_map(|group| group.iter())
-                .map(|row| {
-                    Row::new(vec![
-                        Cell::from(row.slot.display.to_plain_string()),
-                        Cell::from(row.component_sign.display.to_plain_string()),
-                        Cell::from(row.max_eval.display.to_plain_string()),
-                        Cell::from(row.coordinates.display.to_plain_string()),
-                    ])
-                })
-                .collect::<Vec<_>>();
+            let headers = section.headers();
+            let title = section.title();
+            let mut rows = vec![blank_table_row(4)];
+            rows.extend(
+                section
+                    .rows_by_slot
+                    .iter()
+                    .flat_map(|group| group.iter())
+                    .map(|row| {
+                        Row::new(vec![
+                            cell_from_styled_text(&row.slot.display),
+                            cell_from_styled_text(&row.component_sign.display),
+                            cell_from_styled_text(&row.max_eval.display),
+                            cell_from_styled_text(&row.coordinates.display),
+                        ])
+                        .height(styled_text_line_count(&row.coordinates.display))
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            rows.push(blank_table_row(4));
             let table = Table::new(
                 rows,
                 [
@@ -1176,14 +1704,13 @@ impl RatatuiDashboardState {
                     Constraint::Min(24),
                 ],
             )
-            .header(
-                Row::new(["slot", "cmp", "max eval", "coordinates"]).style(
-                    Style::default()
-                        .fg(Color::Blue)
-                        .add_modifier(Modifier::BOLD),
-                ),
-            )
-            .block(titled_block("Overall max weight"));
+            .header(Row::new(
+                headers
+                    .iter()
+                    .map(cell_from_styled_text)
+                    .collect::<Vec<_>>(),
+            ))
+            .block(titled_block_styled(&title));
             frame.render_widget(table, layout[0]);
         } else {
             frame.render_widget(
@@ -1194,60 +1721,99 @@ impl RatatuiDashboardState {
         }
 
         if let Some(section) = update.discrete_max_weight_details.as_ref() {
-            let rows = section
-                .row_groups
-                .iter()
-                .flat_map(|group| group.iter())
-                .map(|row| {
-                    let values = row
-                        .slot_values
-                        .iter()
-                        .map(|value| {
-                            value
-                                .as_ref()
-                                .map(|field| field.display.to_plain_string())
-                                .unwrap_or_default()
-                        })
-                        .collect::<Vec<_>>()
-                        .join(" | ");
-                    let coordinates = row
-                        .slot_coordinates
-                        .iter()
-                        .map(|entry| {
-                            format!(
-                                "{}: {}",
-                                entry.slot.display.to_plain_string(),
-                                entry.coordinates.display.to_plain_string()
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    Row::new(vec![
-                        Cell::from(row.contribution.display.to_plain_string()),
-                        Cell::from(row.component_sign.display.to_plain_string()),
-                        Cell::from(values),
-                        Cell::from(coordinates),
-                    ])
-                })
+            let sorted_rows = self.sorted_discrete_max_weight_rows(section);
+            let lower = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+                .split(layout[1]);
+            let summary_headers = section.summary_headers();
+            let mut summary_rows = vec![blank_table_row(section.slot_headers.len() + 2)];
+            summary_rows.extend(
+                sorted_rows
+                    .iter()
+                    .map(|row| {
+                        let mut cells = vec![
+                            cell_from_styled_text(&row.contribution.display),
+                            cell_from_styled_text(&row.component_sign.display),
+                        ];
+                        cells.extend(
+                            row.slot_values
+                                .iter()
+                                .map(|value| {
+                                    cell_from_optional_styled_text(
+                                        value.as_ref().map(|field| &field.display),
+                                    )
+                                })
+                                .collect::<Vec<_>>(),
+                        );
+                        Row::new(cells)
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            let summary_widths = std::iter::once(Constraint::Length(24))
+                .chain(std::iter::once(Constraint::Length(10)))
+                .chain(section.slot_headers.iter().map(|_| Constraint::Min(16)))
                 .collect::<Vec<_>>();
-            let table = Table::new(
-                rows,
+            let table = Table::new(summary_rows, summary_widths)
+                .header(Row::new(
+                    summary_headers
+                        .iter()
+                        .map(cell_from_styled_text)
+                        .collect::<Vec<_>>(),
+                ))
+                .block(titled_block(format!(
+                    "Per-bin max weight (sort: {} {})",
+                    discrete_sort_label(self.discrete_sort),
+                    if self.discrete_descending {
+                        "desc"
+                    } else {
+                        "asc"
+                    }
+                )))
+                .column_spacing(1);
+            frame.render_widget(table, lower[0]);
+
+            let coordinate_headers = section.coordinate_headers();
+            let focused_slot_filter = focused_slot_name.clone();
+            let mut coordinate_rows = vec![blank_table_row(3)];
+            coordinate_rows.extend(
+                sorted_rows
+                    .iter()
+                    .flat_map(|row| {
+                        let focused_slot_filter = focused_slot_filter.clone();
+                        row.slot_coordinates
+                            .iter()
+                            .filter(move |entry| entry.slot.raw == focused_slot_filter)
+                            .map(move |entry| {
+                                Row::new(vec![
+                                    cell_from_styled_text(&row.contribution.display),
+                                    cell_from_styled_text(&row.component_sign.display),
+                                    cell_from_styled_text(&entry.coordinates.display),
+                                ])
+                                .height(styled_text_line_count(&entry.coordinates.display))
+                            })
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            let coordinates_table = Table::new(
+                coordinate_rows,
                 [
-                    Constraint::Length(24),
-                    Constraint::Length(10),
-                    Constraint::Min(18),
-                    Constraint::Min(28),
+                    Constraint::Length(18),
+                    Constraint::Length(8),
+                    Constraint::Min(24),
                 ],
             )
-            .header(
-                Row::new(["contribution", "cmp", "slot values", "coordinates"]).style(
-                    Style::default()
-                        .fg(Color::Blue)
-                        .add_modifier(Modifier::BOLD),
-                ),
-            )
-            .block(titled_block("Per-bin max weight"));
-            frame.render_widget(table, layout[1]);
+            .header(Row::new(vec![
+                cell_from_styled_text(&coordinate_headers[0]),
+                cell_from_styled_text(&coordinate_headers[1]),
+                cell_from_styled_text(&coordinate_headers[3]),
+            ]))
+            .block(titled_block_styled(&scoped_integrand_title(
+                "Maximum weight coordinates for integrand ",
+                &update.main_results.slot_headers[focused_slot],
+                "",
+            )));
+            frame.render_widget(coordinates_table, lower[1]);
         } else {
             frame.render_widget(
                 Paragraph::new("No per-bin max-weight data.")
@@ -1266,59 +1832,28 @@ impl RatatuiDashboardState {
             })
             .unwrap_or("n/a");
         let footer = Paragraph::new(Line::from(vec![
-            Span::styled(
-                "Tabs",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("Tabs", label_style()),
             Span::raw(" 1/2/3 or <- ->  "),
-            Span::styled(
-                "Slot",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("Integrand", label_style()),
             Span::raw(" [ / ]  "),
-            Span::styled(
-                "Bins",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("Bins", label_style()),
             Span::raw(" j/k  "),
-            Span::styled(
-                "Metrics",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("Metrics", label_style()),
             Span::raw(" r c w  "),
-            Span::styled(
-                "Sort",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("Phase", label_style()),
+            Span::raw(" p  "),
+            Span::styled("Sort", label_style()),
             Span::raw(" s/v  "),
-            Span::styled(
-                "Density",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::raw(" m  "),
-            Span::styled(
-                "Help",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("History", label_style()),
+            Span::raw(format!(
+                " g +/- ({})  ",
+                self.chart_history_window.description()
+            )),
+            Span::styled("Y-axis", label_style()),
+            Span::raw(format!(" , . 0 (±{}σ)  ", self.chart_y_sigma_span)),
+            Span::styled("Help", label_style()),
             Span::raw(" ?  "),
-            Span::styled(
-                "Abort",
-                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("Abort", label_style()),
             Span::raw(format!(" x / Ctrl-C   training {phase}")),
         ]))
         .alignment(Alignment::Left)
@@ -1332,12 +1867,16 @@ impl RatatuiDashboardState {
         frame.render_widget(
             Paragraph::new(Text::from(vec![
                 Line::from("1/2/3 or Left/Right  switch tabs"),
-                Line::from("[ and ]             change focused slot"),
+                Line::from("[ and ]             change focused integrand"),
                 Line::from("j / k               move selected discrete row"),
                 Line::from("s                   cycle discrete sort"),
                 Line::from("v                   reverse discrete sort order"),
                 Line::from("r / c / w           toggle rel err, chi^2, mwi columns"),
-                Line::from("m                   cycle density mode"),
+                Line::from("p                   toggle convergence real/imag phase"),
+                Line::from("g                   toggle full/recent chart history"),
+                Line::from("+ / -               widen or narrow recent-history window"),
+                Line::from(", / .               tighten or widen the y-range in σ units"),
+                Line::from("0                   reset the y-range to ±4σ"),
                 Line::from("x                   abort the current iteration"),
                 Line::from("Ctrl-C              stop the integration"),
                 Line::from("?                   close help"),
@@ -1349,11 +1888,79 @@ impl RatatuiDashboardState {
         );
     }
 
+    fn draw_mix_panel(
+        &self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        title: &str,
+        segments: &[StatisticsMixSegment],
+    ) {
+        let block = titled_block(title);
+        let inner = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+            ])
+            .split(block.inner(area));
+        frame.render_widget(block, area);
+        frame.render_widget(Paragraph::new(""), inner[0]);
+        frame.render_widget(
+            Paragraph::new(mix_bar_line(segments, inner[1].width as usize)),
+            inner[1],
+        );
+        frame.render_widget(Paragraph::new(""), inner[2]);
+        if !segments.is_empty() {
+            let constraints = (0..segments.len())
+                .map(|_| Constraint::Percentage((100 / segments.len().max(1)) as u16))
+                .collect::<Vec<_>>();
+            let labels = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints(constraints)
+                .split(inner[3]);
+            for (segment, label_area) in segments.iter().zip(labels.iter().copied()) {
+                frame.render_widget(
+                    Paragraph::new(Line::from(vec![Span::styled(
+                        format!(
+                            "{} : {:.1}%",
+                            segment.label.to_plain_string(),
+                            segment.percentage
+                        ),
+                        style_from_text_style(
+                            segment
+                                .label
+                                .spans
+                                .first()
+                                .map(|span| span.style)
+                                .unwrap_or(TextStyle::PLAIN),
+                        )
+                        .add_modifier(Modifier::BOLD),
+                    )]))
+                    .alignment(Alignment::Center),
+                    label_area,
+                );
+            }
+        }
+        frame.render_widget(Paragraph::new(""), inner[4]);
+    }
+
     fn discrete_rows(&self) -> Vec<DiscreteRowRef<'_>> {
         let Some(update) = self.latest_update.as_ref() else {
             return Vec::new();
         };
+        let focused_slot = self
+            .focused_slot
+            .min(update.main_results.slot_headers.len().saturating_sub(1));
+        self.discrete_rows_for_slot(focused_slot)
+    }
 
+    fn discrete_rows_for_slot(&self, slot_index: usize) -> Vec<DiscreteRowRef<'_>> {
+        let Some(update) = self.latest_update.as_ref() else {
+            return Vec::new();
+        };
         let mut rows = update
             .main_results
             .row_groups_of_kind(MainResultsRowGroupKind::Bins)
@@ -1362,8 +1969,8 @@ impl RatatuiDashboardState {
             .collect::<Vec<_>>();
 
         rows.sort_by(|lhs, rhs| {
-            let lhs_key = lhs.sort_value(self.discrete_sort);
-            let rhs_key = rhs.sort_value(self.discrete_sort);
+            let lhs_key = lhs.sort_value(self.discrete_sort, slot_index);
+            let rhs_key = rhs.sort_value(self.discrete_sort, slot_index);
             let ordering = match self.discrete_sort {
                 ContributionSortMode::Index => match (lhs.contribution(), rhs.contribution()) {
                     (ContributionKind::Bin(lhs_index), ContributionKind::Bin(rhs_index)) => {
@@ -1373,18 +1980,61 @@ impl RatatuiDashboardState {
                     }
                     _ => Ordering::Equal,
                 },
-                ContributionSortMode::Integral | ContributionSortMode::Error => rhs_key
-                    .partial_cmp(&lhs_key)
+                ContributionSortMode::Integral | ContributionSortMode::Error => lhs_key
+                    .partial_cmp(&rhs_key)
                     .unwrap_or(Ordering::Equal)
                     .then(lhs.component().cmp(&rhs.component())),
             };
             if self.discrete_descending {
-                ordering
-            } else {
                 ordering.reverse()
+            } else {
+                ordering
             }
         });
         rows
+    }
+
+    fn sorted_discrete_max_weight_rows<'a>(
+        &self,
+        section: &'a super::status_update::DiscreteMaxWeightDetailsSection,
+    ) -> Vec<&'a super::status_update::DiscreteMaxWeightRow> {
+        let discrete_order = self
+            .discrete_rows_for_slot(0)
+            .into_iter()
+            .map(|row| (row.contribution(), row.component()))
+            .collect::<Vec<_>>();
+        let mut all_rows = section
+            .row_groups
+            .iter()
+            .flat_map(|group| group.iter())
+            .collect::<Vec<_>>();
+        all_rows.sort_by_key(|row| {
+            self.max_weight_row_sort_rank(
+                &discrete_order,
+                row.contribution.raw,
+                row.component_sign.raw.0,
+            )
+        });
+        all_rows
+    }
+
+    fn max_weight_row_sort_rank(
+        &self,
+        discrete_order: &[(ContributionKind, ComponentKind)],
+        contribution: ContributionKind,
+        component: ComponentKind,
+    ) -> (usize, usize) {
+        match contribution {
+            ContributionKind::All => (0, component_rank(component)),
+            ContributionKind::Bin(_) => (
+                1,
+                discrete_order
+                    .iter()
+                    .position(|entry| *entry == (contribution, component))
+                    .unwrap_or(usize::MAX),
+            ),
+            ContributionKind::Sum => (2, component_rank(component)),
+        }
     }
 
     fn overview_value_text(&self, update: &StatusUpdate, slot_index: usize) -> Text<'static> {
@@ -1393,13 +2043,62 @@ impl RatatuiDashboardState {
         })
     }
 
-    fn overview_metric_text(
-        &self,
-        update: &StatusUpdate,
-        slot_index: usize,
-        select: impl Fn(&MainTableSlotCells) -> Option<&StyledText>,
-    ) -> Text<'static> {
-        overview_metric_text(update, slot_index, select)
+    fn overview_summary_rows<'a>(&self, update: &'a StatusUpdate) -> Vec<&'a MainResultsRow> {
+        update
+            .main_results
+            .row_groups_of_kind(MainResultsRowGroupKind::All)
+            .chain(
+                update
+                    .main_results
+                    .row_groups_of_kind(MainResultsRowGroupKind::Sum),
+            )
+            .flat_map(|group| group.rows.iter())
+            .collect()
+    }
+
+    fn results_summary_cell(&self, row: &MainResultsRow, slot_index: usize) -> Text<'static> {
+        let Some(cell) = row.slot_cell(slot_index) else {
+            return Text::from("N/A");
+        };
+
+        let mut lines = Vec::new();
+        if let Some(value) = cell.value.as_ref() {
+            lines.push(Line::from(spans_from_styled_text(&value.display)));
+        } else {
+            lines.push(Line::from("N/A"));
+        }
+
+        let mut metrics = Vec::new();
+        if self.metric_visibility.relative_error {
+            metrics.push(labeled_value_line(
+                "rel err",
+                cell.relative_error.as_ref().map(|value| &value.display),
+            ));
+        }
+        if self.metric_visibility.chi_sq {
+            metrics.push(labeled_value_line(
+                "chi^2",
+                cell.chi_sq.as_ref().map(|value| &value.display),
+            ));
+        }
+        if self.metric_visibility.max_weight_impact {
+            metrics.push(labeled_value_line(
+                "mwi",
+                cell.max_weight_impact.as_ref().map(|value| &value.display),
+            ));
+        }
+        if !metrics.is_empty() && !matches!(self.density, DensityMode::Compact) {
+            let mut spans = Vec::new();
+            for (index, metric_line) in metrics.into_iter().enumerate() {
+                if index > 0 {
+                    spans.push(Span::raw("   "));
+                }
+                spans.extend(metric_line.spans);
+            }
+            lines.push(Line::from(spans));
+        }
+
+        Text::from(lines)
     }
 }
 
@@ -1414,17 +2113,9 @@ fn overview_metric_text(
         .row_groups_of_kind(MainResultsRowGroupKind::All)
         .flat_map(|group| group.rows.iter())
         .filter_map(|row| {
-            let component = match row.component.raw {
-                ComponentKind::Real => "re",
-                ComponentKind::Imag => "im",
-            };
             let text = row.slot_cell(slot_index).and_then(select)?;
-            let mut spans = vec![Span::styled(
-                format!("{component}: "),
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            )];
+            let mut spans = spans_from_styled_text(&row.component.display);
+            spans.push(Span::raw(": "));
             spans.extend(spans_from_styled_text(text));
             Some(Line::from(spans))
         })
@@ -1437,14 +2128,47 @@ fn overview_metric_text(
     }
 }
 
+fn component_label_with_colon(component: ComponentKind) -> StyledText {
+    let mut label = component.label_display();
+    label.push_text(":", component.text_style());
+    label
+}
+
+fn component_rank(component: ComponentKind) -> usize {
+    match component {
+        ComponentKind::Real => 0,
+        ComponentKind::Imag => 1,
+    }
+}
+
+fn scoped_integrand_title(prefix: &str, slot_header: &StyledText, suffix: &str) -> StyledText {
+    let mut title = StyledText::styled(prefix, TextStyle::green().bold());
+    title.push_text("[", TextStyle::green().bold());
+    title.append(slot_header.clone());
+    title.push_text("]", TextStyle::green().bold());
+    title.push_text(suffix, TextStyle::green().bold());
+    title
+}
+
+fn format_samples_per_second(rate: f64) -> String {
+    abbreviate_count(rate.max(0.0).round() as usize)
+}
+
+fn labeled_value_line(label: &str, value: Option<&StyledText>) -> Line<'static> {
+    let mut spans = vec![Span::raw(format!("{label} "))];
+    if let Some(value) = value {
+        spans.extend(spans_from_styled_text(value));
+    } else {
+        spans.push(Span::raw("N/A"));
+    }
+    Line::from(spans)
+}
+
 fn style_from_text_style(style: TextStyle) -> Style {
     let mut rendered = Style::default();
-    rendered = match style.color {
-        Some(TextColor::Green) => rendered.fg(Color::Green),
-        Some(TextColor::Blue) => rendered.fg(Color::Blue),
-        Some(TextColor::Red) => rendered.fg(Color::Red),
-        None => rendered,
-    };
+    if let Some(color) = color_from_text_style(style) {
+        rendered = rendered.fg(color);
+    }
     if style.bold {
         rendered = rendered.add_modifier(Modifier::BOLD);
     }
@@ -1461,109 +2185,176 @@ fn spans_from_styled_text(text: &StyledText) -> Vec<Span<'static>> {
         .collect()
 }
 
+fn line_from_styled_text(text: &StyledText) -> Line<'static> {
+    Line::from(spans_from_styled_text(text))
+}
+
+fn text_from_styled_text(text: &StyledText) -> Text<'static> {
+    let mut lines = vec![Line::default()];
+    for span in &text.spans {
+        let style = style_from_text_style(span.style);
+        for (index, segment) in span.text.split('\n').enumerate() {
+            if index > 0 {
+                lines.push(Line::default());
+            }
+            if !segment.is_empty() {
+                lines
+                    .last_mut()
+                    .expect("at least one line")
+                    .spans
+                    .push(Span::styled(segment.to_string(), style));
+            }
+        }
+    }
+    Text::from(lines)
+}
+
+fn styled_text_line_count(text: &StyledText) -> u16 {
+    text.to_plain_string()
+        .lines()
+        .count()
+        .max(1)
+        .try_into()
+        .unwrap_or(u16::MAX)
+}
+
+fn styled_text_line(text: &StyledText, line_index: usize) -> StyledText {
+    let mut lines = vec![StyledText::new()];
+    for span in &text.spans {
+        for (index, segment) in span.text.split('\n').enumerate() {
+            if index > 0 {
+                lines.push(StyledText::new());
+            }
+            if !segment.is_empty() {
+                lines
+                    .last_mut()
+                    .expect("at least one styled line")
+                    .push_text(segment, span.style);
+            }
+        }
+    }
+    lines.get(line_index).cloned().unwrap_or_default()
+}
+
+fn cell_from_styled_text(text: &StyledText) -> Cell<'static> {
+    Cell::from(text_from_styled_text(text))
+}
+
+fn cell_from_optional_styled_text(text: Option<&StyledText>) -> Cell<'static> {
+    text.map(cell_from_styled_text).unwrap_or_else(blank_cell)
+}
+
+fn plain_header_cell(text: impl Into<String>) -> Cell<'static> {
+    Cell::from(Span::styled(text.into(), label_style()))
+}
+
+fn blank_cell() -> Cell<'static> {
+    Cell::from(String::new())
+}
+
+fn blank_table_row(column_count: usize) -> Row<'static> {
+    Row::new((0..column_count).map(|_| blank_cell()).collect::<Vec<_>>())
+}
+
+fn stacked_header(title: &StyledText, subtitle: &str) -> StyledText {
+    let mut text = title.clone();
+    text.push_text("\n", TextStyle::PLAIN);
+    text.push_text(subtitle, TextStyle::PLAIN.bold());
+    text
+}
+
 fn titled_block(title: impl Into<String>) -> Block<'static> {
     Block::default()
         .borders(Borders::ALL)
-        .title(title.into())
-        .border_style(Style::default().fg(Color::Blue))
+        .title(Line::from(vec![Span::styled(
+            title.into(),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        )]))
+        .border_style(Style::default().fg(Color::DarkGray))
+}
+
+fn titled_block_styled(title: &StyledText) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .title(line_from_styled_text(title))
+        .border_style(Style::default().fg(Color::DarkGray))
+}
+
+fn label_style() -> Style {
+    Style::default().add_modifier(Modifier::BOLD)
 }
 
 fn abbreviate_count(value: usize) -> String {
     super::display::format_abbreviated_count(value)
 }
 
-fn format_rate(value: Option<f64>) -> String {
-    let Some(value) = value else {
-        return "N/A".to_string();
-    };
-    if !value.is_finite() || value <= 0.0 {
-        return "N/A".to_string();
-    }
-    format!("{}/s", abbreviate_count(value.round() as usize))
-}
-
-fn stacked_percentage_line(
-    label: &str,
-    segments: &[(String, f64, Color)],
-    width: usize,
-) -> Line<'static> {
-    let prefix = format!("{label:<10}");
-    let bar_width = width.saturating_sub(prefix.len() + 12).max(8);
-    let mut spans = vec![Span::styled(
-        prefix,
-        Style::default()
-            .fg(Color::Blue)
-            .add_modifier(Modifier::BOLD),
-    )];
+fn mix_bar_line(segments: &[StatisticsMixSegment], width: usize) -> Line<'static> {
+    let bar_width = width.max(8);
+    let mut spans = Vec::new();
     let mut used = 0usize;
-    for (index, (_, percentage, color)) in segments.iter().enumerate() {
+    for (index, segment) in segments.iter().enumerate() {
+        let color = color_from_styled_text(&segment.label, Color::DarkGray);
         let width = if index + 1 == segments.len() {
             bar_width.saturating_sub(used)
         } else {
-            let segment = ((*percentage / 100.0) * bar_width as f64).round() as usize;
-            used += segment;
-            segment
+            let segment_width = ((segment.percentage / 100.0) * bar_width as f64).round() as usize;
+            used += segment_width;
+            segment_width
         };
-        spans.push(Span::styled("█".repeat(width), Style::default().fg(*color)));
+        spans.push(Span::styled("█".repeat(width), Style::default().fg(color)));
     }
-    spans.push(Span::raw(" "));
-    spans.push(Span::raw(
-        segments
-            .iter()
-            .map(|(name, percentage, _)| format!("{name}:{percentage:.1}%"))
-            .collect::<Vec<_>>()
-            .join(" "),
-    ));
     Line::from(spans)
 }
 
-fn timing_percentages(snapshot: &IntegrationStatisticsSnapshot) -> Vec<(String, f64, Color)> {
-    let total = snapshot.average_total_time_seconds.max(f64::EPSILON);
-    vec![
-        (
-            "param".to_string(),
-            snapshot.average_parameterization_time_seconds / total * 100.0,
-            Color::Cyan,
-        ),
-        (
-            "integrand".to_string(),
-            snapshot.average_integrand_time_seconds / total * 100.0,
-            Color::Green,
-        ),
-        (
-            "evaluator".to_string(),
-            snapshot.average_evaluator_time_seconds / total * 100.0,
-            Color::Blue,
-        ),
-        (
-            "obs".to_string(),
-            snapshot.average_observable_time_seconds / total * 100.0,
-            Color::Magenta,
-        ),
-        (
-            "overhead".to_string(),
-            snapshot.average_integrator_time_seconds / total * 100.0,
-            Color::Yellow,
-        ),
-    ]
+fn discrete_sort_label(mode: ContributionSortMode) -> &'static str {
+    match mode {
+        ContributionSortMode::Index => "index",
+        ContributionSortMode::Integral => "integral",
+        ContributionSortMode::Error => "error",
+    }
 }
 
-fn precision_percentages(snapshot: &IntegrationStatisticsSnapshot) -> Vec<(String, f64, Color)> {
-    vec![
-        ("f64".to_string(), snapshot.f64_percentage, Color::Green),
-        ("f128".to_string(), snapshot.f128_percentage, Color::Blue),
-        ("arb".to_string(), snapshot.arb_percentage, Color::Yellow),
-    ]
+fn color_from_text_style(style: TextStyle) -> Option<Color> {
+    match style.color {
+        Some(TextColor::Green) => Some(Color::Green),
+        Some(TextColor::Blue) => Some(Color::Blue),
+        Some(TextColor::Red) => Some(Color::Red),
+        Some(TextColor::Yellow) => Some(Color::Yellow),
+        Some(TextColor::Pink) => Some(Color::LightMagenta),
+        None => None,
+    }
 }
 
-fn stability_percentages(snapshot: &IntegrationStatisticsSnapshot) -> Vec<(String, f64, Color)> {
-    let unstable = (snapshot.nan_or_unstable_percentage - snapshot.nan_percentage).max(0.0);
-    let stable = (100.0 - snapshot.nan_or_unstable_percentage).max(0.0);
-    vec![
-        ("stable".to_string(), stable, Color::Green),
-        ("unstable".to_string(), unstable, Color::Yellow),
-        ("nan".to_string(), snapshot.nan_percentage, Color::Red),
-    ]
+fn color_from_styled_text(text: &StyledText, fallback: Color) -> Color {
+    text.spans
+        .iter()
+        .find_map(|span| color_from_text_style(span.style))
+        .unwrap_or(fallback)
+}
+
+fn count_axis_labels(min: f64, max: f64) -> Vec<Span<'static>> {
+    evenly_spaced_values(min, max, 9)
+        .into_iter()
+        .map(|value| Span::raw(abbreviate_count(value.max(0.0).round() as usize)))
+        .collect()
+}
+
+fn value_axis_labels(min: f64, max: f64) -> Vec<Span<'static>> {
+    evenly_spaced_values(min, max, 9)
+        .into_iter()
+        .map(|value| Span::raw(format!("{value:.3e}")))
+        .collect()
+}
+
+fn evenly_spaced_values(min: f64, max: f64, count: usize) -> Vec<f64> {
+    if count <= 1 || !min.is_finite() || !max.is_finite() || (max - min).abs() < f64::EPSILON {
+        return vec![min];
+    }
+
+    let step = (max - min) / (count.saturating_sub(1) as f64);
+    (0..count).map(|index| min + step * index as f64).collect()
 }
 
 fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {

--- a/crates/gammalooprs/src/integrate/render_tabled.rs
+++ b/crates/gammalooprs/src/integrate/render_tabled.rs
@@ -5,8 +5,8 @@ use tabled::{
     builder::Builder,
     settings::{
         Alignment, Modify, Panel, Span,
-        object::{Cell, Rows},
-        style::Style,
+        object::{Cell, Columns, Object, Rows},
+        style::{HorizontalLine, Style},
         themes::BorderCorrection,
         width::Width,
     },
@@ -18,7 +18,7 @@ use super::{
     display::{StyledText, TextColor},
     status_update::{
         DiscreteMaxWeightDetailsSection, MainResultsRowGroupKind, MainResultsSection,
-        MaxWeightDetailsSection, StatusUpdate,
+        MaxWeightDetailsSection, StatisticsSection, StatusUpdate,
     },
 };
 
@@ -62,6 +62,8 @@ fn render_styled_text(text: &StyledText) -> String {
                 Some(TextColor::Green) => span.text.green(),
                 Some(TextColor::Blue) => span.text.blue(),
                 Some(TextColor::Red) => span.text.red(),
+                Some(TextColor::Yellow) => span.text.yellow(),
+                Some(TextColor::Pink) => span.text.bright_magenta(),
                 None => span.text.normal(),
             };
             if span.style.dimmed {
@@ -75,11 +77,25 @@ fn render_styled_text(text: &StyledText) -> String {
         .collect()
 }
 
+fn render_styled_text_single_line(text: &StyledText) -> String {
+    render_styled_text(text).replace('\n', " ")
+}
+
 fn maybe_render<T>(value: &Option<super::display::DisplayField<T>>) -> String {
     value
         .as_ref()
         .map(|value| render_styled_text(&value.display))
         .unwrap_or_default()
+}
+
+fn status_group_separator() -> tabled::settings::style::VerticalLine<
+    tabled::settings::style::On,
+    tabled::settings::style::On,
+    (),
+> {
+    tabled::settings::style::VerticalLine::new('│')
+        .top('┬')
+        .bottom('┴')
 }
 
 fn suppress_iteration_header_separators(
@@ -263,19 +279,19 @@ fn build_main_results_table(
     builder.push_record(first_row);
 
     let mut header_row = vec![
-        render_styled_text(&section.contribution_header),
+        render_styled_text_single_line(&section.contribution_header),
         String::new(),
     ];
     for slot_header in &section.slot_headers {
         header_row.push(render_styled_text(slot_header));
         header_row.extend(std::iter::repeat_n(String::new(), slot_block_width - 1));
     }
-    header_row.push("χ²/dof".blue().bold().to_string());
-    header_row.push("mwi".blue().bold().to_string());
-    if section.has_target_columns {
-        header_row.push("Δ [σ]".blue().bold().to_string());
-        header_row.push("Δ [%]".blue().bold().to_string());
-    }
+    header_row.extend(
+        section
+            .metadata_headers()
+            .into_iter()
+            .map(|header| render_styled_text(&header)),
+    );
     builder.push_record(header_row);
 
     for group in &visible_row_groups {
@@ -360,11 +376,12 @@ fn build_main_results_table(
 
 fn build_max_weight_details_table(section: &MaxWeightDetailsSection) -> StatusTable {
     let mut builder = Builder::new();
+    let headers = section.headers();
     builder.push_record([
-        "Integrand".blue().bold().to_string(),
-        String::new(),
-        "Max eval".blue().bold().to_string(),
-        "Max eval coordinates".blue().bold().to_string(),
+        render_styled_text(&headers[0]),
+        render_styled_text(&headers[1]),
+        render_styled_text(&headers[2]),
+        render_styled_text(&headers[3]),
     ]);
 
     for group in &section.rows_by_slot {
@@ -380,9 +397,7 @@ fn build_max_weight_details_table(section: &MaxWeightDetailsSection) -> StatusTa
 
     let mut table = builder.build();
     table.modify((0, 0), Span::column(2));
-    table.with(Panel::header(
-        "Maximum weight details".bold().green().to_string(),
-    ));
+    table.with(Panel::header(render_styled_text(&section.title())));
     table.with(Style::rounded().remove_horizontals());
     table.with(BorderCorrection::span());
     table.with(Modify::new(Rows::new(0..2)).with(Alignment::center()));
@@ -411,14 +426,12 @@ fn build_discrete_max_weight_details_table(
     section: &DiscreteMaxWeightDetailsSection,
 ) -> StatusTable {
     let mut builder = Builder::new();
-    let mut header = vec![
-        render_styled_text(&section.contribution_header),
-        String::new(),
-    ];
-    for slot_header in &section.slot_headers {
-        header.push(render_styled_text(slot_header));
-    }
-    header.push("Max eval coordinates".blue().bold().to_string());
+    let mut header = section
+        .summary_headers()
+        .iter()
+        .map(render_styled_text_single_line)
+        .collect_vec();
+    header.push(render_styled_text(&section.coordinates_header()));
     builder.push_record(header);
 
     for group in &section.row_groups {
@@ -451,12 +464,7 @@ fn build_discrete_max_weight_details_table(
 
     let mut table = builder.build();
     table.modify((0, 0), Span::column(2));
-    table.with(Panel::header(
-        "Maximum weight details by discrete bin"
-            .bold()
-            .green()
-            .to_string(),
-    ));
+    table.with(Panel::header(render_styled_text(&section.title())));
 
     let mut separator_rows = vec![1usize, 2usize];
     let mut row_offset = 1usize;
@@ -485,6 +493,57 @@ fn build_discrete_max_weight_details_table(
     }
 }
 
+fn build_statistics_table(section: &StatisticsSection) -> StatusTable {
+    let rows = section.table_rows();
+    let mut builder = Builder::new();
+    for row in &rows {
+        let mut record = vec![render_styled_text(&row.row_label)];
+        for entry in &row.entries {
+            record.push(render_styled_text(&entry.label));
+            record.push(render_styled_text(&entry.value));
+        }
+        builder.push_record(record);
+    }
+
+    let mut table = builder.build();
+    table.with(Panel::header(render_styled_text(&section.title())));
+    table.with(
+        Style::rounded()
+            .remove_horizontals()
+            .verticals([
+                (1, status_group_separator()),
+                (3, status_group_separator()),
+                (5, status_group_separator()),
+                (7, status_group_separator()),
+            ])
+            .horizontals([(
+                1,
+                HorizontalLine::new('─')
+                    .intersection('┬')
+                    .left('├')
+                    .right('┤'),
+            )])
+            .remove_vertical(),
+    );
+    table.with(BorderCorrection::span());
+    table.with(Modify::new(Rows::new(0..1)).with(Alignment::center()));
+    table.with(Modify::new(Rows::new(1..)).with(Alignment::left()));
+    for column in [1usize, 3, 5, 7] {
+        table.with(
+            Modify::new(Rows::new(1..).intersect(Columns::one(column))).with(Alignment::right()),
+        );
+    }
+
+    StatusTable {
+        table,
+        separator_after_rows: Vec::new(),
+        hidden_vertical_boundaries: Vec::new(),
+        full_row_vertical_count: 0,
+        suppress_header_middle_separator: false,
+        suppress_header_tail_separator: false,
+    }
+}
+
 pub(crate) fn render_status_update(update: &StatusUpdate, options: &TabledRenderOptions) -> String {
     let mut tables = vec![build_main_results_table(&update.main_results, options)];
     if options.show_max_weight_details
@@ -501,14 +560,7 @@ pub(crate) fn render_status_update(update: &StatusUpdate, options: &TabledRender
     if options.show_statistics
         && let Some(section) = update.statistics.as_ref()
     {
-        tables.push(StatusTable {
-            table: section.raw.build_status_table(),
-            separator_after_rows: Vec::new(),
-            hidden_vertical_boundaries: Vec::new(),
-            full_row_vertical_count: 0,
-            suppress_header_middle_separator: false,
-            suppress_header_tail_separator: false,
-        });
+        tables.push(build_statistics_table(section));
     }
 
     render_tables_with_shared_width(tables, options.max_table_width)

--- a/crates/gammalooprs/src/integrate/render_tabled.rs
+++ b/crates/gammalooprs/src/integrate/render_tabled.rs
@@ -17,19 +17,30 @@ use crate::utils::normalize_tabled_separator_rows;
 use super::{
     display::{StyledText, TextColor},
     status_update::{
-        DiscreteMaxWeightDetailsSection, MainResultsSection, MaxWeightDetailsSection, StatusUpdate,
+        DiscreteMaxWeightDetailsSection, MainResultsRowGroupKind, MainResultsSection,
+        MaxWeightDetailsSection, StatusUpdate,
     },
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TabledRenderOptions {
     pub max_table_width: usize,
+    pub show_statistics: bool,
+    pub show_max_weight_details: bool,
+    pub show_top_discrete_grid: bool,
+    pub show_discrete_contributions_sum: bool,
+    pub show_max_weight_info_for_discrete_bins: bool,
 }
 
 impl Default for TabledRenderOptions {
     fn default() -> Self {
         Self {
             max_table_width: 250,
+            show_statistics: true,
+            show_max_weight_details: true,
+            show_top_discrete_grid: false,
+            show_discrete_contributions_sum: false,
+            show_max_weight_info_for_discrete_bins: false,
         }
     }
 }
@@ -222,8 +233,22 @@ fn render_tables_with_shared_width(mut tables: Vec<StatusTable>, max_table_width
         .join("\n")
 }
 
-fn build_main_results_table(section: &MainResultsSection) -> StatusTable {
-    let slot_block_width = if section.show_discrete_columns { 5 } else { 2 };
+fn build_main_results_table(
+    section: &MainResultsSection,
+    options: &TabledRenderOptions,
+) -> StatusTable {
+    let visible_row_groups = section
+        .row_groups
+        .iter()
+        .filter(|group| match group.kind {
+            MainResultsRowGroupKind::All => true,
+            MainResultsRowGroupKind::Sum => options.show_discrete_contributions_sum,
+            MainResultsRowGroupKind::Bins => options.show_top_discrete_grid,
+        })
+        .collect_vec();
+    let show_discrete_columns = section.has_discrete_columns
+        && (options.show_top_discrete_grid || options.show_discrete_contributions_sum);
+    let slot_block_width = if show_discrete_columns { 5 } else { 2 };
     let metadata_columns = if section.has_target_columns { 4 } else { 2 };
     let n_columns = 2 + section.slot_headers.len() * slot_block_width + metadata_columns;
 
@@ -253,8 +278,8 @@ fn build_main_results_table(section: &MainResultsSection) -> StatusTable {
     }
     builder.push_record(header_row);
 
-    for group in &section.row_groups {
-        for row in group {
+    for group in &visible_row_groups {
+        for row in &group.rows {
             let mut record = vec![
                 render_styled_text(&row.contribution.display),
                 render_styled_text(&row.component.display),
@@ -262,7 +287,7 @@ fn build_main_results_table(section: &MainResultsSection) -> StatusTable {
             for slot_cells in &row.slot_cells {
                 record.push(maybe_render(&slot_cells.value));
                 record.push(maybe_render(&slot_cells.relative_error));
-                if section.show_discrete_columns {
+                if show_discrete_columns {
                     record.push(maybe_render(&slot_cells.sample_fraction));
                     record.push(maybe_render(&slot_cells.sample_count));
                     record.push(maybe_render(&slot_cells.target_pdf));
@@ -294,9 +319,9 @@ fn build_main_results_table(section: &MainResultsSection) -> StatusTable {
 
     let mut separator_rows = vec![1usize, 2usize];
     let mut row_offset = 2usize;
-    for (group_index, group) in section.row_groups.iter().enumerate() {
-        row_offset += group.len();
-        if group_index + 1 < section.row_groups.len() {
+    for (group_index, group) in visible_row_groups.iter().enumerate() {
+        row_offset += group.rows.len();
+        if group_index + 1 < visible_row_groups.len() {
             separator_rows.push(row_offset);
         }
     }
@@ -461,14 +486,21 @@ fn build_discrete_max_weight_details_table(
 }
 
 pub(crate) fn render_status_update(update: &StatusUpdate, options: &TabledRenderOptions) -> String {
-    let mut tables = vec![build_main_results_table(&update.main_results)];
-    if let Some(section) = update.max_weight_details.as_ref() {
+    let mut tables = vec![build_main_results_table(&update.main_results, options)];
+    if options.show_max_weight_details
+        && let Some(section) = update.max_weight_details.as_ref()
+    {
         tables.push(build_max_weight_details_table(section));
     }
-    if let Some(section) = update.discrete_max_weight_details.as_ref() {
+    if options.show_max_weight_details
+        && options.show_max_weight_info_for_discrete_bins
+        && let Some(section) = update.discrete_max_weight_details.as_ref()
+    {
         tables.push(build_discrete_max_weight_details_table(section));
     }
-    if let Some(section) = update.statistics.as_ref() {
+    if options.show_statistics
+        && let Some(section) = update.statistics.as_ref()
+    {
         tables.push(StatusTable {
             table: section.raw.build_status_table(),
             separator_after_rows: Vec::new(),

--- a/crates/gammalooprs/src/integrate/status_update.rs
+++ b/crates/gammalooprs/src/integrate/status_update.rs
@@ -5,7 +5,10 @@ use spenso::algebra::algebraic_traits::IsZero;
 use spenso::algebra::complex::Complex;
 use symbolica::numerical_integration::StatisticsAccumulator;
 
-use crate::{integrands::evaluation::StatisticsCounter, utils, utils::F};
+use crate::{
+    integrands::evaluation::StatisticsCounter, settings::runtime::IntegrationStatisticsSnapshot,
+    utils, utils::F,
+};
 
 use super::{
     ComplexAccumulator, DiscreteGridAccumulatorSummary, IntegrationState,
@@ -51,6 +54,8 @@ pub enum ContributionSortMode {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IntegrationStatusViewOptions {
     pub phase_display: IntegrationStatusPhaseDisplay,
+    pub training_phase_display: IntegrationStatusPhaseDisplay,
+    pub training_slot: usize,
     pub show_statistics: bool,
     pub show_max_weight_details: bool,
     pub show_top_discrete_grid: bool,
@@ -72,6 +77,20 @@ impl IntegrationStatusViewOptions {
 pub(crate) struct LiveIterationProgress {
     pub(crate) completed_points: usize,
     pub(crate) target_points: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct StatusMeta {
+    pub(crate) elapsed_time: Duration,
+    pub(crate) iteration_elapsed_time: Duration,
+    pub(crate) iteration: usize,
+    pub(crate) current_iteration_points: usize,
+    pub(crate) total_points: usize,
+    pub(crate) n_samples_evaluated: usize,
+    pub(crate) cores: usize,
+    pub(crate) training_slot: usize,
+    pub(crate) training_phase_display: IntegrationStatusPhaseDisplay,
+    pub(crate) live_progress: Option<LiveIterationProgress>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -117,6 +136,8 @@ pub(crate) enum ContributionKind {
 #[derive(Clone, Debug)]
 pub struct StatusUpdate {
     pub(crate) kind: IntegrationStatusKind,
+    pub(crate) meta: StatusMeta,
+    pub(crate) targets: Vec<Option<Complex<F<f64>>>>,
     pub(crate) main_results: MainResultsSection,
     pub(crate) max_weight_details: Option<MaxWeightDetailsSection>,
     pub(crate) discrete_max_weight_details: Option<DiscreteMaxWeightDetailsSection>,
@@ -127,6 +148,97 @@ impl StatusUpdate {
     pub fn kind(&self) -> IntegrationStatusKind {
         self.kind
     }
+
+    pub fn is_initial_live_status(&self) -> bool {
+        self.kind == IntegrationStatusKind::Live
+            && self
+                .meta
+                .live_progress
+                .is_some_and(|progress| progress.completed_points == 0)
+    }
+
+    pub(crate) fn training_component(&self) -> Option<ComponentKind> {
+        match self.meta.training_phase_display {
+            IntegrationStatusPhaseDisplay::Real => Some(ComponentKind::Real),
+            IntegrationStatusPhaseDisplay::Imag => Some(ComponentKind::Imag),
+            IntegrationStatusPhaseDisplay::Both => None,
+        }
+    }
+
+    pub(crate) fn statistics_snapshot(&self) -> Option<IntegrationStatisticsSnapshot> {
+        self.statistics.map(|section| section.raw.snapshot())
+    }
+
+    pub(crate) fn training_target(&self) -> Option<F<f64>> {
+        let component = self.training_component()?;
+        let target = self.targets.get(self.meta.training_slot)?.as_ref()?;
+        Some(match component {
+            ComponentKind::Real => target.re,
+            ComponentKind::Imag => target.im,
+        })
+    }
+}
+
+impl StatusMeta {
+    pub(crate) fn iteration_progress_ratio(self) -> Option<f64> {
+        self.live_progress.map(|progress| {
+            if progress.target_points == 0 {
+                0.0
+            } else {
+                progress.completed_points as f64 / progress.target_points as f64
+            }
+        })
+    }
+
+    pub(crate) fn iteration_eta(self) -> Option<Duration> {
+        let progress = self.live_progress?;
+        if progress.completed_points == 0 || self.iteration_elapsed_time.is_zero() {
+            return None;
+        }
+
+        let processed_per_second =
+            progress.completed_points as f64 / self.iteration_elapsed_time.as_secs_f64();
+        if processed_per_second <= 0.0 {
+            return None;
+        }
+
+        let remaining_points = progress
+            .target_points
+            .saturating_sub(progress.completed_points);
+        Some(utils::duration_from_secs_f64_saturating(
+            remaining_points as f64 / processed_per_second,
+        ))
+    }
+}
+
+impl MainResultsSection {
+    pub(crate) fn all_rows(&self) -> impl Iterator<Item = &MainResultsRow> {
+        self.row_groups.iter().flat_map(|group| group.rows.iter())
+    }
+
+    pub(crate) fn row_groups_of_kind(
+        &self,
+        kind: MainResultsRowGroupKind,
+    ) -> impl Iterator<Item = &MainResultsRowGroup> {
+        self.row_groups
+            .iter()
+            .filter(move |group| group.kind == kind)
+    }
+
+    pub(crate) fn find_row(
+        &self,
+        contribution: ContributionKind,
+        component: ComponentKind,
+    ) -> Option<&MainResultsRow> {
+        self.all_rows()
+            .find(|row| row.contribution.raw == contribution && row.component.raw == component)
+    }
+}
+
+impl MainResultsRow {
+    pub(crate) fn slot_cell(&self, slot_index: usize) -> Option<&MainTableSlotCells> {
+        self.slot_cells.get(slot_index)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -136,9 +248,22 @@ pub(crate) struct MainResultsSection {
     pub(crate) header_tail: StyledText,
     pub(crate) contribution_header: StyledText,
     pub(crate) slot_headers: Vec<StyledText>,
-    pub(crate) show_discrete_columns: bool,
+    pub(crate) has_discrete_columns: bool,
     pub(crate) has_target_columns: bool,
-    pub(crate) row_groups: Vec<Vec<MainResultsRow>>,
+    pub(crate) row_groups: Vec<MainResultsRowGroup>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MainResultsRowGroupKind {
+    All,
+    Sum,
+    Bins,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MainResultsRowGroup {
+    pub(crate) kind: MainResultsRowGroupKind,
+    pub(crate) rows: Vec<MainResultsRow>,
 }
 
 #[derive(Clone, Debug)]
@@ -156,6 +281,8 @@ pub(crate) struct MainResultsRow {
 pub(crate) struct MainTableSlotCells {
     pub(crate) value: Option<DisplayField<(F<f64>, F<f64>)>>,
     pub(crate) relative_error: Option<DisplayField<f64>>,
+    pub(crate) chi_sq: Option<DisplayField<f64>>,
+    pub(crate) max_weight_impact: Option<DisplayField<f64>>,
     pub(crate) sample_fraction: Option<DisplayField<f64>>,
     pub(crate) sample_count: Option<DisplayField<usize>>,
     pub(crate) target_pdf: Option<DisplayField<f64>>,
@@ -504,7 +631,7 @@ fn main_results_row(
     monitored_path: Option<&[usize]>,
     contribution: ContributionKind,
     component: ComponentKind,
-    show_discrete_columns: bool,
+    has_discrete_columns: bool,
 ) -> Option<MainResultsRow> {
     let slot_cells = integration_state
         .slot_metas
@@ -517,6 +644,8 @@ fn main_results_row(
                 Some(MainTableSlotCells {
                     value: Some(format_value_field(accumulator.avg, accumulator.err)),
                     relative_error: format_relative_error_field(accumulator),
+                    chi_sq: format_chi_sq_field(accumulator, integration_state.iter),
+                    max_weight_impact: format_mwi_field(accumulator),
                     sample_fraction: None,
                     sample_count: None,
                     target_pdf: None,
@@ -531,6 +660,8 @@ fn main_results_row(
                 Some(MainTableSlotCells {
                     value: Some(format_value_field(avg, err)),
                     relative_error: format_relative_error_field_from_estimate(avg, err),
+                    chi_sq: None,
+                    max_weight_impact: None,
                     sample_fraction: None,
                     sample_count: None,
                     target_pdf: None,
@@ -545,7 +676,7 @@ fn main_results_row(
                     })?;
                 let bin = summary.bins.get(bin_index)?;
                 let total_samples = total_processed_samples(summary);
-                let sample_fraction = if show_discrete_columns && total_samples > 0 {
+                let sample_fraction = if has_discrete_columns && total_samples > 0 {
                     let raw =
                         bin.accumulator.processed_samples as f64 / total_samples as f64 * 100.0;
                     Some(DisplayField::new(
@@ -558,7 +689,7 @@ fn main_results_row(
                 } else {
                     None
                 };
-                let sample_count = if show_discrete_columns {
+                let sample_count = if has_discrete_columns {
                     Some(DisplayField::new(
                         bin.accumulator.processed_samples,
                         styled_colored(
@@ -569,7 +700,7 @@ fn main_results_row(
                 } else {
                     None
                 };
-                let target_pdf = if show_discrete_columns {
+                let target_pdf = if has_discrete_columns {
                     slot_context
                         .as_ref()
                         .and_then(|ctx| ctx.pdfs.get(bin_index).copied())
@@ -585,6 +716,8 @@ fn main_results_row(
                 Some(MainTableSlotCells {
                     value: Some(format_value_field(bin.accumulator.avg, bin.accumulator.err)),
                     relative_error: format_relative_error_field(&bin.accumulator),
+                    chi_sq: format_chi_sq_field(&bin.accumulator, integration_state.iter),
+                    max_weight_impact: format_mwi_field(&bin.accumulator),
                     sample_fraction,
                     sample_count,
                     target_pdf,
@@ -684,13 +817,12 @@ fn build_main_results_section(
     let components = ComponentKind::all_for_display(render_options.phase_display);
     let discrete_context = integration_state.monitored_discrete_context();
     let monitored_path = integration_state.monitored_discrete_path.as_deref();
-    let show_discrete_columns = monitored_path.is_some()
-        && (render_options.show_top_discrete_grid
-            || render_options.show_discrete_contributions_sum);
+    let has_discrete_columns = monitored_path.is_some();
     let has_target_columns = targets.first().is_some_and(Option::is_some);
 
-    let mut row_groups = vec![
-        components
+    let mut row_groups = vec![MainResultsRowGroup {
+        kind: MainResultsRowGroupKind::All,
+        rows: components
             .iter()
             .filter_map(|component| {
                 main_results_row(
@@ -699,91 +831,96 @@ fn build_main_results_section(
                     monitored_path,
                     ContributionKind::All,
                     *component,
-                    show_discrete_columns,
+                    has_discrete_columns,
                 )
             })
             .collect_vec(),
-    ];
+    }];
 
     if let Some(discrete_context) = discrete_context.as_ref() {
-        if render_options.show_discrete_contributions_sum {
-            let sum_rows = components
-                .iter()
-                .filter_map(|component| {
-                    main_results_row(
-                        integration_state,
-                        targets,
-                        monitored_path,
-                        ContributionKind::Sum,
-                        *component,
-                        show_discrete_columns,
-                    )
-                })
-                .collect_vec();
-            if !sum_rows.is_empty() {
-                row_groups.push(sum_rows);
-            }
+        let sum_rows = components
+            .iter()
+            .filter_map(|component| {
+                main_results_row(
+                    integration_state,
+                    targets,
+                    monitored_path,
+                    ContributionKind::Sum,
+                    *component,
+                    has_discrete_columns,
+                )
+            })
+            .collect_vec();
+        if !sum_rows.is_empty() {
+            row_groups.push(MainResultsRowGroup {
+                kind: MainResultsRowGroupKind::Sum,
+                rows: sum_rows,
+            });
         }
 
-        if render_options.show_top_discrete_grid {
-            let bin_count = discrete_context.pdfs.len();
-            match render_options.contribution_sort {
-                ContributionSortMode::Index => {
-                    let mut rows = Vec::new();
-                    for bin_index in 0..bin_count {
-                        for component in &components {
-                            if let Some(row) = main_results_row(
+        let bin_count = discrete_context.pdfs.len();
+        match render_options.contribution_sort {
+            ContributionSortMode::Index => {
+                let mut rows = Vec::new();
+                for bin_index in 0..bin_count {
+                    for component in &components {
+                        if let Some(row) = main_results_row(
+                            integration_state,
+                            targets,
+                            monitored_path,
+                            ContributionKind::Bin(bin_index),
+                            *component,
+                            has_discrete_columns,
+                        ) {
+                            rows.push(row);
+                        }
+                    }
+                }
+                if !rows.is_empty() {
+                    row_groups.push(MainResultsRowGroup {
+                        kind: MainResultsRowGroupKind::Bins,
+                        rows,
+                    });
+                }
+            }
+            ContributionSortMode::Integral | ContributionSortMode::Error => {
+                for component in &components {
+                    let mut bin_indices = (0..bin_count).collect_vec();
+                    bin_indices.sort_by(|lhs, rhs| {
+                        discrete_sort_key(
+                            integration_state,
+                            &discrete_context.path,
+                            *component,
+                            *rhs,
+                            render_options.contribution_sort,
+                        )
+                        .partial_cmp(&discrete_sort_key(
+                            integration_state,
+                            &discrete_context.path,
+                            *component,
+                            *lhs,
+                            render_options.contribution_sort,
+                        ))
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                    });
+                    let rows = bin_indices
+                        .into_iter()
+                        .filter_map(|bin_index| {
+                            main_results_row(
                                 integration_state,
                                 targets,
                                 monitored_path,
                                 ContributionKind::Bin(bin_index),
                                 *component,
-                                show_discrete_columns,
-                            ) {
-                                rows.push(row);
-                            }
-                        }
-                    }
-                    if !rows.is_empty() {
-                        row_groups.push(rows);
-                    }
-                }
-                ContributionSortMode::Integral | ContributionSortMode::Error => {
-                    for component in &components {
-                        let mut bin_indices = (0..bin_count).collect_vec();
-                        bin_indices.sort_by(|lhs, rhs| {
-                            discrete_sort_key(
-                                integration_state,
-                                &discrete_context.path,
-                                *component,
-                                *rhs,
-                                render_options.contribution_sort,
+                                has_discrete_columns,
                             )
-                            .partial_cmp(&discrete_sort_key(
-                                integration_state,
-                                &discrete_context.path,
-                                *component,
-                                *lhs,
-                                render_options.contribution_sort,
-                            ))
-                            .unwrap_or(std::cmp::Ordering::Equal)
+                        })
+                        .collect_vec();
+                    if !rows.is_empty() {
+                        row_groups.push(MainResultsRowGroup {
+                            kind: MainResultsRowGroupKind::Bins,
+                            rows,
                         });
-                        let rows = bin_indices
-                            .into_iter()
-                            .filter_map(|bin_index| {
-                                main_results_row(
-                                    integration_state,
-                                    targets,
-                                    monitored_path,
-                                    ContributionKind::Bin(bin_index),
-                                    *component,
-                                    show_discrete_columns,
-                                )
-                            })
-                            .collect_vec();
-                        if !rows.is_empty() {
-                            row_groups.push(rows);
-                        }
                     }
                 }
             }
@@ -795,13 +932,13 @@ fn build_main_results_section(
         header_left: header_left(elapsed_time, integration_state.iter, live_progress),
         header_middle: header_middle(cur_points, total_points_display, live_progress),
         header_tail: header_tail(cores, elapsed_time, n_samples_evaluated),
-        contribution_header: contribution_header(integration_state, show_discrete_columns),
+        contribution_header: contribution_header(integration_state, has_discrete_columns),
         slot_headers: integration_state
             .slot_metas
             .iter()
             .map(|slot_meta| styled_colored(slot_meta.key(), TextStyle::blue().bold()))
             .collect(),
-        show_discrete_columns,
+        has_discrete_columns,
         has_target_columns,
         row_groups,
     }
@@ -1045,6 +1182,7 @@ pub(crate) fn build_status_update(
     integration_state: &IntegrationState,
     cores: usize,
     elapsed_time: Duration,
+    iteration_elapsed_time: Duration,
     cur_points: usize,
     total_points_display: usize,
     n_samples_evaluated: usize,
@@ -1054,6 +1192,19 @@ pub(crate) fn build_status_update(
 ) -> StatusUpdate {
     StatusUpdate {
         kind,
+        meta: StatusMeta {
+            elapsed_time,
+            iteration_elapsed_time,
+            iteration: integration_state.iter,
+            current_iteration_points: cur_points,
+            total_points: total_points_display,
+            n_samples_evaluated,
+            cores,
+            training_slot: render_options.training_slot,
+            training_phase_display: render_options.training_phase_display,
+            live_progress,
+        },
+        targets: targets.to_vec(),
         main_results: build_main_results_section(
             kind,
             integration_state,
@@ -1066,15 +1217,12 @@ pub(crate) fn build_status_update(
             render_options,
             live_progress,
         ),
-        max_weight_details: render_options
-            .show_max_weight_details
-            .then(|| build_max_weight_details_section(integration_state, render_options))
-            .flatten(),
-        discrete_max_weight_details: (render_options.show_max_weight_details
-            && render_options.show_max_weight_info_for_discrete_bins)
-            .then(|| build_discrete_max_weight_details_section(integration_state, render_options))
-            .flatten(),
-        statistics: render_options.show_statistics.then_some(StatisticsSection {
+        max_weight_details: build_max_weight_details_section(integration_state, render_options),
+        discrete_max_weight_details: build_discrete_max_weight_details_section(
+            integration_state,
+            render_options,
+        ),
+        statistics: Some(StatisticsSection {
             raw: integration_state.stats,
         }),
     }
@@ -1090,6 +1238,7 @@ pub(crate) fn build_saved_status_update(
         integration_state,
         integration_state.n_cores.max(1),
         utils::duration_from_secs_f64_saturating(integration_state.elapsed_seconds),
+        Duration::ZERO,
         0,
         integration_state.num_points,
         integration_state.num_points,

--- a/crates/gammalooprs/src/integrate/status_update.rs
+++ b/crates/gammalooprs/src/integrate/status_update.rs
@@ -51,13 +51,15 @@ pub enum ContributionSortMode {
     Error,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct IntegrationStatusViewOptions {
     pub phase_display: IntegrationStatusPhaseDisplay,
     pub training_phase_display: IntegrationStatusPhaseDisplay,
     pub training_slot: usize,
     pub slot_training_phase_displays: Vec<IntegrationStatusPhaseDisplay>,
     pub per_slot_training_phase: bool,
+    pub target_relative_accuracy: Option<f64>,
+    pub target_absolute_accuracy: Option<f64>,
     pub show_statistics: bool,
     pub show_max_weight_details: bool,
     pub show_top_discrete_grid: bool,
@@ -81,7 +83,7 @@ pub(crate) struct LiveIterationProgress {
     pub(crate) target_points: usize,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct StatusMeta {
     pub(crate) elapsed_time: Duration,
     pub(crate) iteration_elapsed_time: Duration,
@@ -93,6 +95,22 @@ pub(crate) struct StatusMeta {
     pub(crate) training_slot: usize,
     pub(crate) training_phase_display: IntegrationStatusPhaseDisplay,
     pub(crate) live_progress: Option<LiveIterationProgress>,
+    pub(crate) show_eta_to_target: bool,
+    pub(crate) eta_to_target_specification: Option<String>,
+    pub(crate) eta_to_target: Option<Duration>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct TargetAccuracyStatus {
+    pub(crate) relative_reached: bool,
+    pub(crate) absolute_reached: bool,
+    pub(crate) eta_to_target: Option<Duration>,
+}
+
+impl TargetAccuracyStatus {
+    pub(crate) fn is_reached(self) -> bool {
+        self.relative_reached || self.absolute_reached
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -102,6 +120,16 @@ pub(crate) enum ComponentKind {
 }
 
 impl ComponentKind {
+    pub(crate) fn from_training_phase_display(
+        display: IntegrationStatusPhaseDisplay,
+    ) -> Option<Self> {
+        match display {
+            IntegrationStatusPhaseDisplay::Real => Some(Self::Real),
+            IntegrationStatusPhaseDisplay::Imag => Some(Self::Imag),
+            IntegrationStatusPhaseDisplay::Both => None,
+        }
+    }
+
     pub(crate) fn all_for_display(display: IntegrationStatusPhaseDisplay) -> Vec<Self> {
         let mut components = Vec::new();
         if display.shows_real() {
@@ -177,11 +205,7 @@ impl StatusUpdate {
     }
 
     pub(crate) fn training_component(&self) -> Option<ComponentKind> {
-        match self.meta.training_phase_display {
-            IntegrationStatusPhaseDisplay::Real => Some(ComponentKind::Real),
-            IntegrationStatusPhaseDisplay::Imag => Some(ComponentKind::Imag),
-            IntegrationStatusPhaseDisplay::Both => None,
-        }
+        ComponentKind::from_training_phase_display(self.meta.training_phase_display)
     }
 
     pub(crate) fn statistics_snapshot(&self) -> Option<IntegrationStatisticsSnapshot> {
@@ -266,7 +290,7 @@ impl StatusUpdate {
 }
 
 impl StatusMeta {
-    pub(crate) fn iteration_progress_ratio(self) -> Option<f64> {
+    pub(crate) fn iteration_progress_ratio(&self) -> Option<f64> {
         self.live_progress.map(|progress| {
             if progress.target_points == 0 {
                 0.0
@@ -276,7 +300,7 @@ impl StatusMeta {
         })
     }
 
-    pub(crate) fn iteration_eta(self) -> Option<Duration> {
+    pub(crate) fn iteration_eta(&self) -> Option<Duration> {
         let progress = self.live_progress?;
         if progress.completed_points == 0 || self.iteration_elapsed_time.is_zero() {
             return None;
@@ -296,14 +320,14 @@ impl StatusMeta {
         ))
     }
 
-    pub(crate) fn total_sample_rate_per_second(self) -> Option<f64> {
+    pub(crate) fn total_sample_rate_per_second(&self) -> Option<f64> {
         if self.total_points == 0 || self.elapsed_time.is_zero() {
             return None;
         }
         Some(self.total_points as f64 / self.elapsed_time.as_secs_f64())
     }
 
-    pub(crate) fn sample_core_time(self) -> Option<String> {
+    pub(crate) fn sample_core_time(&self) -> Option<String> {
         if self.n_samples_evaluated == 0 {
             return None;
         }
@@ -312,6 +336,78 @@ impl StatusMeta {
             self.elapsed_time.as_secs_f64() / (self.n_samples_evaluated as f64)
                 * (self.cores as f64),
         ))
+    }
+
+    pub(crate) fn eta_to_target(&self) -> Option<Duration> {
+        self.eta_to_target
+    }
+
+    pub(crate) fn eta_to_target_specification(&self) -> Option<&str> {
+        self.eta_to_target_specification.as_deref()
+    }
+}
+
+pub(crate) fn evaluate_target_accuracy(
+    integration_state: &IntegrationState,
+    total_points: usize,
+    elapsed_time: Duration,
+    targets: &[Option<Complex<F<f64>>>],
+    training_phase_display: IntegrationStatusPhaseDisplay,
+    target_relative_accuracy: Option<f64>,
+    target_absolute_accuracy: Option<f64>,
+) -> TargetAccuracyStatus {
+    if target_relative_accuracy.is_none() && target_absolute_accuracy.is_none() {
+        return TargetAccuracyStatus::default();
+    }
+    if total_points == 0 {
+        return TargetAccuracyStatus::default();
+    }
+
+    let Some(component) = ComponentKind::from_training_phase_display(training_phase_display) else {
+        return TargetAccuracyStatus::default();
+    };
+    let Some(accumulator) = integration_state.all_integrals.first() else {
+        return TargetAccuracyStatus::default();
+    };
+    let (avg, err) = match component {
+        ComponentKind::Real => (accumulator.re.avg.0, accumulator.re.err.0),
+        ComponentKind::Imag => (accumulator.im.avg.0, accumulator.im.err.0),
+    };
+
+    let absolute_target_error = target_absolute_accuracy.filter(|target| *target >= 0.0);
+    let relative_target_error = target_relative_accuracy
+        .filter(|target| *target >= 0.0)
+        .and_then(|target_accuracy| {
+            let reference = targets
+                .first()
+                .and_then(|target| target.as_ref())
+                .map(|target| match component {
+                    ComponentKind::Real => target.re.0,
+                    ComponentKind::Imag => target.im.0,
+                })
+                .unwrap_or(avg)
+                .abs();
+            if reference == 0.0 {
+                None
+            } else {
+                Some(target_accuracy * reference)
+            }
+        });
+
+    let absolute_reached = absolute_target_error.is_some_and(|target_error| err <= target_error);
+    let relative_reached = relative_target_error.is_some_and(|target_error| err <= target_error);
+    let eta_to_target = [
+        estimate_eta_to_target(total_points, elapsed_time, err, absolute_target_error),
+        estimate_eta_to_target(total_points, elapsed_time, err, relative_target_error),
+    ]
+    .into_iter()
+    .flatten()
+    .min();
+
+    TargetAccuracyStatus {
+        relative_reached,
+        absolute_reached,
+        eta_to_target,
     }
 }
 
@@ -796,12 +892,70 @@ fn normalize_mix_segments(segments: Vec<(StyledText, f64)>) -> Vec<StatisticsMix
         .collect()
 }
 
+fn estimate_eta_to_target(
+    total_points: usize,
+    elapsed_time: Duration,
+    current_error: f64,
+    target_error: Option<f64>,
+) -> Option<Duration> {
+    let target_error = target_error?;
+    if target_error < 0.0 {
+        return None;
+    }
+    if current_error <= target_error {
+        return Some(Duration::ZERO);
+    }
+    if total_points == 0 || elapsed_time.is_zero() || current_error <= 0.0 || target_error == 0.0 {
+        return None;
+    }
+
+    let rate_per_second = total_points as f64 / elapsed_time.as_secs_f64();
+    if rate_per_second <= 0.0 {
+        return None;
+    }
+
+    let target_points = total_points as f64 * (current_error / target_error).powi(2);
+    let remaining_points = (target_points - total_points as f64).max(0.0);
+    Some(utils::duration_from_secs_f64_saturating(
+        remaining_points / rate_per_second,
+    ))
+}
+
 fn styled_plain(text: impl Into<String>) -> StyledText {
     StyledText::plain(text)
 }
 
 fn styled_colored(text: impl Into<String>, style: TextStyle) -> StyledText {
     StyledText::styled(text, style)
+}
+
+fn format_eta_to_target_specification(
+    target_relative_accuracy: Option<f64>,
+    target_absolute_accuracy: Option<f64>,
+) -> Option<String> {
+    let relative_spec = target_relative_accuracy
+        .filter(|target| *target >= 0.0)
+        .map(|target| {
+            format!(
+                "% err <= {}",
+                format_percentage_target_value_for_display(target * 100.0)
+            )
+        });
+    let absolute_spec = target_absolute_accuracy
+        .filter(|target| *target >= 0.0)
+        .map(|target| {
+            format!(
+                "err <= {}",
+                format_positive_target_value_for_display(target)
+            )
+        });
+
+    match (relative_spec, absolute_spec) {
+        (Some(relative), Some(absolute)) => Some(format!("{relative} or {absolute}")),
+        (Some(relative), None) => Some(relative),
+        (None, Some(absolute)) => Some(absolute),
+        (None, None) => None,
+    }
 }
 
 fn format_target_value_for_display(value: f64) -> String {
@@ -843,6 +997,48 @@ fn ordered_f64_bits(value: f64) -> u64 {
         !bits
     } else {
         bits | (1_u64 << 63)
+    }
+}
+
+fn format_positive_target_value_for_display(value: f64) -> String {
+    format_target_value_for_display(value)
+        .trim_start_matches('+')
+        .to_string()
+}
+
+fn format_percentage_target_value_for_display(value: f64) -> String {
+    let formatted = if value.abs() <= 1.0e-4 {
+        format_positive_target_value_for_display(value)
+    } else {
+        format_fixed_target_value_for_display(value)
+    };
+    format!("{formatted}%")
+}
+
+fn format_fixed_target_value_for_display(value: f64) -> String {
+    if value == 0.0 {
+        return String::from("0");
+    }
+
+    for precision in 0..=16 {
+        let candidate = normalize_fixed_decimal(&format!("{value:.precision$}"));
+        let Ok(parsed) = candidate.parse::<f64>() else {
+            continue;
+        };
+        if ulp_distance(parsed, value) <= 8 {
+            return candidate;
+        }
+    }
+
+    format_positive_target_value_for_display(value)
+}
+
+fn normalize_fixed_decimal(formatted: &str) -> String {
+    let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
+    if trimmed.is_empty() || trimmed == "-0" {
+        String::from("0")
+    } else {
+        trimmed.to_string()
     }
 }
 
@@ -1682,6 +1878,15 @@ pub(crate) fn build_status_update(
     render_options: &IntegrationStatusViewOptions,
     live_progress: Option<LiveIterationProgress>,
 ) -> StatusUpdate {
+    let target_accuracy_status = evaluate_target_accuracy(
+        integration_state,
+        total_points_display,
+        elapsed_time,
+        targets,
+        render_options.training_phase_display,
+        render_options.target_relative_accuracy,
+        render_options.target_absolute_accuracy,
+    );
     StatusUpdate {
         kind,
         meta: StatusMeta {
@@ -1695,6 +1900,13 @@ pub(crate) fn build_status_update(
             training_slot: render_options.training_slot,
             training_phase_display: render_options.training_phase_display,
             live_progress,
+            show_eta_to_target: render_options.target_relative_accuracy.is_some()
+                || render_options.target_absolute_accuracy.is_some(),
+            eta_to_target_specification: format_eta_to_target_specification(
+                render_options.target_relative_accuracy,
+                render_options.target_absolute_accuracy,
+            ),
+            eta_to_target: target_accuracy_status.eta_to_target,
         },
         targets: targets.to_vec(),
         slot_training_phase_displays: render_options.slot_training_phase_displays.clone(),

--- a/crates/gammalooprs/src/integrate/status_update.rs
+++ b/crates/gammalooprs/src/integrate/status_update.rs
@@ -51,11 +51,13 @@ pub enum ContributionSortMode {
     Error,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IntegrationStatusViewOptions {
     pub phase_display: IntegrationStatusPhaseDisplay,
     pub training_phase_display: IntegrationStatusPhaseDisplay,
     pub training_slot: usize,
+    pub slot_training_phase_displays: Vec<IntegrationStatusPhaseDisplay>,
+    pub per_slot_training_phase: bool,
     pub show_statistics: bool,
     pub show_max_weight_details: bool,
     pub show_top_discrete_grid: bool,
@@ -118,11 +120,26 @@ impl ComponentKind {
         }
     }
 
+    pub(crate) fn phase_name(self) -> &'static str {
+        match self {
+            Self::Real => "real",
+            Self::Imag => "imag",
+        }
+    }
+
+    pub(crate) fn text_style(self) -> TextStyle {
+        match self {
+            Self::Real => TextStyle::pink().bold(),
+            Self::Imag => TextStyle::yellow().bold(),
+        }
+    }
+
+    pub(crate) fn label_display(self) -> StyledText {
+        StyledText::styled(self.tag(), self.text_style())
+    }
+
     fn display_field(self) -> DisplayField<Self> {
-        DisplayField::new(
-            self,
-            StyledText::styled(self.tag(), TextStyle::blue().bold()),
-        )
+        DisplayField::new(self, self.label_display())
     }
 }
 
@@ -138,6 +155,8 @@ pub struct StatusUpdate {
     pub(crate) kind: IntegrationStatusKind,
     pub(crate) meta: StatusMeta,
     pub(crate) targets: Vec<Option<Complex<F<f64>>>>,
+    pub(crate) slot_training_phase_displays: Vec<IntegrationStatusPhaseDisplay>,
+    pub(crate) per_slot_training_phase: bool,
     pub(crate) main_results: MainResultsSection,
     pub(crate) max_weight_details: Option<MaxWeightDetailsSection>,
     pub(crate) discrete_max_weight_details: Option<DiscreteMaxWeightDetailsSection>,
@@ -170,12 +189,79 @@ impl StatusUpdate {
     }
 
     pub(crate) fn training_target(&self) -> Option<F<f64>> {
+        self.target_for_slot(self.meta.training_slot)
+    }
+
+    pub(crate) fn target_for_slot(&self, slot_index: usize) -> Option<F<f64>> {
         let component = self.training_component()?;
-        let target = self.targets.get(self.meta.training_slot)?.as_ref()?;
+        self.target_for_slot_component(slot_index, component)
+    }
+
+    pub(crate) fn target_for_slot_component(
+        &self,
+        slot_index: usize,
+        component: ComponentKind,
+    ) -> Option<F<f64>> {
+        let target = self.targets.get(slot_index)?.as_ref()?;
         Some(match component {
             ComponentKind::Real => target.re,
             ComponentKind::Imag => target.im,
         })
+    }
+
+    pub(crate) fn target_display_for_slot_component(
+        &self,
+        slot_index: usize,
+        component: ComponentKind,
+    ) -> Option<StyledText> {
+        self.target_for_slot_component(slot_index, component)
+            .map(|value| {
+                StyledText::styled(
+                    format_target_value_for_display(value.0),
+                    TextStyle::blue().bold(),
+                )
+            })
+    }
+
+    pub(crate) fn training_component_for_slot(&self, slot_index: usize) -> Option<ComponentKind> {
+        let phase = if self.per_slot_training_phase {
+            self.slot_training_phase_displays
+                .get(slot_index)
+                .copied()
+                .unwrap_or(self.meta.training_phase_display)
+        } else if slot_index == self.meta.training_slot {
+            self.meta.training_phase_display
+        } else {
+            return None;
+        };
+        match phase {
+            IntegrationStatusPhaseDisplay::Real => Some(ComponentKind::Real),
+            IntegrationStatusPhaseDisplay::Imag => Some(ComponentKind::Imag),
+            IntegrationStatusPhaseDisplay::Both => None,
+        }
+    }
+
+    pub(crate) fn slot_component_selected_for_training(
+        &self,
+        slot_index: usize,
+        component: ComponentKind,
+    ) -> bool {
+        self.training_component_for_slot(slot_index) == Some(component)
+    }
+
+    pub(crate) fn target_deltas_for_row_slot(
+        &self,
+        row: &MainResultsRow,
+        slot_index: usize,
+    ) -> (Option<DisplayField<f64>>, Option<DisplayField<f64>>) {
+        let Some(cell) = row.slot_cell(slot_index) else {
+            return (None, None);
+        };
+        let Some(value) = cell.value.as_ref() else {
+            return (None, None);
+        };
+        let target = self.target_for_slot_component(slot_index, row.component.raw);
+        format_delta_fields_from_estimate(value.raw.0, value.raw.1, target)
     }
 }
 
@@ -209,6 +295,24 @@ impl StatusMeta {
             remaining_points as f64 / processed_per_second,
         ))
     }
+
+    pub(crate) fn total_sample_rate_per_second(self) -> Option<f64> {
+        if self.total_points == 0 || self.elapsed_time.is_zero() {
+            return None;
+        }
+        Some(self.total_points as f64 / self.elapsed_time.as_secs_f64())
+    }
+
+    pub(crate) fn sample_core_time(self) -> Option<String> {
+        if self.n_samples_evaluated == 0 {
+            return None;
+        }
+
+        Some(utils::format_evaluation_time_from_f64(
+            self.elapsed_time.as_secs_f64() / (self.n_samples_evaluated as f64)
+                * (self.cores as f64),
+        ))
+    }
 }
 
 impl MainResultsSection {
@@ -233,11 +337,295 @@ impl MainResultsSection {
         self.all_rows()
             .find(|row| row.contribution.raw == contribution && row.component.raw == component)
     }
+
+    pub(crate) fn metadata_headers(&self) -> Vec<StyledText> {
+        let mut headers = vec![
+            styled_colored("χ²/dof", TextStyle::blue().bold()),
+            styled_colored("mwi", TextStyle::blue().bold()),
+        ];
+        if self.has_target_columns {
+            headers.push(styled_colored("Δ [σ]", TextStyle::blue().bold()));
+            headers.push(styled_colored("Δ [%]", TextStyle::blue().bold()));
+        }
+        headers
+    }
+
+    pub(crate) fn component_header(&self) -> StyledText {
+        styled_plain("")
+    }
+
+    pub(crate) fn summary_headers(&self) -> Vec<StyledText> {
+        let mut headers = vec![self.contribution_header.clone(), self.component_header()];
+        headers.extend(self.slot_headers.iter().cloned());
+        headers
+    }
+
+    pub(crate) fn discrete_headers(&self) -> Vec<StyledText> {
+        vec![
+            self.contribution_header.clone(),
+            self.component_header(),
+            styled_plain("integral"),
+            styled_plain("% err"),
+            styled_plain("χ^2"),
+            styled_plain("m.w.i"),
+            styled_plain("sample %"),
+            styled_plain("# samples"),
+            styled_plain("pdf"),
+        ]
+    }
+
+    pub(crate) fn selected_bin_detail_headers(&self) -> Vec<StyledText> {
+        vec![
+            styled_plain("Integrand"),
+            styled_plain("integral"),
+            styled_plain("% err"),
+            styled_plain("χ^2"),
+            styled_plain("m.w.i"),
+            styled_plain("sample %"),
+            styled_plain("# samples"),
+            styled_plain("pdf"),
+        ]
+    }
 }
 
 impl MainResultsRow {
     pub(crate) fn slot_cell(&self, slot_index: usize) -> Option<&MainTableSlotCells> {
         self.slot_cells.get(slot_index)
+    }
+}
+
+impl MaxWeightDetailsSection {
+    pub(crate) fn title(&self) -> StyledText {
+        styled_colored("Maximum weight details", TextStyle::green().bold())
+    }
+
+    pub(crate) fn headers(&self) -> Vec<StyledText> {
+        vec![
+            styled_colored("Integrand", TextStyle::blue().bold()),
+            styled_plain(""),
+            styled_colored("Max eval", TextStyle::blue().bold()),
+            styled_colored("Max eval coordinates", TextStyle::blue().bold()),
+        ]
+    }
+}
+
+impl DiscreteMaxWeightDetailsSection {
+    pub(crate) fn title(&self) -> StyledText {
+        styled_colored(
+            "Maximum weight details by discrete bin",
+            TextStyle::green().bold(),
+        )
+    }
+
+    pub(crate) fn summary_headers(&self) -> Vec<StyledText> {
+        let mut headers = vec![self.contribution_header.clone(), styled_plain("")];
+        headers.extend(self.slot_headers.iter().cloned());
+        headers
+    }
+
+    pub(crate) fn coordinates_header(&self) -> StyledText {
+        styled_colored("Max eval coordinates", TextStyle::blue().bold())
+    }
+
+    pub(crate) fn coordinate_headers(&self) -> Vec<StyledText> {
+        vec![
+            self.contribution_header.clone(),
+            styled_plain(""),
+            styled_plain("Integrand"),
+            self.coordinates_header(),
+        ]
+    }
+}
+
+impl StatisticsSection {
+    pub(crate) fn title(&self) -> StyledText {
+        styled_colored("Integration statistics", TextStyle::green().bold())
+    }
+
+    pub(crate) fn table_rows(&self) -> Vec<StatisticsTableRow> {
+        let snapshot = self.raw.snapshot();
+        vec![
+            StatisticsTableRow {
+                row_label: styled_colored("  timing", TextStyle::blue().bold()),
+                entries: vec![
+                    StatisticsTableEntry {
+                        label: styled_plain("total"),
+                        value: styled_colored(
+                            utils::format_evaluation_time_from_f64(
+                                snapshot.average_total_time_seconds,
+                            ),
+                            TextStyle::green(),
+                        ),
+                    },
+                    StatisticsTableEntry {
+                        label: styled_plain("param"),
+                        value: styled_colored(
+                            utils::format_evaluation_time_from_f64(
+                                snapshot.average_parameterization_time_seconds,
+                            ),
+                            TextStyle::green(),
+                        ),
+                    },
+                    StatisticsTableEntry {
+                        label: styled_plain("itg"),
+                        value: styled_colored(
+                            utils::format_evaluation_time_from_f64(
+                                snapshot.average_integrand_time_seconds,
+                            ),
+                            TextStyle::green(),
+                        ),
+                    },
+                    StatisticsTableEntry {
+                        label: styled_plain("evaluators"),
+                        value: styled_colored(
+                            utils::format_evaluation_time_from_f64(
+                                snapshot.average_evaluator_time_seconds,
+                            ),
+                            TextStyle::green(),
+                        ),
+                    },
+                ],
+            },
+            StatisticsTableRow {
+                row_label: styled_colored("  evals", TextStyle::blue().bold()),
+                entries: vec![
+                    StatisticsTableEntry {
+                        label: styled_plain("f64"),
+                        value: styled_colored(
+                            format!("{:.2}%", snapshot.f64_percentage),
+                            TextStyle::green(),
+                        ),
+                    },
+                    StatisticsTableEntry {
+                        label: styled_plain("f128"),
+                        value: styled_colored(
+                            format!("{:.2}%", snapshot.f128_percentage),
+                            TextStyle::blue(),
+                        ),
+                    },
+                    StatisticsTableEntry {
+                        label: styled_plain("arb"),
+                        value: styled_plain(format!("{:.2}%", snapshot.arb_percentage)),
+                    },
+                    StatisticsTableEntry {
+                        label: styled_plain("nans+unstable"),
+                        value: styled_colored(
+                            format!("{:.2}%", snapshot.nan_or_unstable_percentage),
+                            if snapshot.nan_or_unstable_percentage > 0.0 {
+                                TextStyle::red()
+                            } else {
+                                TextStyle::green()
+                            },
+                        ),
+                    },
+                ],
+            },
+            StatisticsTableRow {
+                row_label: styled_colored("  events", TextStyle::blue().bold()),
+                entries: vec![
+                    StatisticsTableEntry {
+                        label: styled_plain("evts #"),
+                        value: styled_colored(
+                            format_abbreviated_count(snapshot.generated_event_count),
+                            TextStyle::green(),
+                        ),
+                    },
+                    StatisticsTableEntry {
+                        label: styled_plain("sel. %"),
+                        value: snapshot
+                            .selection_efficiency_percentage
+                            .map(|value| styled_colored(format!("{value:.2}%"), TextStyle::green()))
+                            .unwrap_or_else(|| styled_plain("N/A")),
+                    },
+                    StatisticsTableEntry {
+                        label: styled_plain("obs"),
+                        value: styled_colored(
+                            utils::format_evaluation_time_from_f64(
+                                snapshot.average_observable_time_seconds,
+                            ),
+                            TextStyle::green(),
+                        ),
+                    },
+                    StatisticsTableEntry {
+                        label: styled_plain("integrator"),
+                        value: styled_colored(
+                            utils::format_evaluation_time_from_f64(
+                                snapshot.average_integrator_time_seconds,
+                            ),
+                            TextStyle::green(),
+                        ),
+                    },
+                ],
+            },
+        ]
+    }
+
+    pub(crate) fn timing_mix_segments(&self) -> Vec<StatisticsMixSegment> {
+        let snapshot = self.raw.snapshot();
+        let parameterization = snapshot.average_parameterization_time_seconds.max(0.0);
+        let evaluator = snapshot.average_evaluator_time_seconds.max(0.0);
+        let observable = snapshot.average_observable_time_seconds.max(0.0);
+        let integrand_core =
+            (snapshot.average_integrand_time_seconds.max(0.0) - observable - evaluator).max(0.0);
+        let integrator = snapshot.average_integrator_time_seconds.max(0.0);
+        let mut segments = normalize_mix_segments(vec![
+            (
+                styled_colored("evaluators", TextStyle::green().bold()),
+                evaluator,
+            ),
+            (
+                styled_colored("itg_core", TextStyle::blue().bold()),
+                integrand_core,
+            ),
+            (
+                styled_colored("obs", TextStyle::yellow().bold()),
+                observable,
+            ),
+            (
+                styled_colored("param", TextStyle::red().bold()),
+                parameterization,
+            ),
+            (styled_plain("integrator"), integrator),
+        ]);
+        segments.sort_by(|lhs, rhs| {
+            rhs.percentage
+                .partial_cmp(&lhs.percentage)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        segments
+    }
+
+    pub(crate) fn precision_mix_segments(&self) -> Vec<StatisticsMixSegment> {
+        let snapshot = self.raw.snapshot();
+        normalize_mix_segments(vec![
+            (
+                styled_colored("f64", TextStyle::green()),
+                snapshot.f64_percentage,
+            ),
+            (
+                styled_colored("f128", TextStyle::blue()),
+                snapshot.f128_percentage,
+            ),
+            (styled_plain("arb"), snapshot.arb_percentage),
+            (
+                styled_colored("unstbl.+nan.", TextStyle::red()),
+                snapshot.nan_or_unstable_percentage,
+            ),
+        ])
+    }
+
+    pub(crate) fn stability_mix_segments(&self) -> Vec<StatisticsMixSegment> {
+        let snapshot = self.raw.snapshot();
+        let unstable = (snapshot.nan_or_unstable_percentage - snapshot.nan_percentage).max(0.0);
+        let stable = (100.0 - snapshot.nan_or_unstable_percentage).max(0.0);
+        normalize_mix_segments(vec![
+            (styled_colored("stable", TextStyle::green()), stable),
+            (styled_colored("unstable", TextStyle::red()), unstable),
+            (
+                styled_colored("nan", TextStyle::red()),
+                snapshot.nan_percentage,
+            ),
+        ])
     }
 }
 
@@ -327,6 +715,24 @@ pub(crate) struct StatisticsSection {
     pub(crate) raw: StatisticsCounter,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct StatisticsTableRow {
+    pub(crate) row_label: StyledText,
+    pub(crate) entries: Vec<StatisticsTableEntry>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct StatisticsTableEntry {
+    pub(crate) label: StyledText,
+    pub(crate) value: StyledText,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct StatisticsMixSegment {
+    pub(crate) label: StyledText,
+    pub(crate) percentage: f64,
+}
+
 fn component_accumulator(
     accumulator: &ComplexAccumulator,
     component: ComponentKind,
@@ -369,6 +775,27 @@ fn total_processed_samples(summary: &DiscreteGridAccumulatorSummary) -> usize {
         .sum()
 }
 
+fn normalize_mix_segments(segments: Vec<(StyledText, f64)>) -> Vec<StatisticsMixSegment> {
+    let total: f64 = segments.iter().map(|(_, value)| value.max(0.0)).sum();
+    if total <= f64::EPSILON {
+        return segments
+            .into_iter()
+            .map(|(label, _)| StatisticsMixSegment {
+                label,
+                percentage: 0.0,
+            })
+            .collect();
+    }
+
+    segments
+        .into_iter()
+        .map(|(label, value)| StatisticsMixSegment {
+            label,
+            percentage: value.max(0.0) / total * 100.0,
+        })
+        .collect()
+}
+
 fn styled_plain(text: impl Into<String>) -> StyledText {
     StyledText::plain(text)
 }
@@ -377,14 +804,78 @@ fn styled_colored(text: impl Into<String>, style: TextStyle) -> StyledText {
     StyledText::styled(text, style)
 }
 
+fn format_target_value_for_display(value: f64) -> String {
+    if value == 0.0 {
+        return String::from("+0e0");
+    }
+
+    for precision in 0..=16 {
+        let candidate = normalize_scientific_exponent(&format!("{:+.*e}", precision, value));
+        let Ok(parsed) = candidate.parse::<f64>() else {
+            continue;
+        };
+        if ulp_distance(parsed, value) <= 8 {
+            return candidate;
+        }
+    }
+
+    normalize_scientific_exponent(&format!("{:+.16e}", value))
+}
+
+fn normalize_scientific_exponent(formatted: &str) -> String {
+    let Some((mantissa, exponent)) = formatted.rsplit_once('e') else {
+        return formatted.to_string();
+    };
+    let exponent = exponent.parse::<i32>().unwrap_or_default();
+    format!("{mantissa}e{exponent:+}")
+}
+
+fn ulp_distance(lhs: f64, rhs: f64) -> u64 {
+    if lhs.is_nan() || rhs.is_nan() {
+        return u64::MAX;
+    }
+    ordered_f64_bits(lhs).abs_diff(ordered_f64_bits(rhs))
+}
+
+fn ordered_f64_bits(value: f64) -> u64 {
+    let bits = value.to_bits();
+    if (bits >> 63) != 0 {
+        !bits
+    } else {
+        bits | (1_u64 << 63)
+    }
+}
+
 fn format_value_field(avg: F<f64>, err: F<f64>) -> DisplayField<(F<f64>, F<f64>)> {
-    DisplayField::new(
-        (avg, err),
-        styled_colored(
-            format_signed_uncertainty(avg, err, UncertaintyNotation::Scientific),
-            TextStyle::blue().bold(),
-        ),
-    )
+    let formatted = format_signed_uncertainty(avg, err, UncertaintyNotation::Scientific);
+    let uncertainty_style = format_relative_error_field_from_estimate(avg, err)
+        .map(|field| {
+            field
+                .display
+                .spans
+                .first()
+                .map(|span| span.style)
+                .unwrap_or(TextStyle::PLAIN)
+                .bold()
+        })
+        .unwrap_or(TextStyle::PLAIN.bold());
+
+    let display = if let Some(start) = formatted.find('(') {
+        if let Some(end_offset) = formatted[start..].find(')') {
+            let end = start + end_offset + 1;
+            let mut styled = StyledText::new();
+            styled.push_text(&formatted[..start], TextStyle::blue().bold());
+            styled.push_text(&formatted[start..end], uncertainty_style);
+            styled.push_text(&formatted[end..], TextStyle::blue().bold());
+            styled
+        } else {
+            styled_colored(formatted, TextStyle::blue().bold())
+        }
+    } else {
+        styled_colored(formatted, TextStyle::blue().bold())
+    };
+
+    DisplayField::new((avg, err), display)
 }
 
 fn format_relative_error_field_from_estimate(
@@ -536,10 +1027,11 @@ fn contribution_header(
             .first_non_trivial_discrete_label
             .as_deref()
     {
-        return styled_colored(
-            format!("Contribution (idx={label})"),
-            TextStyle::blue().bold(),
-        );
+        let mut header = StyledText::styled("Contribution", TextStyle::blue().bold());
+        header.push_text("\n(idx=", TextStyle::PLAIN);
+        header.push_text(label, TextStyle::blue().bold());
+        header.push_text(")", TextStyle::PLAIN);
+        return header;
     }
 
     styled_colored("Contribution", TextStyle::blue().bold())
@@ -965,7 +1457,7 @@ fn styled_component_sign(
     positive: bool,
 ) -> DisplayField<(ComponentKind, bool)> {
     let mut display = StyledText::new();
-    display.push_text(component.tag(), TextStyle::blue().bold());
+    display.append(component.label_display());
     display.push_text(" [", TextStyle::PLAIN);
     display.push_text(sign, TextStyle::blue());
     display.push_text("]", TextStyle::PLAIN);
@@ -1205,6 +1697,8 @@ pub(crate) fn build_status_update(
             live_progress,
         },
         targets: targets.to_vec(),
+        slot_training_phase_displays: render_options.slot_training_phase_displays.clone(),
+        per_slot_training_phase: render_options.per_slot_training_phase,
         main_results: build_main_results_section(
             kind,
             integration_state,
@@ -1243,7 +1737,7 @@ pub(crate) fn build_saved_status_update(
         integration_state.num_points,
         integration_state.num_points,
         targets,
-        &render_options.for_final(),
+        &render_options.clone().for_final(),
         None,
     )
 }

--- a/crates/gammalooprs/src/integrate/status_update.rs
+++ b/crates/gammalooprs/src/integrate/status_update.rs
@@ -83,6 +83,69 @@ pub(crate) struct LiveIterationProgress {
     pub(crate) target_points: usize,
 }
 
+pub(crate) struct StatusUpdateBuildRequest<'a> {
+    pub(crate) kind: IntegrationStatusKind,
+    pub(crate) integration_state: &'a IntegrationState,
+    pub(crate) cores: usize,
+    pub(crate) elapsed_time: Duration,
+    pub(crate) iteration_elapsed_time: Duration,
+    pub(crate) cur_points: usize,
+    pub(crate) total_points_display: usize,
+    pub(crate) n_samples_evaluated: usize,
+    pub(crate) targets: &'a [Option<Complex<F<f64>>>],
+    pub(crate) render_options: &'a IntegrationStatusViewOptions,
+    pub(crate) live_progress: Option<LiveIterationProgress>,
+}
+
+impl<'a> StatusUpdateBuildRequest<'a> {
+    pub(crate) fn new(
+        kind: IntegrationStatusKind,
+        integration_state: &'a IntegrationState,
+        targets: &'a [Option<Complex<F<f64>>>],
+        render_options: &'a IntegrationStatusViewOptions,
+    ) -> Self {
+        Self {
+            kind,
+            integration_state,
+            cores: 0,
+            elapsed_time: Duration::ZERO,
+            iteration_elapsed_time: Duration::ZERO,
+            cur_points: 0,
+            total_points_display: 0,
+            n_samples_evaluated: 0,
+            targets,
+            render_options,
+            live_progress: None,
+        }
+    }
+
+    pub(crate) fn with_timing(
+        mut self,
+        cores: usize,
+        elapsed_time: Duration,
+        iteration_elapsed_time: Duration,
+        cur_points: usize,
+        total_points_display: usize,
+        n_samples_evaluated: usize,
+    ) -> Self {
+        self.cores = cores;
+        self.elapsed_time = elapsed_time;
+        self.iteration_elapsed_time = iteration_elapsed_time;
+        self.cur_points = cur_points;
+        self.total_points_display = total_points_display;
+        self.n_samples_evaluated = n_samples_evaluated;
+        self
+    }
+
+    pub(crate) fn with_live_progress(
+        mut self,
+        live_progress: Option<LiveIterationProgress>,
+    ) -> Self {
+        self.live_progress = live_progress;
+        self
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct StatusMeta {
     pub(crate) elapsed_time: Duration,
@@ -1490,23 +1553,12 @@ fn discrete_sort_key(
     }
 }
 
-fn build_main_results_section(
-    kind: IntegrationStatusKind,
-    integration_state: &IntegrationState,
-    cores: usize,
-    elapsed_time: Duration,
-    cur_points: usize,
-    total_points_display: usize,
-    n_samples_evaluated: usize,
-    targets: &[Option<Complex<F<f64>>>],
-    render_options: &IntegrationStatusViewOptions,
-    live_progress: Option<LiveIterationProgress>,
-) -> MainResultsSection {
-    let components = ComponentKind::all_for_display(render_options.phase_display);
-    let discrete_context = integration_state.monitored_discrete_context();
-    let monitored_path = integration_state.monitored_discrete_path.as_deref();
+fn build_main_results_section(request: &StatusUpdateBuildRequest<'_>) -> MainResultsSection {
+    let components = ComponentKind::all_for_display(request.render_options.phase_display);
+    let discrete_context = request.integration_state.monitored_discrete_context();
+    let monitored_path = request.integration_state.monitored_discrete_path.as_deref();
     let has_discrete_columns = monitored_path.is_some();
-    let has_target_columns = targets.first().is_some_and(Option::is_some);
+    let has_target_columns = request.targets.first().is_some_and(Option::is_some);
 
     let mut row_groups = vec![MainResultsRowGroup {
         kind: MainResultsRowGroupKind::All,
@@ -1514,8 +1566,8 @@ fn build_main_results_section(
             .iter()
             .filter_map(|component| {
                 main_results_row(
-                    integration_state,
-                    targets,
+                    request.integration_state,
+                    request.targets,
                     monitored_path,
                     ContributionKind::All,
                     *component,
@@ -1530,8 +1582,8 @@ fn build_main_results_section(
             .iter()
             .filter_map(|component| {
                 main_results_row(
-                    integration_state,
-                    targets,
+                    request.integration_state,
+                    request.targets,
                     monitored_path,
                     ContributionKind::Sum,
                     *component,
@@ -1547,14 +1599,14 @@ fn build_main_results_section(
         }
 
         let bin_count = discrete_context.pdfs.len();
-        match render_options.contribution_sort {
+        match request.render_options.contribution_sort {
             ContributionSortMode::Index => {
                 let mut rows = Vec::new();
                 for bin_index in 0..bin_count {
                     for component in &components {
                         if let Some(row) = main_results_row(
-                            integration_state,
-                            targets,
+                            request.integration_state,
+                            request.targets,
                             monitored_path,
                             ContributionKind::Bin(bin_index),
                             *component,
@@ -1576,18 +1628,18 @@ fn build_main_results_section(
                     let mut bin_indices = (0..bin_count).collect_vec();
                     bin_indices.sort_by(|lhs, rhs| {
                         discrete_sort_key(
-                            integration_state,
+                            request.integration_state,
                             &discrete_context.path,
                             *component,
                             *rhs,
-                            render_options.contribution_sort,
+                            request.render_options.contribution_sort,
                         )
                         .partial_cmp(&discrete_sort_key(
-                            integration_state,
+                            request.integration_state,
                             &discrete_context.path,
                             *component,
                             *lhs,
-                            render_options.contribution_sort,
+                            request.render_options.contribution_sort,
                         ))
                         .unwrap_or(std::cmp::Ordering::Equal)
                     });
@@ -1595,8 +1647,8 @@ fn build_main_results_section(
                         .into_iter()
                         .filter_map(|bin_index| {
                             main_results_row(
-                                integration_state,
-                                targets,
+                                request.integration_state,
+                                request.targets,
                                 monitored_path,
                                 ContributionKind::Bin(bin_index),
                                 *component,
@@ -1615,13 +1667,25 @@ fn build_main_results_section(
         }
     }
 
-    let _ = kind;
     MainResultsSection {
-        header_left: header_left(elapsed_time, integration_state.iter, live_progress),
-        header_middle: header_middle(cur_points, total_points_display, live_progress),
-        header_tail: header_tail(cores, elapsed_time, n_samples_evaluated),
-        contribution_header: contribution_header(integration_state, has_discrete_columns),
-        slot_headers: integration_state
+        header_left: header_left(
+            request.elapsed_time,
+            request.integration_state.iter,
+            request.live_progress,
+        ),
+        header_middle: header_middle(
+            request.cur_points,
+            request.total_points_display,
+            request.live_progress,
+        ),
+        header_tail: header_tail(
+            request.cores,
+            request.elapsed_time,
+            request.n_samples_evaluated,
+        ),
+        contribution_header: contribution_header(request.integration_state, has_discrete_columns),
+        slot_headers: request
+            .integration_state
             .slot_metas
             .iter()
             .map(|slot_meta| styled_colored(slot_meta.key(), TextStyle::blue().bold()))
@@ -1865,71 +1929,51 @@ fn build_discrete_max_weight_details_section(
     })
 }
 
-pub(crate) fn build_status_update(
-    kind: IntegrationStatusKind,
-    integration_state: &IntegrationState,
-    cores: usize,
-    elapsed_time: Duration,
-    iteration_elapsed_time: Duration,
-    cur_points: usize,
-    total_points_display: usize,
-    n_samples_evaluated: usize,
-    targets: &[Option<Complex<F<f64>>>],
-    render_options: &IntegrationStatusViewOptions,
-    live_progress: Option<LiveIterationProgress>,
-) -> StatusUpdate {
+pub(crate) fn build_status_update(request: StatusUpdateBuildRequest<'_>) -> StatusUpdate {
     let target_accuracy_status = evaluate_target_accuracy(
-        integration_state,
-        total_points_display,
-        elapsed_time,
-        targets,
-        render_options.training_phase_display,
-        render_options.target_relative_accuracy,
-        render_options.target_absolute_accuracy,
+        request.integration_state,
+        request.total_points_display,
+        request.elapsed_time,
+        request.targets,
+        request.render_options.training_phase_display,
+        request.render_options.target_relative_accuracy,
+        request.render_options.target_absolute_accuracy,
     );
     StatusUpdate {
-        kind,
+        kind: request.kind,
         meta: StatusMeta {
-            elapsed_time,
-            iteration_elapsed_time,
-            iteration: integration_state.iter,
-            current_iteration_points: cur_points,
-            total_points: total_points_display,
-            n_samples_evaluated,
-            cores,
-            training_slot: render_options.training_slot,
-            training_phase_display: render_options.training_phase_display,
-            live_progress,
-            show_eta_to_target: render_options.target_relative_accuracy.is_some()
-                || render_options.target_absolute_accuracy.is_some(),
+            elapsed_time: request.elapsed_time,
+            iteration_elapsed_time: request.iteration_elapsed_time,
+            iteration: request.integration_state.iter,
+            current_iteration_points: request.cur_points,
+            total_points: request.total_points_display,
+            n_samples_evaluated: request.n_samples_evaluated,
+            cores: request.cores,
+            training_slot: request.render_options.training_slot,
+            training_phase_display: request.render_options.training_phase_display,
+            live_progress: request.live_progress,
+            show_eta_to_target: request.render_options.target_relative_accuracy.is_some()
+                || request.render_options.target_absolute_accuracy.is_some(),
             eta_to_target_specification: format_eta_to_target_specification(
-                render_options.target_relative_accuracy,
-                render_options.target_absolute_accuracy,
+                request.render_options.target_relative_accuracy,
+                request.render_options.target_absolute_accuracy,
             ),
             eta_to_target: target_accuracy_status.eta_to_target,
         },
-        targets: targets.to_vec(),
-        slot_training_phase_displays: render_options.slot_training_phase_displays.clone(),
-        per_slot_training_phase: render_options.per_slot_training_phase,
-        main_results: build_main_results_section(
-            kind,
-            integration_state,
-            cores,
-            elapsed_time,
-            cur_points,
-            total_points_display,
-            n_samples_evaluated,
-            targets,
-            render_options,
-            live_progress,
+        targets: request.targets.to_vec(),
+        slot_training_phase_displays: request.render_options.slot_training_phase_displays.clone(),
+        per_slot_training_phase: request.render_options.per_slot_training_phase,
+        main_results: build_main_results_section(&request),
+        max_weight_details: build_max_weight_details_section(
+            request.integration_state,
+            request.render_options,
         ),
-        max_weight_details: build_max_weight_details_section(integration_state, render_options),
         discrete_max_weight_details: build_discrete_max_weight_details_section(
-            integration_state,
-            render_options,
+            request.integration_state,
+            request.render_options,
         ),
         statistics: Some(StatisticsSection {
-            raw: integration_state.stats,
+            raw: request.integration_state.stats,
         }),
     }
 }
@@ -1939,17 +1983,18 @@ pub(crate) fn build_saved_status_update(
     targets: &[Option<Complex<F<f64>>>],
     render_options: &IntegrationStatusViewOptions,
 ) -> StatusUpdate {
-    build_status_update(
-        IntegrationStatusKind::Final,
+    let final_render_options = render_options.clone().for_final();
+    build_status_update(StatusUpdateBuildRequest {
+        kind: IntegrationStatusKind::Final,
         integration_state,
-        integration_state.n_cores.max(1),
-        utils::duration_from_secs_f64_saturating(integration_state.elapsed_seconds),
-        Duration::ZERO,
-        0,
-        integration_state.num_points,
-        integration_state.num_points,
+        cores: integration_state.n_cores.max(1),
+        elapsed_time: utils::duration_from_secs_f64_saturating(integration_state.elapsed_seconds),
+        iteration_elapsed_time: Duration::ZERO,
+        cur_points: 0,
+        total_points_display: integration_state.num_points,
+        n_samples_evaluated: integration_state.num_points,
         targets,
-        &render_options.clone().for_final(),
-        None,
-    )
+        render_options: &final_render_options,
+        live_progress: None,
+    })
 }

--- a/crates/gammalooprs/src/lib.rs
+++ b/crates/gammalooprs/src/lib.rs
@@ -36,6 +36,7 @@ use utils::F;
 use utils::FloatLike;
 
 pub static INTERRUPTED: AtomicBool = AtomicBool::new(false);
+pub static ITERATION_ABORT_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 pub const GAMMALOOP_NAMESPACE: &str = "GL";
 pub const MAX_CORES: usize = 1000;
@@ -83,9 +84,20 @@ pub const MAX_LOOP: usize = 6;
 
 pub fn set_interrupt_handler() {
     INTERRUPTED.store(false, std::sync::atomic::Ordering::Relaxed);
+    ITERATION_ABORT_REQUESTED.store(false, std::sync::atomic::Ordering::Relaxed);
     let _ = ctrlc::set_handler(|| {
         INTERRUPTED.store(true, std::sync::atomic::Ordering::Relaxed);
     });
+}
+
+#[inline]
+pub fn request_interrupt() {
+    INTERRUPTED.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[inline]
+pub fn request_iteration_abort() {
+    ITERATION_ABORT_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
 }
 
 #[inline]
@@ -94,8 +106,18 @@ pub(crate) fn is_interrupted() -> bool {
 }
 
 #[inline]
+pub(crate) fn is_iteration_abort_requested() -> bool {
+    ITERATION_ABORT_REQUESTED.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+#[inline]
 pub(crate) fn set_interrupted(flag: bool) {
     INTERRUPTED.store(flag, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[inline]
+pub(crate) fn clear_iteration_abort_request() {
+    ITERATION_ABORT_REQUESTED.store(false, std::sync::atomic::Ordering::Relaxed);
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/gammalooprs/src/processes/mod.rs
+++ b/crates/gammalooprs/src/processes/mod.rs
@@ -88,6 +88,7 @@ impl EvaluatorSettings {
             max_common_pair_cache_entries: self.max_common_pair_cache_entries,
             max_common_pair_distance: self.max_common_pair_distance,
             verbose: self.verbose,
+            ..OptimizationSettings::default()
         }
     }
 }

--- a/crates/gammalooprs/src/settings/runtime.rs
+++ b/crates/gammalooprs/src/settings/runtime.rs
@@ -238,6 +238,10 @@ pub struct IntegratorSettings {
     #[serde(skip_serializing_if = "is_usize::<10000000000>")]
     pub n_max: usize,
     #[serde(skip_serializing_if = "IsDefault::is_default")]
+    pub target_relative_accuracy: Option<f64>,
+    #[serde(skip_serializing_if = "IsDefault::is_default")]
+    pub target_absolute_accuracy: Option<f64>,
+    #[serde(skip_serializing_if = "IsDefault::is_default")]
     pub integrated_phase: IntegratedPhase,
     #[serde(skip_serializing_if = "is_float::<1>")]
     pub discrete_dim_learning_rate: f64,
@@ -264,6 +268,8 @@ impl Default for IntegratorSettings {
             n_start: 100000,
             n_increase: 10000,
             n_max: 10000000000,
+            target_relative_accuracy: None,
+            target_absolute_accuracy: None,
             integrated_phase: IntegratedPhase::default(),
             discrete_dim_learning_rate: 1.0,
             continuous_dim_learning_rate: 1.0,
@@ -531,6 +537,7 @@ impl Display for IntegrationResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::serde_utils::ShowDefaultsGuard;
     use spenso::algebra::complex::Complex;
 
     #[test]
@@ -565,6 +572,33 @@ mod tests {
         // Test with custom precision
         let precision_str = format!("{:.2}", result);
         println!("With precision 2: {}", precision_str);
+    }
+
+    #[test]
+    fn integrator_settings_target_accuracy_defaults_serialize_via_showdefaults() {
+        let settings = IntegratorSettings::default();
+
+        let hidden_defaults = toml::to_string(&settings).expect("serialize integrator defaults");
+        assert!(!hidden_defaults.contains("target_relative_accuracy"));
+        assert!(!hidden_defaults.contains("target_absolute_accuracy"));
+
+        let _guard = ShowDefaultsGuard::new(true);
+        let shown_defaults = toml::to_string(&settings).expect("serialize integrator defaults");
+        assert!(shown_defaults.contains("target_relative_accuracy"));
+        assert!(shown_defaults.contains("target_absolute_accuracy"));
+    }
+
+    #[test]
+    fn integrator_settings_target_accuracy_serializes_when_configured() {
+        let settings = IntegratorSettings {
+            target_relative_accuracy: Some(0.05),
+            target_absolute_accuracy: Some(1.0e-6),
+            ..IntegratorSettings::default()
+        };
+
+        let serialized = toml::to_string(&settings).expect("serialize configured integrator");
+        assert!(serialized.contains("target_relative_accuracy = 0.05"));
+        assert!(serialized.contains("target_absolute_accuracy = 1e-6"));
     }
 }
 

--- a/crates/gammalooprs/src/tests.rs
+++ b/crates/gammalooprs/src/tests.rs
@@ -35,6 +35,8 @@ fn default_render_options() -> IntegrationStatusViewOptions {
         training_slot: 0,
         slot_training_phase_displays: vec![IntegrationStatusPhaseDisplay::Real],
         per_slot_training_phase: false,
+        target_relative_accuracy: None,
+        target_absolute_accuracy: None,
         show_statistics: true,
         show_max_weight_details: true,
         show_top_discrete_grid: false,

--- a/crates/gammalooprs/src/tests.rs
+++ b/crates/gammalooprs/src/tests.rs
@@ -31,6 +31,8 @@ const N_CORES_FOR_INTEGRATION_IN_TESTS: usize = 16;
 fn default_render_options() -> IntegrationStatusViewOptions {
     IntegrationStatusViewOptions {
         phase_display: IntegrationStatusPhaseDisplay::Both,
+        training_phase_display: IntegrationStatusPhaseDisplay::Real,
+        training_slot: 0,
         show_statistics: true,
         show_max_weight_details: true,
         show_top_discrete_grid: false,

--- a/crates/gammalooprs/src/tests.rs
+++ b/crates/gammalooprs/src/tests.rs
@@ -33,6 +33,8 @@ fn default_render_options() -> IntegrationStatusViewOptions {
         phase_display: IntegrationStatusPhaseDisplay::Both,
         training_phase_display: IntegrationStatusPhaseDisplay::Real,
         training_slot: 0,
+        slot_training_phase_displays: vec![IntegrationStatusPhaseDisplay::Real],
+        per_slot_training_phase: false,
         show_statistics: true,
         show_max_weight_details: true,
         show_top_discrete_grid: false,

--- a/crates/gammalooprs/src/tests.rs
+++ b/crates/gammalooprs/src/tests.rs
@@ -17,8 +17,8 @@ use spenso::algebra::complex::Complex;
 use symbolica::domains::float::Complex as SymComplex;
 
 use crate::integrate::{
-    ContributionSortMode, IntegrationStatusPhaseDisplay, IntegrationStatusViewOptions,
-    SamplingCorrelationMode, SlotMeta, havana_integrate,
+    ContributionSortMode, HavanaIntegrateRequest, IntegrationSlot, IntegrationStatusPhaseDisplay,
+    IntegrationStatusViewOptions, SamplingCorrelationMode, SlotMeta, havana_integrate,
 };
 
 const CENTRAL_VALUE_TOLERANCE: F<f64> = F(2.0e-2);
@@ -83,18 +83,22 @@ fn compare_integration(
         IntegratedPhase::Both => {
             settings.integrator.integrated_phase = IntegratedPhase::Real;
             let res = havana_integrate(
-                vec![settings.clone()],
-                SamplingCorrelationMode::Correlated,
-                vec![model.clone()],
-                vec![slot_meta.clone()],
-                vec![crate::integrand_factory(settings)],
-                N_CORES_FOR_INTEGRATION_IN_TESTS,
-                vec![Some(target)],
-                None,
-                None,
-                crate::integrate::WorkspaceSnapshotControl::default(),
-                crate::integrate::IterationBatchingSettings::default(),
-                default_render_options(),
+                HavanaIntegrateRequest {
+                    slots: vec![IntegrationSlot::new(
+                        slot_meta.clone(),
+                        settings.clone(),
+                        model.clone(),
+                        crate::integrand_factory(settings),
+                        Some(target),
+                    )],
+                    sampling_correlation_mode: SamplingCorrelationMode::Correlated,
+                    n_cores: N_CORES_FOR_INTEGRATION_IN_TESTS,
+                    state: None,
+                    workspace: None,
+                    output_control: crate::integrate::WorkspaceSnapshotControl::default(),
+                    batching: crate::integrate::IterationBatchingSettings::default(),
+                    view_options: default_render_options(),
+                },
                 |_| Ok(()),
             )?;
             let integral = &res.single_slot().expect("single slot expected").integral;
@@ -115,18 +119,22 @@ fn compare_integration(
             }
             settings.integrator.integrated_phase = IntegratedPhase::Imag;
             let res = havana_integrate(
-                vec![settings.clone()],
-                SamplingCorrelationMode::Correlated,
-                vec![model.clone()],
-                vec![slot_meta.clone()],
-                vec![crate::integrand_factory(settings)],
-                N_CORES_FOR_INTEGRATION_IN_TESTS,
-                vec![Some(target)],
-                None,
-                None,
-                crate::integrate::WorkspaceSnapshotControl::default(),
-                crate::integrate::IterationBatchingSettings::default(),
-                default_render_options(),
+                HavanaIntegrateRequest {
+                    slots: vec![IntegrationSlot::new(
+                        slot_meta.clone(),
+                        settings.clone(),
+                        model.clone(),
+                        crate::integrand_factory(settings),
+                        Some(target),
+                    )],
+                    sampling_correlation_mode: SamplingCorrelationMode::Correlated,
+                    n_cores: N_CORES_FOR_INTEGRATION_IN_TESTS,
+                    state: None,
+                    workspace: None,
+                    output_control: crate::integrate::WorkspaceSnapshotControl::default(),
+                    batching: crate::integrate::IterationBatchingSettings::default(),
+                    view_options: default_render_options(),
+                },
                 |_| Ok(()),
             )?;
             let integral = &res.single_slot().expect("single slot expected").integral;
@@ -149,18 +157,22 @@ fn compare_integration(
         IntegratedPhase::Real => {
             settings.integrator.integrated_phase = IntegratedPhase::Real;
             let res = havana_integrate(
-                vec![settings.clone()],
-                SamplingCorrelationMode::Correlated,
-                vec![model.clone()],
-                vec![slot_meta.clone()],
-                vec![crate::integrand_factory(settings)],
-                N_CORES_FOR_INTEGRATION_IN_TESTS,
-                vec![Some(target)],
-                None,
-                None,
-                crate::integrate::WorkspaceSnapshotControl::default(),
-                crate::integrate::IterationBatchingSettings::default(),
-                default_render_options(),
+                HavanaIntegrateRequest {
+                    slots: vec![IntegrationSlot::new(
+                        slot_meta.clone(),
+                        settings.clone(),
+                        model.clone(),
+                        crate::integrand_factory(settings),
+                        Some(target),
+                    )],
+                    sampling_correlation_mode: SamplingCorrelationMode::Correlated,
+                    n_cores: N_CORES_FOR_INTEGRATION_IN_TESTS,
+                    state: None,
+                    workspace: None,
+                    output_control: crate::integrate::WorkspaceSnapshotControl::default(),
+                    batching: crate::integrate::IterationBatchingSettings::default(),
+                    view_options: default_render_options(),
+                },
                 |_| Ok(()),
             )?;
             let integral = &res.single_slot().expect("single slot expected").integral;
@@ -183,18 +195,22 @@ fn compare_integration(
         IntegratedPhase::Imag => {
             settings.integrator.integrated_phase = IntegratedPhase::Imag;
             let res = havana_integrate(
-                vec![settings.clone()],
-                SamplingCorrelationMode::Correlated,
-                vec![model.clone()],
-                vec![slot_meta],
-                vec![crate::integrand_factory(settings)],
-                N_CORES_FOR_INTEGRATION_IN_TESTS,
-                vec![Some(target)],
-                None,
-                None,
-                crate::integrate::WorkspaceSnapshotControl::default(),
-                crate::integrate::IterationBatchingSettings::default(),
-                default_render_options(),
+                HavanaIntegrateRequest {
+                    slots: vec![IntegrationSlot::new(
+                        slot_meta,
+                        settings.clone(),
+                        model.clone(),
+                        crate::integrand_factory(settings),
+                        Some(target),
+                    )],
+                    sampling_correlation_mode: SamplingCorrelationMode::Correlated,
+                    n_cores: N_CORES_FOR_INTEGRATION_IN_TESTS,
+                    state: None,
+                    workspace: None,
+                    output_control: crate::integrate::WorkspaceSnapshotControl::default(),
+                    batching: crate::integrate::IterationBatchingSettings::default(),
+                    view_options: default_render_options(),
+                },
                 |_| Ok(()),
             )?;
             let integral = &res.single_slot().expect("single slot expected").integral;

--- a/crates/vakint/build.rs
+++ b/crates/vakint/build.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=EXTRA_MACOS_LIBS_FOR_GNU_GCC");
+
     if cfg!(target_os = "macos") && std::env::var_os("EXTRA_MACOS_LIBS_FOR_GNU_GCC").is_some() {
         let lib_dir = "/opt/local/lib/libgcc";
         let lib_name = "gcc_s.1.1";

--- a/examples/cli/scalar_topologies/multi_scalar_integrands.toml
+++ b/examples/cli/scalar_topologies/multi_scalar_integrands.toml
@@ -182,20 +182,27 @@ helicities = [
     subtype = "multi_channeling"
     '""",
 
-    "set process -p box -i scalar_box kv integrator.n_increase=0 integrator.n_start=1000000 integrator.n_max=5000000 integrator.seed=1337",
+    "set process -p box -i scalar_box kv integrator.n_increase=0 integrator.n_start=500000 integrator.n_max=50000000 integrator.seed=1337",
     # --show-max-weight-info-for-discrete-bins
 	# --batch-size 100000
 	# --no-stream-iterations
-	# --show-max-weight-info-for-discrete-bins	
+	# --show-max-weight-info-for-discrete-bins
+	# --no-stream-iterations	
+
+	#			 --show-phase both
+	#			 --show-top-discrete-grid
+	#			 --show-discrete-contributions-sum
+	#			 --sort-contributions integral
+	#			 --show-max-weight-info
+	#			 --renderer ratatui
 	"""integrate -p box -i scalar_box -p box_copy -i scalar_box_copy --n-cores 10
                  --target box@scalar_box=7.6e-6,7.43e-5 box_copy@scalar_box_copy=6.63e-5,0.0
+				 --renderer ratatui
+				 --batch-size 10000
 				 --show-phase both
+				 --show-max-weight-info
 				 --show-top-discrete-grid
 				 --show-discrete-contributions-sum
-				 --sort-contributions integral
-				 --show-max-weight-info
-				 --no-stream-iterations
-				 --renderer ratatui 
                  --restart
     """,
 ]

--- a/examples/cli/scalar_topologies/multi_scalar_integrands.toml
+++ b/examples/cli/scalar_topologies/multi_scalar_integrands.toml
@@ -182,7 +182,7 @@ helicities = [
     subtype = "multi_channeling"
     '""",
 
-    "set process -p box -i scalar_box kv integrator.n_increase=0 integrator.n_start=10000 integrator.n_max=2000000000 integrator.seed=1337",
+    "set process -p box -i scalar_box kv integrator.n_increase=0 integrator.n_start=1000000 integrator.n_max=5000000 integrator.seed=1337",
     # --show-max-weight-info-for-discrete-bins
 	# --batch-size 100000
 	# --no-stream-iterations
@@ -194,6 +194,8 @@ helicities = [
 				 --show-discrete-contributions-sum
 				 --sort-contributions integral
 				 --show-max-weight-info
+				 --no-stream-iterations
+				 --renderer ratatui 
                  --restart
     """,
 ]

--- a/examples/cli/scalar_topologies/multi_scalar_integrands.toml
+++ b/examples/cli/scalar_topologies/multi_scalar_integrands.toml
@@ -182,6 +182,7 @@ helicities = [
     subtype = "multi_channeling"
     '""",
 
+    "set process -p box -i scalar_box kv integrator.target_relative_accuracy=0.001 integrator.target_absolute_accuracy=1.0e-9",
     "set process -p box -i scalar_box kv integrator.n_increase=0 integrator.n_start=500000 integrator.n_max=50000000 integrator.seed=1337",
     # --show-max-weight-info-for-discrete-bins
 	# --batch-size 100000

--- a/ratatui_plan.md
+++ b/ratatui_plan.md
@@ -1,0 +1,526 @@
+# Ratatui Integration Dashboard Plan
+
+This file is the living plan for the ratatui integration-status dashboard work.
+Update it whenever scope, decisions, or implementation sequencing changes.
+
+## Confirmed decisions
+
+- Ratatui becomes the default interactive streaming renderer via
+  `--renderer=ratatui|tabled`, with `ratatui` as the new default.
+- `info!()` output remains tabled/canonical. Ratatui is only for interactive
+  streaming updates.
+- If live updates are streamed but end-of-iteration summaries are not, the
+  ratatui dashboard should suspend, let the tabled `info!()` summary print
+  cleanly, and then resume on the next live update.
+- The convergence chart uses:
+  - x-axis = total sample count
+  - y-axis = central value
+- Multi-slot layout should use an all-slot ribbon plus a focused-slot detail
+  area instead of a permanently wide all-columns matrix.
+- ETA for the current iteration should be shown.
+- Keyboard interrupt handling should become responsive inside
+  `evaluate_samples(..)` / `evaluate_samples_raw(..)` after each individual
+  sample finishes.
+
+## Implementation status (2026-03-21)
+
+### Implemented
+
+- CLI renderer selection is live in
+  `crates/gammaloop-api/src/commands/integrate.rs` with
+  `--renderer=ratatui|tabled` and `ratatui` as the default.
+- Ratatui streaming now runs through a dedicated dashboard controller with:
+  - alternate-screen lifecycle
+  - suspend/resume around canonical tabled `info!()` summaries
+  - keyboard handling for tabs, slot focus, bin focus, sort mode, sort
+    direction, metric toggles, chart-history window controls, chart-phase
+    toggle, y-range controls/reset, help, `Ctrl-C`, and `x`
+- Renderer-neutral status assembly was expanded with:
+  - current-iteration timing metadata
+  - training-slot / training-phase metadata
+  - per-slot `chi^2` and max-weight impact
+  - always-available statistics / max-weight / discrete sections for ratatui
+- The ratatui dashboard currently includes:
+  - overview tab with progress ribbon, ETA, convergence chart, focused-slot
+    panel, results-summary table, and statistics composition bars
+  - discrete tab with sortable/selectable bin rows and selected-bin detail
+  - max-weight tab with overall and per-bin panels
+- Ratatui now renders upstream `StyledText` content directly in tables and
+  panels instead of flattening values to plain strings, so backend-independent
+  formatting is shared across tabled and ratatui.
+- Shared status-formatting helpers now cover ratatui-specific headers as well:
+  - summary/discrete/detail headers for main results
+  - slot-specific target-delta formatting
+  - max-weight coordinate-table headers
+  - statistics table rows and percentage-mix segments
+- Shared value formatting now colors the parenthesized Monte Carlo uncertainty
+  with the same threshold-based color as the corresponding relative error, and
+  shared contribution headers now use the two-line `Contribution` /
+  `(idx=...)` format.
+- The canonical tabled renderer now explicitly flattens those contribution
+  headers back to a single line, so tabled keeps
+  `Contribution (idx=...)` while ratatui keeps the richer two-line layout.
+- Shared component formatting now uses:
+  - `re` in pink
+  - `im` in yellow
+  across both tabled and ratatui, including max-weight sign labels.
+- Review-driven follow-ups now in place:
+  - tabled raw-mode shutdown acknowledges only after terminal cleanup
+  - Python API integrations stay on `tabled` until renderer selection is
+    exposed there explicitly
+  - the convergence history preserves the completed-iteration point when the
+    next iteration emits its initial live update at the same sample count
+  - `x` now discards a partial iteration instead of letting it affect later
+    resume checkpoints
+  - discrete-bin index sorting now respects ascending vs descending order
+- The overview tab now uses the requested shape:
+  - progress block with leading/trailing spacer rows, the reordered
+    `[elapsed] | # samples total ... | Iteration ... | ETA ...` header, a
+    right-aligned `#samples/s | /sample/core` group, and the gauge label kept
+    on the bar
+  - `Integrands` table with aligned `re:` / `im:` labels, focused-integrand
+    marker, and optional per-integrand target displays using trimmed
+    user-like scientific precision rather than raw noisy `f64` tails
+  - large convergence panel with focused-integrand tracking, denser axis ticks,
+    `current value +/- 4 sigma` y-window, chart-history controls that now
+    scope by the actual iteration number seen in live updates instead of
+    relying on completed-iteration summary markers, an interactive real/imag
+    phase toggle, sigma-based y-range controls up to `±128σ`, and a title that
+    shows the training-selection state plus the active history/y-range scope
+  - the full-history view now preserves the global x-span by compacting old
+    history points instead of simply dropping the earliest samples once the
+    dashboard history buffer fills up
+  - completed-iteration markers in the convergence plot are rendered as a
+    distinct pink `iter` series in the legend so they remain visually separate
+    from the live central-value line without overpowering it
+  - focused-integrand table with persistent `% err` / `chi^2` / `m.w.i`
+  - results-summary table with a dedicated second header row for per-integrand
+    metric labels instead of repeating metric labels in each data row
+- The statistics side now keeps the raw timing/eval/event rows readable in a
+  tabled-like table and replaces the old ad hoc text blocks with proper mix
+  panels for:
+  - timing composition, sorted by largest slice first and split into
+    `evaluators`, `itg_core`, `obs`, `param`, and `integrator`
+  - precision mix, including the combined unstable/nan slice
+- The discrete tab now follows the focused integrand for bin ordering/rendering
+  and always shows `% err`, `chi^2`, and `m.w.i` in the discrete-bin table,
+  plus `sample %`, while the selected-bin detail remains an all-integrands
+  view.
+- The discrete-tab row selection bug caused by the spacer row has been fixed so
+  the highlighted bin and the selected-bin detail stay in sync.
+- The max-weight tab now uses a wider coordinates panel filtered to the
+  currently focused integrand, multi-line coordinate cells with explicit row
+  heights, and the per-bin tables now follow the same contribution ordering as
+  the discrete tab sorting for the first integrand. The top max-weight details
+  table now also reserves enough height to keep the requested single trailing
+  spacer row visible.
+- Panel titles that mention a focused integrand now render the brackets in
+  green and the integrand identifier in blue, to match the rest of the shared
+  renderer formatting.
+- The tabled renderer still obeys the existing show/hide flags; ratatui ignores
+  those flags and always shows all available tabs/sections.
+- Per-sample interrupt checks are implemented in:
+  - `crates/gammalooprs/src/integrands/mod.rs`
+  - `crates/gammalooprs/src/integrands/process/mod.rs`
+- Ratatui now distinguishes:
+  - `Ctrl-C` -> request full integration interrupt
+  - `x` -> abort the current iteration after the current batch finishes
+- Interactive streaming now shows a zero-progress frame immediately when each
+  iteration starts, and the initial live status is now emitted before the
+  expensive per-iteration worker-state construction begins.
+- `--renderer=tabled` now starts a lightweight raw-mode control listener so
+  streamed tabled output remains responsive to `Ctrl-C` and `x`.
+- Tabled parity fixes now explicitly cover:
+  - single-line contribution headers
+  - preserved canonical `info!()` summaries while ratatui keeps its richer
+    panel/table layout
+- Targeted ratatui buffer tests were added in
+  `crates/gammalooprs/src/integrate/mod.rs` for the overview, convergence-phase
+  toggle, and discrete tabs.
+
+### Still open / follow-up
+
+- Python-facing renderer selection has not been threaded through every possible
+  API surface yet; the CLI path is implemented.
+- Interrupted work is still treated as partial-iteration work: the system
+  remains checkpointed at completed-iteration boundaries only, which matches
+  the current workspace/resume model. There is no partial-iteration persistence
+  plan.
+- Ratatui still needs broader state-machine coverage and more screenshot-driven
+  polish:
+  - mixed live ratatui + tabled summaries
+  - non-TTY fallback
+  - narrow-terminal layout behavior
+  - max-weight-heavy payloads / long coordinate wrapping
+- Optional UX polish still available:
+  - more compact overview summary columns on narrower terminals
+  - tighter chart/summary spacing on medium-width terminals
+  - more aggressive chart-history downsampling tuning
+
+## High-level goals
+
+- Build a high-quality ratatui dashboard that feels native to terminal UIs
+  rather than a direct port of the current tabled output.
+- Preserve the existing cell content and label formatting conventions already
+  captured in `crates/gammalooprs/src/integrate/display.rs`, and prefer using
+  the preformatted display strings already carried by `StatusUpdate`.
+- Keep the renderer boundary clean:
+  - `gammalooprs` owns semantic integration status data
+  - `gammaloop-api` owns TTY handling, alternate-screen lifecycle, and the
+    ratatui event loop
+- Improve readability for narrow terminals, multi-slot runs, and discrete-grid
+  monitoring instead of forcing one static layout.
+
+## Proposed architecture
+
+### 1. Renderer selection and fallback behavior
+
+- Add a `RendererOption` enum to
+  `crates/gammaloop-api/src/commands/integrate.rs`.
+- Thread that selection through CLI and Python bindings so both frontends stay
+  aligned.
+- Behavior matrix:
+  - `--renderer=tabled`: keep the current streaming-in-place text renderer,
+    plus keyboard controls for `Ctrl-C` and `x`.
+  - `--renderer=ratatui` on a TTY: use the dashboard.
+  - `--renderer=ratatui` on a non-TTY: log one fallback message and use current
+    tabled logging behavior.
+  - `--show-summary-only`: bypass ratatui entirely and print the current final
+    tabled summary.
+
+### 2. Semantic status snapshot refactor
+
+- Keep `StatusUpdate` as the renderer-neutral contract, but make it less
+  table-shaped and more complete for ratatui.
+- Extend the status payload with data that ratatui needs but tabled currently
+  hides or compresses:
+  - explicit per-slot metrics for all slots, not just slot 0
+  - current iteration timing metadata needed for ETA
+  - training-slot and training-phase metadata for the live chart
+  - typed statistics/timing breakdowns instead of only a prebuilt statistics
+    table
+  - monitored discrete-axis/path metadata for breadcrumbs and per-bin drilldown
+- Prefer attaching behavior to existing section/state structs with methods where
+  that improves discoverability, instead of adding more free helper functions.
+
+### 3. Per-slot metrics model
+
+- The current main table already carries per-slot value and relative error, but
+  `chi^2` and max-weight impact are effectively slot-0 metadata.
+- Ratatui should have access to per-slot:
+  - value +/- uncertainty
+  - relative error
+  - `chi^2/dof` where meaningful
+  - max-weight impact
+  - target deltas for the first slot when targets exist
+- Tabled can continue to render the compact slot-0 metadata columns, while the
+  ratatui overview can show a richer all-slot metrics matrix.
+
+### 4. Ratatui controller/event-loop design
+
+- Implement ratatui in `gammaloop-api`, likely as a small dashboard module
+  split into:
+  - app state
+  - terminal lifecycle/suspend-resume guard
+  - drawing/layout helpers
+  - key handling
+  - status-history/cache logic
+- Use a dedicated UI controller/thread:
+  - integration sends `StatusUpdate` messages
+  - UI thread handles input, redraw ticks, resize, suspend/resume, and shutdown
+- This keeps the integrator hot path simple and makes interactive features like
+  sorting and column toggles straightforward.
+
+### 5. Suspend/resume lifecycle
+
+- Ratatui path should use alternate screen + raw mode while active.
+- Before emitting a tabled iteration summary or final summary:
+  - leave alternate screen
+  - disable raw mode
+  - clear ratatui state from the terminal
+  - print the tabled summary with the existing `info!()` path
+- On the next live update, re-enter alternate screen and redraw from the latest
+  cached dashboard state.
+
+## Dashboard UX plan
+
+### Global shell
+
+- Keep a stable top-level frame with:
+  - top title/tabs row
+  - progress/status ribbon
+  - main content area
+  - bottom help/status footer
+- Provide a small persistent key-hint footer, with a fuller help overlay on `?`.
+- Support dynamic layout tiers:
+  - wide: side-by-side panels
+  - medium: stacked secondary panels
+  - narrow: focus-first layout with fewer simultaneous tables
+
+### Tab 1: Overview
+
+- This is the main landing tab.
+- Layout target on wide terminals:
+  - top: progress ribbon + slot ribbon
+  - left: convergence chart
+  - right: focused-slot details card
+  - bottom-left: all-slot metrics matrix
+  - bottom-right: integration statistics panel
+
+#### Progress ribbon
+
+- Fancy ratatui gauge for current iteration progress.
+- Include:
+  - iteration number/state
+  - completed/target iteration samples
+  - total samples
+  - throughput
+  - ETA for the current iteration
+  - elapsed wall time
+- Use color states for healthy / warning / interrupted conditions.
+
+#### Slot ribbon
+
+- Show every slot as a compact card so multi-slot runs stay visible together.
+- Each card should include at least:
+  - slot label
+  - current value +/- uncertainty
+  - relative error badge
+  - `chi^2/dof` badge
+  - max-weight impact badge
+- One slot is focused at a time; focus drives the right-side detail card and,
+  when appropriate, secondary annotations in the chart.
+
+#### Convergence chart
+
+- Plot the training-slot integral in the selected training phase.
+- Datasets:
+  - central-value line
+  - upper uncertainty line
+  - lower uncertainty line
+  - completed-iteration markers
+  - target line when available
+- Keep completed-iteration points visually distinct from intra-iteration live
+  points.
+- Use axis hysteresis/padding so the plot does not jitter on every redraw.
+- Downsample history to terminal width.
+- Allow:
+  - phase toggle between real/imag for the focused integrand
+  - history window toggle between full history and the last `N` iterations
+  - y-range adjustment/reset in units of the current MC uncertainty
+
+#### All-slot metrics matrix
+
+- Show all slots together in a compact comparison matrix.
+- Include interactively toggled extra columns:
+  - relative error
+  - `chi^2/dof`
+  - max-weight impact
+- Proposed interaction:
+  - `r` toggles relative-error column
+  - `c` toggles `chi^2/dof`
+  - `w` toggles max-weight impact
+  - `m` cycles density presets (`compact`, `metrics`, `full`)
+- On narrow terminals, collapse this matrix into per-slot stacked rows instead
+  of truncating columns aggressively.
+
+#### Statistics panel
+
+- Keep raw numbers readable, but complement them with visual composition bars.
+- Show both exact values and percent-based visuals for metrics that should sum
+  to 100%.
+- Best candidates:
+  - timing breakdown:
+    - parameterization
+    - evaluator
+    - integrand
+    - event processing
+    - integrator overhead
+  - precision mix:
+    - double
+    - quad
+    - arb
+  - stability mix:
+    - stable
+    - unstable
+    - nan
+  - event/selection efficiency:
+    - accepted
+    - rejected
+- Preferred visual treatment:
+  - compact numeric table on one side
+  - horizontal composition bars on the other side
+- That keeps the exact data visible while letting the user perceive balance and
+  anomalies immediately.
+
+### Tab 2: Discrete breakdown
+
+- Always present, but show a clear empty-state panel when there is no monitored
+  discrete dimension.
+- Layout target:
+  - left: discrete-bin table
+  - right: selected-bin detail pane
+  - optional bottom strip: slot comparison for the selected bin
+
+#### Discrete-bin table
+
+- Ratatui should improve on the current static sort choice with live sorting.
+- Support:
+  - sort mode cycle (`index`, `integral`, `error`, maybe `sample fraction`)
+  - sort direction toggle
+  - keyboard selection of a specific bin
+- Show compact bar-style augmentations for:
+  - sample fraction
+  - target PDF
+  - maybe absolute contribution magnitude
+
+#### Selected-bin detail pane
+
+- Show richer detail for the highlighted bin:
+  - breadcrumb of fixed coordinates / monitored path
+  - label formatting preserved from existing display helpers
+  - per-slot values and uncertainties
+  - per-slot relative errors
+  - per-slot `chi^2/dof`
+  - per-slot max-weight impact
+  - max-weight coordinates if available
+
+### Tab 3: Max weight
+
+- Always present, with empty-state handling if no data exists.
+- Layout target:
+  - upper panel: overall max-weight details table
+  - lower/side panel: per-bin max-weight details for either all bins or the
+    currently selected discrete bin
+- If a discrete tab selection exists, reuse that bin selection here so the UI
+  feels coherent across tabs.
+- For long coordinate payloads, show a wrapped viewer panel rather than forcing
+  a huge wide table.
+
+### Help/footer UX
+
+- Bottom footer should show the current mode and the most important keys:
+  - tab switching
+  - slot/bin focus
+  - sorting
+  - metric toggles
+  - density toggle
+  - help
+- `?` opens a centered help overlay/modal summarizing all keybindings.
+
+## Creative ratatui features to leverage
+
+- Composition bars for timing/precision/stability percentages.
+- Focused-slot cards with threshold-colored metric badges.
+- Empty-state panels that explain why a tab has no data instead of showing a
+  blank area.
+- Density modes so the same dashboard can feel spacious on large terminals and
+  still usable on laptops.
+- Mode/status toast line in the footer when a sort mode or column toggle
+  changes.
+- Stable selection coupling between tabs, especially for the focused slot and
+  selected discrete bin.
+
+## ETA plan
+
+- Add explicit current-iteration elapsed time to the status snapshot so ETA does
+  not need to be guessed from total integration runtime.
+- Compute ETA from smoothed current-iteration throughput rather than using only
+  the latest batch delta.
+- Show:
+  - instantaneous-ish throughput
+  - smoothed throughput
+  - ETA to iteration completion
+- If too little data exists, show `ETA: warming up` instead of a noisy guess.
+
+## Interrupt-responsiveness plan
+
+- Add interrupt checks after each completed sample inside:
+  - `crates/gammalooprs/src/integrands/mod.rs`
+  - `crates/gammalooprs/src/integrands/process/mod.rs`
+- Also break before starting the next sample once the interrupt flag is set, so
+  no extra sample is started after the user has already interrupted.
+- Do not change the completed-iteration checkpoint model: interrupted work
+  inside the current iteration is still not persisted as a resumable partial
+  iteration.
+- Keep the existing outer batch-level checks in
+  `crates/gammalooprs/src/integrate/mod.rs` as a second layer.
+- Tests should verify prompt return at sample boundaries; persistence semantics
+  remain iteration-level, not partial-iteration-level.
+
+## Proposed implementation phases
+
+### Phase 1: Renderer plumbing and status refactor
+
+- Status: mostly done for the CLI/runtime path.
+- Add renderer selection to CLI/Python/config surfaces.
+- Add ratatui dependency to `crates/gammaloop-api/Cargo.toml`.
+- Refactor `StatusUpdate` into a richer renderer-neutral snapshot.
+- Add typed statistics/timing breakdown structures.
+- Add per-slot metric support for all slots.
+
+### Phase 2: Dashboard controller and terminal lifecycle
+
+- Status: done for the current CLI dashboard implementation.
+- Implement alternate-screen/raw-mode guard.
+- Implement UI thread/controller with message passing.
+- Add suspend/resume around iteration-summary and final-summary tabled output.
+- Add resize handling and redraw ticks.
+
+### Phase 3: Overview tab
+
+- Status: done for the first production cut.
+- Implement progress ribbon with ETA.
+- Implement slot ribbon and focused-slot detail card.
+- Implement convergence chart and status history cache.
+- Add convergence controls for phase toggle, history-window selection, and
+  y-range adjustment/reset in units of the current MC error.
+- Implement all-slot metrics matrix with interactive metric toggles.
+- Implement statistics table + composition bars.
+
+### Phase 4: Discrete and max-weight tabs
+
+- Status: done for the first production cut.
+- Implement discrete-bin table with keyboard sorting and selection.
+- Implement selected-bin detail pane.
+- Implement overall and per-bin max-weight panels.
+- Couple slot/bin focus across tabs where it helps.
+
+### Phase 5: Interrupt responsiveness
+
+- Status: core interrupt checks are done; iteration-level persistence semantics
+  stay unchanged.
+- Add per-sample interrupt checks in `evaluate_samples_raw` paths.
+- Ensure partial batch results are returned cleanly.
+- Add targeted tests.
+
+### Phase 6: Polish and tests
+
+- Status: in progress.
+- Ratatui buffer/snapshot tests for wide and narrow layouts.
+- Tabled parity tests to ensure the refactor does not regress the current
+  non-ratatui summaries, including preserving single-line contribution headers
+  in the canonical tabled output while ratatui keeps the richer two-line
+  header layout.
+- State-machine tests for:
+  - live-only streaming
+  - iteration-summary-only streaming
+  - mixed ratatui live + tabled iteration summaries
+  - final-summary suspend/teardown
+  - non-TTY fallback
+- Manual validation passes for:
+  - single-slot
+  - multi-slot
+  - discrete monitoring
+  - long max-weight coordinate payloads
+
+## Risks to watch
+
+- Overfitting the semantic snapshot to the current tabled structure instead of
+  giving ratatui the richer data it needs.
+- Letting narrow-terminal behavior degrade into clipped unreadable tables.
+- Recomputing expensive history or derived metrics on every frame instead of
+  caching in the UI controller.
+- Making suspend/resume flaky around `info!()` logging; this needs clean
+  terminal ownership boundaries.
+- Breaking current tabled output while refactoring shared status assembly.

--- a/ratatui_plan.md
+++ b/ratatui_plan.md
@@ -514,6 +514,26 @@ Update it whenever scope, decisions, or implementation sequencing changes.
   - discrete monitoring
   - long max-weight coordinate payloads
 
+### Phase 7: Accuracy-target termination and ETA-to-target
+
+- Status: in progress.
+- Add optional `integrator.target_relative_accuracy` and
+  `integrator.target_absolute_accuracy` settings with `None` defaults and
+  correct `SHOWDEFAULTS` serialization.
+- Keep `integrator.n_max` as the hard stop, but also terminate after a
+  completed iteration when either configured accuracy target is reached.
+- Use only slot 0 and only slot 0's trained phase when evaluating accuracy
+  targets, even in multi-slot runs.
+- Add `ETA to target` to the ratatui overview header, based on the current
+  slot-0 trained-phase error, current throughput, and `1/sqrt(N)` error
+  scaling, and include the active target condition in the header as
+  `ETA to target (<spec>) <eta>`, with relative targets shown as percentages
+  in fixed notation above `1e-4%` and scientific notation at or below that
+  threshold.
+- If both accuracy targets are configured, compute the ETA using whichever
+  target would be reached first; if the relative reference is zero, treat the
+  relative target as inactive.
+
 ## Risks to watch
 
 - Overfitting the semantic snapshot to the current tabled structure instead of


### PR DESCRIPTION
# Ratatui Integration Dashboard Plan

This file is the living plan for the ratatui integration-status dashboard work.
Update it whenever scope, decisions, or implementation sequencing changes.

## Confirmed decisions

- Ratatui becomes the default interactive streaming renderer via
  `--renderer=ratatui|tabled`, with `ratatui` as the new default.
- `info!()` output remains tabled/canonical. Ratatui is only for interactive
  streaming updates.
- If live updates are streamed but end-of-iteration summaries are not, the
  ratatui dashboard should suspend, let the tabled `info!()` summary print
  cleanly, and then resume on the next live update.
- The convergence chart uses:
  - x-axis = total sample count
  - y-axis = central value
- Multi-slot layout should use an all-slot ribbon plus a focused-slot detail
  area instead of a permanently wide all-columns matrix.
- ETA for the current iteration should be shown.
- Keyboard interrupt handling should become responsive inside
  `evaluate_samples(..)` / `evaluate_samples_raw(..)` after each individual
  sample finishes.

## Implementation status (2026-03-21)

### Implemented

- CLI renderer selection is live in
  `crates/gammaloop-api/src/commands/integrate.rs` with
  `--renderer=ratatui|tabled` and `ratatui` as the default.
- Ratatui streaming now runs through a dedicated dashboard controller with:
  - alternate-screen lifecycle
  - suspend/resume around canonical tabled `info!()` summaries
  - keyboard handling for tabs, slot focus, bin focus, sort mode, sort
    direction, metric toggles, chart-history window controls, chart-phase
    toggle, y-range controls/reset, help, `Ctrl-C`, and `x`
- Renderer-neutral status assembly was expanded with:
  - current-iteration timing metadata
  - training-slot / training-phase metadata
  - per-slot `chi^2` and max-weight impact
  - always-available statistics / max-weight / discrete sections for ratatui
- The ratatui dashboard currently includes:
  - overview tab with progress ribbon, ETA, convergence chart, focused-slot
    panel, results-summary table, and statistics composition bars
  - discrete tab with sortable/selectable bin rows and selected-bin detail
  - max-weight tab with overall and per-bin panels
- Ratatui now renders upstream `StyledText` content directly in tables and
  panels instead of flattening values to plain strings, so backend-independent
  formatting is shared across tabled and ratatui.
- Shared status-formatting helpers now cover ratatui-specific headers as well:
  - summary/discrete/detail headers for main results
  - slot-specific target-delta formatting
  - max-weight coordinate-table headers
  - statistics table rows and percentage-mix segments
- Shared value formatting now colors the parenthesized Monte Carlo uncertainty
  with the same threshold-based color as the corresponding relative error, and
  shared contribution headers now use the two-line `Contribution` /
  `(idx=...)` format.
- The canonical tabled renderer now explicitly flattens those contribution
  headers back to a single line, so tabled keeps
  `Contribution (idx=...)` while ratatui keeps the richer two-line layout.
- Shared component formatting now uses:
  - `re` in pink
  - `im` in yellow
  across both tabled and ratatui, including max-weight sign labels.
- Review-driven follow-ups now in place:
  - tabled raw-mode shutdown acknowledges only after terminal cleanup
  - Python API integrations stay on `tabled` until renderer selection is
    exposed there explicitly
  - the convergence history preserves the completed-iteration point when the
    next iteration emits its initial live update at the same sample count
  - `x` now discards a partial iteration instead of letting it affect later
    resume checkpoints
  - discrete-bin index sorting now respects ascending vs descending order
- The overview tab now uses the requested shape:
  - progress block with leading/trailing spacer rows, the reordered
    `[elapsed] | # samples total ... | Iteration ... | ETA ...` header, a
    right-aligned `#samples/s | /sample/core` group, and the gauge label kept
    on the bar
  - `Integrands` table with aligned `re:` / `im:` labels, focused-integrand
    marker, and optional per-integrand target displays using trimmed
    user-like scientific precision rather than raw noisy `f64` tails
  - large convergence panel with focused-integrand tracking, denser axis ticks,
    `current value +/- 4 sigma` y-window, chart-history controls that now
    scope by the actual iteration number seen in live updates instead of
    relying on completed-iteration summary markers, an interactive real/imag
    phase toggle, sigma-based y-range controls, and a title that shows the
    training-selection state plus the active history/y-range scope
  - completed-iteration markers in the convergence plot are rendered as a
    distinct `iter` series in the legend so they remain visually separate from
    the live central-value line
  - focused-integrand table with persistent `% err` / `chi^2` / `m.w.i`
  - results-summary table with a dedicated second header row for per-integrand
    metric labels instead of repeating metric labels in each data row
- The statistics side now keeps the raw timing/eval/event rows readable in a
  tabled-like table and replaces the old ad hoc text blocks with proper mix
  panels for:
  - timing composition, sorted by largest slice first and split into
    `evaluators`, `itg_core`, `obs`, `param`, and `integrator`
  - precision mix, including the combined unstable/nan slice
- The discrete tab now follows the focused integrand for bin ordering/rendering
  and always shows `% err`, `chi^2`, and `m.w.i` in the discrete-bin table,
  plus `sample %`, while the selected-bin detail remains an all-integrands
  view.
- The discrete-tab row selection bug caused by the spacer row has been fixed so
  the highlighted bin and the selected-bin detail stay in sync.
- The max-weight tab now uses a wider coordinates panel filtered to the
  currently focused integrand, multi-line coordinate cells with explicit row
  heights, and the per-bin tables now follow the same contribution ordering as
  the discrete tab sorting for the first integrand. The top max-weight details
  table now also reserves enough height to keep the requested trailing spacer
  row visible.
- Panel titles that mention a focused integrand now render the brackets in
  green and the integrand identifier in blue, to match the rest of the shared
  renderer formatting.
- The tabled renderer still obeys the existing show/hide flags; ratatui ignores
  those flags and always shows all available tabs/sections.
- Per-sample interrupt checks are implemented in:
  - `crates/gammalooprs/src/integrands/mod.rs`
  - `crates/gammalooprs/src/integrands/process/mod.rs`
- Ratatui now distinguishes:
  - `Ctrl-C` -> request full integration interrupt
  - `x` -> abort the current iteration after the current batch finishes
- Interactive streaming now shows a zero-progress frame immediately when each
  iteration starts, and the initial live status is now emitted before the
  expensive per-iteration worker-state construction begins.
- `--renderer=tabled` now starts a lightweight raw-mode control listener so
  streamed tabled output remains responsive to `Ctrl-C` and `x`.
- Tabled parity fixes now explicitly cover:
  - single-line contribution headers
  - preserved canonical `info!()` summaries while ratatui keeps its richer
    panel/table layout
- Targeted ratatui buffer tests were added in
  `crates/gammalooprs/src/integrate/mod.rs` for the overview, convergence-phase
  toggle, and discrete tabs.

### Still open / follow-up

- Python-facing renderer selection has not been threaded through every possible
  API surface yet; the CLI path is implemented.
- Interrupted work is still treated as partial-iteration work: the system
  remains checkpointed at completed-iteration boundaries only, which matches
  the current workspace/resume model. There is no partial-iteration persistence
  plan.
- Ratatui still needs broader state-machine coverage and more screenshot-driven
  polish:
  - mixed live ratatui + tabled summaries
  - non-TTY fallback
  - narrow-terminal layout behavior
  - max-weight-heavy payloads / long coordinate wrapping
- Optional UX polish still available:
  - more compact overview summary columns on narrower terminals
  - tighter chart/summary spacing on medium-width terminals
  - more aggressive chart-history downsampling tuning

## High-level goals

- Build a high-quality ratatui dashboard that feels native to terminal UIs
  rather than a direct port of the current tabled output.
- Preserve the existing cell content and label formatting conventions already
  captured in `crates/gammalooprs/src/integrate/display.rs`, and prefer using
  the preformatted display strings already carried by `StatusUpdate`.
- Keep the renderer boundary clean:
  - `gammalooprs` owns semantic integration status data
  - `gammaloop-api` owns TTY handling, alternate-screen lifecycle, and the
    ratatui event loop
- Improve readability for narrow terminals, multi-slot runs, and discrete-grid
  monitoring instead of forcing one static layout.

## Proposed architecture

### 1. Renderer selection and fallback behavior

- Add a `RendererOption` enum to
  `crates/gammaloop-api/src/commands/integrate.rs`.
- Thread that selection through CLI and Python bindings so both frontends stay
  aligned.
- Behavior matrix:
  - `--renderer=tabled`: keep the current streaming-in-place text renderer,
    plus keyboard controls for `Ctrl-C` and `x`.
  - `--renderer=ratatui` on a TTY: use the dashboard.
  - `--renderer=ratatui` on a non-TTY: log one fallback message and use current
    tabled logging behavior.
  - `--show-summary-only`: bypass ratatui entirely and print the current final
    tabled summary.

### 2. Semantic status snapshot refactor

- Keep `StatusUpdate` as the renderer-neutral contract, but make it less
  table-shaped and more complete for ratatui.
- Extend the status payload with data that ratatui needs but tabled currently
  hides or compresses:
  - explicit per-slot metrics for all slots, not just slot 0
  - current iteration timing metadata needed for ETA
  - training-slot and training-phase metadata for the live chart
  - typed statistics/timing breakdowns instead of only a prebuilt statistics
    table
  - monitored discrete-axis/path metadata for breadcrumbs and per-bin drilldown
- Prefer attaching behavior to existing section/state structs with methods where
  that improves discoverability, instead of adding more free helper functions.

### 3. Per-slot metrics model

- The current main table already carries per-slot value and relative error, but
  `chi^2` and max-weight impact are effectively slot-0 metadata.
- Ratatui should have access to per-slot:
  - value +/- uncertainty
  - relative error
  - `chi^2/dof` where meaningful
  - max-weight impact
  - target deltas for the first slot when targets exist
- Tabled can continue to render the compact slot-0 metadata columns, while the
  ratatui overview can show a richer all-slot metrics matrix.

### 4. Ratatui controller/event-loop design

- Implement ratatui in `gammaloop-api`, likely as a small dashboard module
  split into:
  - app state
  - terminal lifecycle/suspend-resume guard
  - drawing/layout helpers
  - key handling
  - status-history/cache logic
- Use a dedicated UI controller/thread:
  - integration sends `StatusUpdate` messages
  - UI thread handles input, redraw ticks, resize, suspend/resume, and shutdown
- This keeps the integrator hot path simple and makes interactive features like
  sorting and column toggles straightforward.

### 5. Suspend/resume lifecycle

- Ratatui path should use alternate screen + raw mode while active.
- Before emitting a tabled iteration summary or final summary:
  - leave alternate screen
  - disable raw mode
  - clear ratatui state from the terminal
  - print the tabled summary with the existing `info!()` path
- On the next live update, re-enter alternate screen and redraw from the latest
  cached dashboard state.

## Dashboard UX plan

### Global shell

- Keep a stable top-level frame with:
  - top title/tabs row
  - progress/status ribbon
  - main content area
  - bottom help/status footer
- Provide a small persistent key-hint footer, with a fuller help overlay on `?`.
- Support dynamic layout tiers:
  - wide: side-by-side panels
  - medium: stacked secondary panels
  - narrow: focus-first layout with fewer simultaneous tables

### Tab 1: Overview

- This is the main landing tab.
- Layout target on wide terminals:
  - top: progress ribbon + slot ribbon
  - left: convergence chart
  - right: focused-slot details card
  - bottom-left: all-slot metrics matrix
  - bottom-right: integration statistics panel

#### Progress ribbon

- Fancy ratatui gauge for current iteration progress.
- Include:
  - iteration number/state
  - completed/target iteration samples
  - total samples
  - throughput
  - ETA for the current iteration
  - elapsed wall time
- Use color states for healthy / warning / interrupted conditions.

#### Slot ribbon

- Show every slot as a compact card so multi-slot runs stay visible together.
- Each card should include at least:
  - slot label
  - current value +/- uncertainty
  - relative error badge
  - `chi^2/dof` badge
  - max-weight impact badge
- One slot is focused at a time; focus drives the right-side detail card and,
  when appropriate, secondary annotations in the chart.

#### Convergence chart

- Plot the training-slot integral in the selected training phase.
- Datasets:
  - central-value line
  - upper uncertainty line
  - lower uncertainty line
  - completed-iteration markers
  - target line when available
- Keep completed-iteration points visually distinct from intra-iteration live
  points.
- Use axis hysteresis/padding so the plot does not jitter on every redraw.
- Downsample history to terminal width.
- Allow:
  - phase toggle between real/imag for the focused integrand
  - history window toggle between full history and the last `N` iterations
  - y-range adjustment/reset in units of the current MC uncertainty

#### All-slot metrics matrix

- Show all slots together in a compact comparison matrix.
- Include interactively toggled extra columns:
  - relative error
  - `chi^2/dof`
  - max-weight impact
- Proposed interaction:
  - `r` toggles relative-error column
  - `c` toggles `chi^2/dof`
  - `w` toggles max-weight impact
  - `m` cycles density presets (`compact`, `metrics`, `full`)
- On narrow terminals, collapse this matrix into per-slot stacked rows instead
  of truncating columns aggressively.

#### Statistics panel

- Keep raw numbers readable, but complement them with visual composition bars.
- Show both exact values and percent-based visuals for metrics that should sum
  to 100%.
- Best candidates:
  - timing breakdown:
    - parameterization
    - evaluator
    - integrand
    - event processing
    - integrator overhead
  - precision mix:
    - double
    - quad
    - arb
  - stability mix:
    - stable
    - unstable
    - nan
  - event/selection efficiency:
    - accepted
    - rejected
- Preferred visual treatment:
  - compact numeric table on one side
  - horizontal composition bars on the other side
- That keeps the exact data visible while letting the user perceive balance and
  anomalies immediately.

### Tab 2: Discrete breakdown

- Always present, but show a clear empty-state panel when there is no monitored
  discrete dimension.
- Layout target:
  - left: discrete-bin table
  - right: selected-bin detail pane
  - optional bottom strip: slot comparison for the selected bin

#### Discrete-bin table

- Ratatui should improve on the current static sort choice with live sorting.
- Support:
  - sort mode cycle (`index`, `integral`, `error`, maybe `sample fraction`)
  - sort direction toggle
  - keyboard selection of a specific bin
- Show compact bar-style augmentations for:
  - sample fraction
  - target PDF
  - maybe absolute contribution magnitude

#### Selected-bin detail pane

- Show richer detail for the highlighted bin:
  - breadcrumb of fixed coordinates / monitored path
  - label formatting preserved from existing display helpers
  - per-slot values and uncertainties
  - per-slot relative errors
  - per-slot `chi^2/dof`
  - per-slot max-weight impact
  - max-weight coordinates if available

### Tab 3: Max weight

- Always present, with empty-state handling if no data exists.
- Layout target:
  - upper panel: overall max-weight details table
  - lower/side panel: per-bin max-weight details for either all bins or the
    currently selected discrete bin
- If a discrete tab selection exists, reuse that bin selection here so the UI
  feels coherent across tabs.
- For long coordinate payloads, show a wrapped viewer panel rather than forcing
  a huge wide table.

### Help/footer UX

- Bottom footer should show the current mode and the most important keys:
  - tab switching
  - slot/bin focus
  - sorting
  - metric toggles
  - density toggle
  - help
- `?` opens a centered help overlay/modal summarizing all keybindings.

## Creative ratatui features to leverage

- Composition bars for timing/precision/stability percentages.
- Focused-slot cards with threshold-colored metric badges.
- Empty-state panels that explain why a tab has no data instead of showing a
  blank area.
- Density modes so the same dashboard can feel spacious on large terminals and
  still usable on laptops.
- Mode/status toast line in the footer when a sort mode or column toggle
  changes.
- Stable selection coupling between tabs, especially for the focused slot and
  selected discrete bin.

## ETA plan

- Add explicit current-iteration elapsed time to the status snapshot so ETA does
  not need to be guessed from total integration runtime.
- Compute ETA from smoothed current-iteration throughput rather than using only
  the latest batch delta.
- Show:
  - instantaneous-ish throughput
  - smoothed throughput
  - ETA to iteration completion
- If too little data exists, show `ETA: warming up` instead of a noisy guess.

## Interrupt-responsiveness plan

- Add interrupt checks after each completed sample inside:
  - `crates/gammalooprs/src/integrands/mod.rs`
  - `crates/gammalooprs/src/integrands/process/mod.rs`
- Also break before starting the next sample once the interrupt flag is set, so
  no extra sample is started after the user has already interrupted.
- Do not change the completed-iteration checkpoint model: interrupted work
  inside the current iteration is still not persisted as a resumable partial
  iteration.
- Keep the existing outer batch-level checks in
  `crates/gammalooprs/src/integrate/mod.rs` as a second layer.
- Tests should verify prompt return at sample boundaries; persistence semantics
  remain iteration-level, not partial-iteration-level.

## Proposed implementation phases

### Phase 1: Renderer plumbing and status refactor

- Status: mostly done for the CLI/runtime path.
- Add renderer selection to CLI/Python/config surfaces.
- Add ratatui dependency to `crates/gammaloop-api/Cargo.toml`.
- Refactor `StatusUpdate` into a richer renderer-neutral snapshot.
- Add typed statistics/timing breakdown structures.
- Add per-slot metric support for all slots.

### Phase 2: Dashboard controller and terminal lifecycle

- Status: done for the current CLI dashboard implementation.
- Implement alternate-screen/raw-mode guard.
- Implement UI thread/controller with message passing.
- Add suspend/resume around iteration-summary and final-summary tabled output.
- Add resize handling and redraw ticks.

### Phase 3: Overview tab

- Status: done for the first production cut.
- Implement progress ribbon with ETA.
- Implement slot ribbon and focused-slot detail card.
- Implement convergence chart and status history cache.
- Add convergence controls for phase toggle, history-window selection, and
  y-range adjustment/reset in units of the current MC error.
- Implement all-slot metrics matrix with interactive metric toggles.
- Implement statistics table + composition bars.

### Phase 4: Discrete and max-weight tabs

- Status: done for the first production cut.
- Implement discrete-bin table with keyboard sorting and selection.
- Implement selected-bin detail pane.
- Implement overall and per-bin max-weight panels.
- Couple slot/bin focus across tabs where it helps.

### Phase 5: Interrupt responsiveness

- Status: core interrupt checks are done; iteration-level persistence semantics
  stay unchanged.
- Add per-sample interrupt checks in `evaluate_samples_raw` paths.
- Ensure partial batch results are returned cleanly.
- Add targeted tests.

### Phase 6: Polish and tests

- Status: in progress.
- Ratatui buffer/snapshot tests for wide and narrow layouts.
- Tabled parity tests to ensure the refactor does not regress the current
  non-ratatui summaries, including preserving single-line contribution headers
  in the canonical tabled output while ratatui keeps the richer two-line
  header layout.
- State-machine tests for:
  - live-only streaming
  - iteration-summary-only streaming
  - mixed ratatui live + tabled iteration summaries
  - final-summary suspend/teardown
  - non-TTY fallback
- Manual validation passes for:
  - single-slot
  - multi-slot
  - discrete monitoring
  - long max-weight coordinate payloads

## Risks to watch

- Overfitting the semantic snapshot to the current tabled structure instead of
  giving ratatui the richer data it needs.
- Letting narrow-terminal behavior degrade into clipped unreadable tables.
- Recomputing expensive history or derived metrics on every frame instead of
  caching in the UI controller.
- Making suspend/resume flaky around `info!()` logging; this needs clean
  terminal ownership boundaries.
- Breaking current tabled output while refactoring shared status assembly.
