### PR TITLE
Bulk profile

### DIFF
--- a/assets/schemas/runhistory.json
+++ b/assets/schemas/runhistory.json
@@ -2678,7 +2678,7 @@
           ]
         },
         {
-          "description": "Infrared profile analysis",
+          "description": "Bulk profile analysis",
           "type": "object",
           "properties": {
             "InfraRed": {

--- a/crates/gammaloop-api/src/commands/profile.rs
+++ b/crates/gammaloop-api/src/commands/profile.rs
@@ -131,6 +131,10 @@ pub struct InfraRedProfile {
     /// Profile each visible orientation separately and report one row per orientation
     #[arg(long = "per-orientation")]
     pub per_orientation: bool,
+
+    /// Retain generated event data so per-cut IR fits can be computed and displayed
+    #[arg(long = "show-per-cut-info")]
+    pub show_per_cut_info: bool,
 }
 
 impl Default for InfraRedProfile {
@@ -145,6 +149,7 @@ impl Default for InfraRedProfile {
             output_file: None,
             select: None,
             per_orientation: false,
+            show_per_cut_info: false,
         }
     }
 }
@@ -274,6 +279,7 @@ impl Profile {
                 output_file: _,
                 select,
                 per_orientation,
+                show_per_cut_info,
             }) => {
                 let ir_profile_settings = IRProfileSetting {
                     lambda_exp_start: *min_scale_exponent,
@@ -286,6 +292,7 @@ impl Profile {
                     } else {
                         OrientationProfileMode::Summed
                     },
+                    show_per_cut_info: *show_per_cut_info,
                 };
 
                 let (process_id, integrand_name) =

--- a/crates/gammaloop-api/src/commands/profile.rs
+++ b/crates/gammaloop-api/src/commands/profile.rs
@@ -28,7 +28,8 @@ use clap::{Args, Subcommand};
 pub enum Profile {
     /// Ultraviolet profile analysis
     UltraViolet(#[command(flatten)] UltraVioletProfile),
-    /// Infrared profile analysis
+    /// Bulk profile analysis
+    #[command(name = "bulk")]
     InfraRed(#[command(flatten)] InfraRedProfile),
 }
 

--- a/crates/gammaloop-api/src/repl.rs
+++ b/crates/gammaloop-api/src/repl.rs
@@ -2698,7 +2698,7 @@ fn add_selected_integrand_category_suggestions(
 }
 
 fn is_ir_profile_select_argument(context: &CommandContext<'_>, arg: &clap::Arg) -> bool {
-    matches_command_path(context, &["profile", "infra-red"]) && arg.get_long() == Some("select")
+    matches_command_path(context, &["profile", "bulk"]) && arg.get_long() == Some("select")
 }
 
 fn add_ir_profile_select_suggestions(
@@ -4517,7 +4517,7 @@ mod tests {
         assert!(uv_values.contains(&"virtual".to_string()));
         assert!(!uv_values.contains(&"subtracted".to_string()));
 
-        let ir_values = completion_values("profile infra-red -i ", &completion_state);
+        let ir_values = completion_values("profile bulk -i ", &completion_state);
         assert!(ir_values.contains(&"LO".to_string()));
         assert!(ir_values.contains(&"subtracted".to_string()));
         assert!(!ir_values.contains(&"virtual".to_string()));
@@ -4534,7 +4534,7 @@ mod tests {
         assert!(uv_values.contains(&"epem_a_tth".to_string()));
         assert!(!uv_values.contains(&"epem_xs".to_string()));
 
-        let ir_values = completion_values("profile infra-red -p e", &completion_state);
+        let ir_values = completion_values("profile bulk -p e", &completion_state);
         assert!(ir_values.contains(&"epem_xs".to_string()));
         assert!(!ir_values.contains(&"epem_a_tth".to_string()));
     }
@@ -5152,7 +5152,7 @@ mod tests {
         };
 
         let graph_values = completion_values(
-            "profile infra-red -p epem_xs -i subtracted --select GL",
+            "profile bulk -p epem_xs -i subtracted --select GL",
             &completion_state,
         );
         assert!(
@@ -5165,7 +5165,7 @@ mod tests {
         );
 
         let limit_values = completion_values(
-            "profile infra-red -p epem_xs -i subtracted --select GL1\\ ",
+            "profile bulk -p epem_xs -i subtracted --select GL1\\ ",
             &completion_state,
         );
         assert!(

--- a/crates/gammalooprs/src/graph/mod.rs
+++ b/crates/gammalooprs/src/graph/mod.rs
@@ -8,8 +8,8 @@ use linnet::{
         HedgeGraph,
         involution::{EdgeData, EdgeIndex, Hedge, HedgePair},
         subgraph::{
-            HedgeNode, Inclusion, ModifySubSet, OrientedCut, SuBitGraph, SubGraphLike, SubSetLike,
-            SubSetOps, subset::SubSet,
+            HedgeNode, Inclusion, ModifySubSet, OrientedCut, SuBitGraph, SubSetLike, SubSetOps,
+            subset::SubSet,
         },
     },
     parser::DotGraph,

--- a/crates/gammalooprs/src/integrands/process/amplitude/mod.rs
+++ b/crates/gammalooprs/src/integrands/process/amplitude/mod.rs
@@ -30,7 +30,8 @@ use crate::{
     DependentMomentaConstructor, F, FloatLike, GammaLoopContext, GammaLoopContextContainer,
     cff::{
         esurface::{
-            EsurfaceCollection, EsurfaceID, ExistingEsurfaces, GroupEsurfaceId, get_representative,
+            EsurfaceCollection, EsurfaceID, ExistingEsurfaceId, ExistingEsurfaces, GroupEsurfaceId,
+            get_representative,
         },
         expression::OrientationID,
         surface::HybridSurfaceID,
@@ -39,16 +40,20 @@ use crate::{
         FeynmanGraph, Graph, GraphGroup, GraphGroupPosition, GroupId, LMBext, LmbIndex,
         LoopMomentumBasis,
     },
-    integrands::HasIntegrand,
-    integrands::evaluation::{EvaluationMetaData, EvaluationResult, GraphEvaluationResult},
-    integrands::process::{
-        ChannelIndex, ParamBuilder,
-        evaluators::{ActiveF64Backend, EvaluatorStack},
+    integrands::{
+        HasIntegrand,
+        evaluation::{EvaluationMetaData, EvaluationResult, GraphEvaluationResult},
+        process::{
+            ChannelIndex, ParamBuilder,
+            evaluators::{ActiveF64Backend, EvaluatorStack},
+        },
     },
     model::Model,
-    momentum::sample::{ExternalIndex, MomentumSample},
-    momentum::signature::SignatureLike,
-    momentum::{Helicity, Rotation, RotationMethod, SignOrZero},
+    momentum::{
+        Helicity, Rotation, RotationMethod, SignOrZero,
+        sample::{ExternalIndex, LoopMomenta, MomentumSample},
+        signature::SignatureLike,
+    },
     observables::{AdditionalWeightKey, EventProcessingRuntime, GenericEvent},
     processes::{AmplitudeGraph, GraphGenerationStats, GroupDerivedData},
     settings::{GlobalSettings, RuntimeSettings, global::FrozenCompilationMode},
@@ -58,7 +63,7 @@ use crate::{
         },
         overlap::{OverlapInput, SingleGraphOverlapData, find_maximal_overlap},
     },
-    utils::{W_, serde_utils::SmartSerde, symbolica_ext::LOGPRINTOPTS},
+    utils::{ArbPrec, W_, serde_utils::SmartSerde, symbolica_ext::LOGPRINTOPTS},
 };
 
 use super::{

--- a/crates/gammalooprs/src/integrands/process/amplitude/mod.rs
+++ b/crates/gammalooprs/src/integrands/process/amplitude/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     },
     model::Model,
     momentum::{
-        Helicity, Rotation, RotationMethod, SignOrZero,
+        self, Helicity, Rotation, RotationMethod, SignOrZero,
         sample::{ExternalIndex, LoopMomenta, MomentumSample},
         signature::SignatureLike,
     },
@@ -60,6 +60,7 @@ use crate::{
     subtraction::{
         amplitude_counterterm::{
             AmplitudeCountertermAtom, AmplitudeCountertermData, AmplitudeCountertermEvaluation,
+            OverlapStructureWithKinematics,
         },
         overlap::{OverlapInput, SingleGraphOverlapData, find_maximal_overlap},
     },
@@ -94,6 +95,21 @@ pub struct AmplitudeGraphTerm {
 
 /// Num(sigma_1,sigma_2,...)*(CFF_1 delta(edge(1),1) delta_(1,1,1,-1,1)+CFF_3 delta_(1,1,1,-1,1)+CFF_2 delta_(1,1,1,-1,1))
 impl AmplitudeGraphTerm {
+    pub fn kinematics_for_threshold_approach(
+        &mut self,
+        settings: &RuntimeSettings,
+        model: &Model,
+        momentum_sample: &MomentumSample<ArbPrec>,
+    ) -> Result<OverlapStructureWithKinematics<ArbPrec>> {
+        self.threshold_counterterm.kinematics_for_approach(
+            momentum_sample,
+            &self.graph,
+            model,
+            &self.esurfaces,
+            &Rotation::new(RotationMethod::Identity),
+            settings,
+        )
+    }
     pub fn from_amplitude_graph(
         graph: &AmplitudeGraph,
         own_group_position: GraphGroupPosition,
@@ -713,6 +729,20 @@ pub mod export;
 pub mod load;
 
 impl AmplitudeIntegrand {
+    pub(crate) fn kinematics_for_threshold_approach(
+        &mut self,
+        momentum_sample: &MomentumSample<ArbPrec>,
+        model: &Model,
+    ) -> Result<Vec<OverlapStructureWithKinematics<ArbPrec>>> {
+        self.data
+            .graph_terms
+            .iter_mut()
+            .map(|term| {
+                term.kinematics_for_threshold_approach(&self.settings, model, momentum_sample)
+            })
+            .try_collect()
+    }
+
     fn warn_on_off_shell_external_states(&self, model: &Model) -> Result<()> {
         let externals = self
             .settings

--- a/crates/gammalooprs/src/integrands/process/amplitude/mod.rs
+++ b/crates/gammalooprs/src/integrands/process/amplitude/mod.rs
@@ -30,8 +30,7 @@ use crate::{
     DependentMomentaConstructor, F, FloatLike, GammaLoopContext, GammaLoopContextContainer,
     cff::{
         esurface::{
-            EsurfaceCollection, EsurfaceID, ExistingEsurfaceId, ExistingEsurfaces, GroupEsurfaceId,
-            get_representative,
+            EsurfaceCollection, EsurfaceID, ExistingEsurfaces, GroupEsurfaceId, get_representative,
         },
         expression::OrientationID,
         surface::HybridSurfaceID,
@@ -50,8 +49,8 @@ use crate::{
     },
     model::Model,
     momentum::{
-        self, Helicity, Rotation, RotationMethod, SignOrZero,
-        sample::{ExternalIndex, LoopMomenta, MomentumSample},
+        Helicity, Rotation, RotationMethod, SignOrZero,
+        sample::{ExternalIndex, MomentumSample},
         signature::SignatureLike,
     },
     observables::{AdditionalWeightKey, EventProcessingRuntime, GenericEvent},

--- a/crates/gammalooprs/src/integrands/process/ir.rs
+++ b/crates/gammalooprs/src/integrands/process/ir.rs
@@ -12,11 +12,12 @@ use rand::Rng;
 use symbolica::numerical_integration::MonteCarloRng;
 use tabled::{builder::Builder, settings::Style};
 use tracing::warn;
+use typed_index_collections::TiVec;
 
 use crate::{
     DependentMomentaConstructor,
-    cff::esurface::EsurfaceID,
-    graph::{FeynmanGraph, LmbError, lmb::LMBwithEdges},
+    cff::esurface::{EsurfaceID, ExistingEsurfaceId, ExistingEsurfaces, GroupEsurfaceId},
+    graph::{FeynmanGraph, GraphGroupPosition, LmbError, lmb::LMBwithEdges},
     integrands::{
         evaluation::PreciseEvaluationResult,
         process::{
@@ -38,6 +39,7 @@ use crate::{
             ParameterizationMode, ParameterizationSettings,
         },
     },
+    subtraction::amplitude_counterterm::OverlapStructureWithKinematics,
     utils::{
         ArbPrec, F, FloatLike, box_muller,
         fitting::{constant_dropped_fit_points, log_log_slope_constant_dropped},
@@ -618,6 +620,24 @@ fn build_single_limit_report(
     }
 }
 
+fn build_threshold_limit_report(
+    threshold_limit: &ThresholdLimit,
+    orientation_label: Option<String>,
+    slope: PowerLawFit,
+    per_cut_reports: Vec<CutLimitReport>,
+) -> SingleLimitReport {
+    let scaling = slope.exponent;
+    SingleLimitReport {
+        limit_name: format!("{}", threshold_limit),
+        orientation_label,
+        passed: scaling > 0.0,
+        power_law_fit: slope,
+        scaling,
+        per_cut_reports,
+        num_soft: 0,
+    }
+}
+
 fn build_cut_limit_reports(
     num_soft: usize,
     cut_fits: Vec<(usize, Result<PowerLawFit>)>,
@@ -641,12 +661,26 @@ fn build_cut_limit_reports(
         .collect()
 }
 
+fn threshold_approach_loop_momenta<T: FloatLike>(
+    overlap_group_center: &LoopMomenta<F<f64>>,
+    threshold_point: &MomentumSample<T>,
+    lambda: &F<T>,
+) -> LoopMomenta<F<T>> {
+    let overlap_group_center = overlap_group_center.cast::<T>();
+    let threshold_loop_momenta = threshold_point.loop_moms();
+    let offset_towards_center =
+        (&overlap_group_center - threshold_loop_momenta).rescale(lambda, None);
+
+    threshold_loop_momenta + &offset_towards_center
+}
+
 fn run_ir_profile<I: ProcessIntegrandImpl>(
     integrand: &mut I,
     ir_profile_settings: &IRProfileSetting,
     model: &Model,
     enumerate_limits: impl Fn(&I) -> Vec<(String, Vec<ProfileLimit>)>,
     graph_cut_definitions: impl Fn(&I, usize) -> Vec<GraphCutDefinition>,
+    points_on_threshold: &[OverlapStructureWithKinematics<ArbPrec>],
     mut test_single_limit: impl FnMut(
         &mut I,
         usize,
@@ -654,6 +688,7 @@ fn run_ir_profile<I: ProcessIntegrandImpl>(
         &mut MonteCarloRng,
         &IRProfileSetting,
         &Model,
+        &[OverlapStructureWithKinematics<ArbPrec>],
     ) -> Result<Vec<SingleLimitReport>>,
 ) -> Result<IrLimitTestReport> {
     let mut rng = MonteCarloRng::new(ir_profile_settings.seed, 0);
@@ -689,6 +724,7 @@ fn run_ir_profile<I: ProcessIntegrandImpl>(
                 &mut rng,
                 ir_profile_settings,
                 model,
+                points_on_threshold,
             )?);
         }
 
@@ -735,12 +771,41 @@ impl AmplitudeIntegrand {
 
         let result = (|| {
             self.warm_up(model)?;
+
+            let dependent_momenta_constructor = DependentMomentaConstructor::Amplitude(
+                &self.data.graph_terms[0].graph.get_external_signature(),
+            );
+
+            let random_loop_momenta = (0..self.data.graph_terms[0]
+                .graph
+                .loop_momentum_basis
+                .loop_edges
+                .len())
+                .map(|_| {
+                    sample_random_unit_vector(&mut MonteCarloRng::new(ir_profile_settings.seed, 0))
+                })
+                .collect();
+
+            let momentum_sample = MomentumSample::new(
+                random_loop_momenta,
+                0,
+                &self.settings.kinematics.externals,
+                0,
+                F::from_f64(1.0),
+                dependent_momenta_constructor,
+                None,
+            )?;
+
+            let points_on_threshold =
+                self.kinematics_for_threshold_approach(&momentum_sample, model)?;
+
             run_ir_profile(
                 self,
                 ir_profile_settings,
                 model,
                 Self::enumerate_ir_limits,
                 Self::graph_cut_definitions,
+                &points_on_threshold,
                 Self::test_single_ir_limit_impl,
             )
         })();
@@ -758,11 +823,22 @@ impl AmplitudeIntegrand {
             .iter()
             .map(|term| {
                 let graph_name = term.graph.name.clone();
-                let limits = term
+                let mut limits = term
                     .enumerate_ir_limits()
                     .into_iter()
                     .map(ProfileLimit::Ir)
-                    .collect::<Vec<_>>();
+                    .collect_vec();
+                limits.extend(
+                    ThresholdLimit::enumerate_from_overlap_structure(
+                        &term.threshold_counterterm.overlap.existing_esurfaces,
+                        &term.threshold_counterterm.esurface_map,
+                        term.threshold_counterterm.own_group_position,
+                    )
+                    .into_iter()
+                    .map(ProfileLimit::Threshold),
+                );
+                limits.sort();
+                limits.dedup();
                 (graph_name, limits)
             })
             .collect()
@@ -779,6 +855,7 @@ impl AmplitudeIntegrand {
         rng: &mut MonteCarloRng,
         approach_settings: &IRProfileSetting,
         model: &Model,
+        points_on_threshold: &[OverlapStructureWithKinematics<ArbPrec>],
     ) -> Result<Vec<SingleLimitReport>> {
         match profile_limit {
             ProfileLimit::Ir(ir_limit) => {
@@ -861,7 +938,7 @@ impl AmplitudeIntegrand {
                         );
 
                         limit_data.data.push(LambdaPointEval {
-                            lambda_point,
+                            lambda: lambda_point.lambda,
                             value: evaluate_profile_momentum_point_arb(
                                 self,
                                 model,
@@ -885,10 +962,78 @@ impl AmplitudeIntegrand {
                 Ok(reports)
             }
             ProfileLimit::Threshold(threshold_limit) => {
-                return Err(eyre!(
-                    "Threshold limit '{}' is not yet supported in amplitude IR profiling",
-                    threshold_limit
-                ));
+                let overlap_structure = points_on_threshold.get(graph_id).ok_or_else(|| {
+                    eyre!(
+                        "Missing threshold-approach kinematics for amplitude graph {}",
+                        graph_id
+                    )
+                })?;
+
+                let existing_esurface_id = threshold_limit.resolve_existing_esurface_id(
+                    &self.data.graph_terms[graph_id]
+                        .threshold_counterterm
+                        .esurface_map,
+                    self.data.graph_terms[graph_id]
+                        .threshold_counterterm
+                        .own_group_position,
+                    &overlap_structure.existing_esurfaces,
+                )?;
+
+                let momenta_per_overlap_group = threshold_limit.get_momenta_per_overlap_group(
+                    overlap_structure,
+                    existing_esurface_id,
+                    approach_settings,
+                )?;
+                let orientations = requested_orientations(self, graph_id, approach_settings)?;
+                let mut reports =
+                    Vec::with_capacity(orientations.len() * momenta_per_overlap_group.len());
+
+                for (overlap_group_label, momenta) in momenta_per_overlap_group {
+                    for (orientation, orientation_label) in &orientations {
+                        let mut limit_data = LimitData { data: Vec::new() };
+
+                        for lambda_point in &momenta {
+                            limit_data.data.push(LambdaPointEval {
+                                lambda: lambda_point.lambda.clone(),
+                                value: evaluate_profile_momentum_point_arb(
+                                    self,
+                                    model,
+                                    graph_id,
+                                    *orientation,
+                                    lambda_point
+                                        .loop_momenta
+                                        .iter()
+                                        .map(|momentum| {
+                                            ThreeMomentum::new(
+                                                F::from_f64(momentum.px.into_f64()),
+                                                F::from_f64(momentum.py.into_f64()),
+                                                F::from_f64(momentum.pz.into_f64()),
+                                            )
+                                        })
+                                        .collect_vec(),
+                                    approach_settings.show_per_cut_info,
+                                )?,
+                            });
+                        }
+
+                        let (power_law_fit, cut_fits) = limit_data.extract_power()?;
+                        let context_label = Some(match orientation_label.as_deref() {
+                            Some(orientation_label) => {
+                                format!("{overlap_group_label} / {orientation_label}")
+                            }
+                            None => overlap_group_label.clone(),
+                        });
+
+                        reports.push(build_threshold_limit_report(
+                            threshold_limit,
+                            context_label,
+                            power_law_fit,
+                            build_cut_limit_reports(0, cut_fits),
+                        ));
+                    }
+                }
+
+                Ok(reports)
             }
         }
     }
@@ -919,6 +1064,8 @@ impl CrossSectionIntegrand {
             self.settings.general.generate_events = true;
         }
 
+        let points_on_thrshold = vec![]; // threshold limits are not yet supported for cross-section IR profiling
+
         let result = (|| {
             self.warm_up(model)?;
             run_ir_profile(
@@ -927,6 +1074,7 @@ impl CrossSectionIntegrand {
                 model,
                 Self::enumerate_ir_limits,
                 Self::graph_cut_definitions,
+                &points_on_thrshold,
                 Self::test_single_ir_limit_impl,
             )
         })();
@@ -965,6 +1113,7 @@ impl CrossSectionIntegrand {
         rng: &mut MonteCarloRng,
         approach_settings: &IRProfileSetting,
         model: &Model,
+        _points_on_threshold: &[OverlapStructureWithKinematics<ArbPrec>],
     ) -> Result<Vec<SingleLimitReport>> {
         let ir_limit = match profile_limit {
             ProfileLimit::Ir(ir_limit) => ir_limit,
@@ -1087,7 +1236,7 @@ impl CrossSectionIntegrand {
                 );
 
                 limit_data.data.push(LambdaPointEval {
-                    lambda_point,
+                    lambda: lambda_point.lambda,
                     value: evaluate_profile_momentum_point_arb(
                         self,
                         model,
@@ -1183,6 +1332,23 @@ impl Display for ProfileLimit {
 }
 
 impl ThresholdLimit {
+    fn enumerate_from_overlap_structure(
+        existing_esurfaces: &ExistingEsurfaces,
+        esurface_map: &TiVec<GroupEsurfaceId, TiVec<GraphGroupPosition, Option<EsurfaceID>>>,
+        own_group_position: GraphGroupPosition,
+    ) -> Vec<Self> {
+        existing_esurfaces
+            .iter()
+            .filter_map(|group_esurface_id| {
+                esurface_map[*group_esurface_id][own_group_position]
+                    .map(|esurface_id| Self { esurface_id })
+            })
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .sorted()
+            .collect()
+    }
+
     fn parse_threshold(threshold: &str) -> Result<Self> {
         let mut threshold = String::from(threshold);
         threshold = String::from(threshold.trim());
@@ -1202,6 +1368,111 @@ impl ThresholdLimit {
         Ok(Self {
             esurface_id: EsurfaceID::from(threshold_id),
         })
+    }
+
+    fn resolve_existing_esurface_id(
+        &self,
+        esurface_map: &TiVec<GroupEsurfaceId, TiVec<GraphGroupPosition, Option<EsurfaceID>>>,
+        own_group_position: GraphGroupPosition,
+        existing_esurfaces: &ExistingEsurfaces,
+    ) -> Result<ExistingEsurfaceId> {
+        existing_esurfaces
+            .iter_enumerated()
+            .find_map(|(existing_esurface_id, group_esurface_id)| {
+                esurface_map
+                    .get(*group_esurface_id)
+                    .and_then(|graph_map| {
+                        (graph_map[own_group_position] == Some(self.esurface_id))
+                            .then_some(existing_esurface_id)
+                    })
+            })
+            .ok_or_else(|| {
+                eyre!(
+                    "Threshold '{}' does not exist in the selected overlap structure",
+                    self
+                )
+            })
+    }
+
+    fn get_momenta_per_overlap_group<T: FloatLike>(
+        &self,
+        overlap_structure: &OverlapStructureWithKinematics<T>,
+        existing_esurface_id: ExistingEsurfaceId,
+        approach_settings: &IRProfileSetting,
+    ) -> Result<Vec<(String, Vec<LambdaLoopMomentaPoint<T>>)>> {
+        let lambda_values = constant_dropped_fit_points(
+            &F::from_f64(10.0_f64.powf(approach_settings.lambda_exp_start)),
+            &F::from_f64(10.0_f64.powf(approach_settings.lambda_exp_end)),
+            approach_settings.steps,
+        )?;
+
+        let mut momenta_per_overlap_group = Vec::new();
+
+        for (overlap_group_id, overlap_group_with_kinematics) in overlap_structure
+            .overlap_groups_with_kinematics
+            .iter()
+            .enumerate()
+        {
+            let mut contains_existing_esurface = false;
+            let mut threshold_point = None;
+
+            for (group_existing_esurface_id, maybe_threshold_point) in overlap_group_with_kinematics
+                .overlap_group
+                .existing_esurfaces
+                .iter()
+                .copied()
+                .zip(
+                    overlap_group_with_kinematics
+                        .loop_momenta_at_esurface
+                        .iter(),
+                )
+            {
+                if group_existing_esurface_id != existing_esurface_id {
+                    continue;
+                }
+
+                contains_existing_esurface = true;
+                threshold_point = maybe_threshold_point.as_ref();
+                break;
+            }
+
+            if !contains_existing_esurface {
+                continue;
+            }
+
+            let threshold_point = threshold_point.ok_or_else(|| {
+                eyre!(
+                    "Threshold '{}' is missing stored approach kinematics for overlap group {}",
+                    self,
+                    overlap_group_id
+                )
+            })?;
+
+            momenta_per_overlap_group.push((
+                format!("overlap group {}", overlap_group_id),
+                lambda_values
+                    .iter()
+                    .cloned()
+                    .map(|lambda| LambdaLoopMomentaPoint {
+                        loop_momenta: threshold_approach_loop_momenta(
+                            &overlap_group_with_kinematics.overlap_group.center,
+                            threshold_point,
+                            &lambda,
+                        ),
+                        lambda,
+                    })
+                    .collect(),
+            ));
+        }
+
+        if momenta_per_overlap_group.is_empty() {
+            return Err(eyre!(
+                "Threshold '{}' does not appear in any overlap group for the selected graph term",
+                self
+            ));
+        }
+
+        Ok(momenta_per_overlap_group)
     }
 }
 
@@ -1719,8 +1990,14 @@ struct LambdaPoint<T: FloatLike> {
     momenta: Vec<TaggedMomenta<F<T>>>,
 }
 
+#[derive(Clone)]
+struct LambdaLoopMomentaPoint<T: FloatLike> {
+    lambda: F<T>,
+    loop_momenta: LoopMomenta<F<T>>,
+}
+
 struct LambdaPointEval<T: FloatLike> {
-    lambda_point: LambdaPoint<T>,
+    lambda: F<T>,
     value: ProfilePointValue,
 }
 
@@ -1738,7 +2015,7 @@ impl<T: FloatLike> LimitData<T> {
         let x = self
             .data
             .iter()
-            .map(|point_eval| F::<ArbPrec>::from_ff64(point_eval.lambda_point.lambda.into_ff64()))
+            .map(|point_eval| F::<ArbPrec>::from_ff64(point_eval.lambda.into_ff64()))
             .collect_vec();
 
         let y = self
@@ -1829,6 +2106,7 @@ fn fit_power_law(x: Vec<F<ArbPrec>>, y: Vec<F<ArbPrec>>) -> Result<PowerLawFit> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use typed_index_collections::ti_vec;
 
     #[test]
     fn test_display() {
@@ -1970,6 +2248,320 @@ mod tests {
         assert!(
             ProfileLimit::parse_limit(invalid_limit_str5).is_err(),
             "Expected error for multiple threshold limits"
+        );
+    }
+
+    #[test]
+    fn resolve_existing_esurface_id_for_threshold_limit() {
+        let threshold_limit = ThresholdLimit {
+            esurface_id: EsurfaceID::from(7usize),
+        };
+        let esurface_map = ti_vec![
+            ti_vec![
+                Some(EsurfaceID::from(5usize)),
+                Some(EsurfaceID::from(6usize))
+            ],
+            ti_vec![Some(EsurfaceID::from(7usize)), None],
+        ];
+        let existing_esurfaces =
+            ti_vec![GroupEsurfaceId::from(0usize), GroupEsurfaceId::from(1usize)];
+
+        let existing_esurface_id = threshold_limit
+            .resolve_existing_esurface_id(
+                &esurface_map,
+                GraphGroupPosition::from(0usize),
+                &existing_esurfaces,
+            )
+            .unwrap();
+
+        assert_eq!(existing_esurface_id, ExistingEsurfaceId::from(1usize));
+    }
+
+    #[test]
+    fn resolve_existing_esurface_id_rejects_threshold_missing_from_graph() {
+        let threshold_limit = ThresholdLimit {
+            esurface_id: EsurfaceID::from(9usize),
+        };
+        let esurface_map = ti_vec![ti_vec![
+            Some(EsurfaceID::from(5usize)),
+            Some(EsurfaceID::from(6usize))
+        ]];
+        let existing_esurfaces = ti_vec![GroupEsurfaceId::from(0usize)];
+
+        assert!(
+            threshold_limit
+                .resolve_existing_esurface_id(
+                    &esurface_map,
+                    GraphGroupPosition::from(0usize),
+                    &existing_esurfaces,
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn resolve_existing_esurface_id_rejects_threshold_missing_from_overlap() {
+        let threshold_limit = ThresholdLimit {
+            esurface_id: EsurfaceID::from(7usize),
+        };
+        let esurface_map = ti_vec![ti_vec![Some(EsurfaceID::from(7usize))]];
+        let existing_esurfaces = ti_vec![GroupEsurfaceId::from(1usize)];
+
+        assert!(
+            threshold_limit
+                .resolve_existing_esurface_id(
+                    &esurface_map,
+                    GraphGroupPosition::from(0usize),
+                    &existing_esurfaces,
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn enumerate_threshold_limits_from_overlap_structure() {
+        let esurface_map = ti_vec![
+            ti_vec![
+                Some(EsurfaceID::from(5usize)),
+                Some(EsurfaceID::from(8usize))
+            ],
+            ti_vec![Some(EsurfaceID::from(7usize)), None],
+            ti_vec![
+                Some(EsurfaceID::from(5usize)),
+                Some(EsurfaceID::from(9usize))
+            ],
+            ti_vec![None, Some(EsurfaceID::from(3usize))],
+        ];
+        let existing_esurfaces = ti_vec![
+            GroupEsurfaceId::from(2usize),
+            GroupEsurfaceId::from(0usize),
+            GroupEsurfaceId::from(1usize),
+            GroupEsurfaceId::from(3usize),
+        ];
+
+        let threshold_limits = ThresholdLimit::enumerate_from_overlap_structure(
+            &existing_esurfaces,
+            &esurface_map,
+            GraphGroupPosition::from(0usize),
+        );
+        let threshold_limits_for_other_group = ThresholdLimit::enumerate_from_overlap_structure(
+            &existing_esurfaces,
+            &esurface_map,
+            GraphGroupPosition::from(1usize),
+        );
+
+        assert_eq!(
+            threshold_limits,
+            vec![
+                ThresholdLimit {
+                    esurface_id: EsurfaceID::from(5usize),
+                },
+                ThresholdLimit {
+                    esurface_id: EsurfaceID::from(7usize),
+                },
+            ]
+        );
+        assert_eq!(
+            threshold_limits_for_other_group,
+            vec![
+                ThresholdLimit {
+                    esurface_id: EsurfaceID::from(3usize),
+                },
+                ThresholdLimit {
+                    esurface_id: EsurfaceID::from(8usize),
+                },
+                ThresholdLimit {
+                    esurface_id: EsurfaceID::from(9usize),
+                },
+            ]
+        );
+    }
+
+    fn test_ir_profile_settings(steps: usize) -> IRProfileSetting {
+        IRProfileSetting {
+            lambda_exp_start: -3.0,
+            lambda_exp_end: -1.0,
+            steps,
+            seed: 0,
+            select_limits_and_graphs: None,
+            orientation_mode: OrientationProfileMode::Summed,
+            show_per_cut_info: false,
+        }
+    }
+
+    fn test_momentum_sample(loop_momenta: Vec<ThreeMomentum<F<f64>>>) -> MomentumSample<f64> {
+        MomentumSample {
+            sample: crate::momentum::sample::BareMomentumSample {
+                loop_moms: loop_momenta.into_iter().collect(),
+                dual_loop_moms: None,
+                loop_mom_cache_id: 0,
+                loop_mom_base_cache_id: 0,
+                external_moms: ti_vec![],
+                external_mom_cache_id: 0,
+                external_mom_base_cache_id: 0,
+                jacobian: F::from_f64(1.0),
+                orientation: None,
+            },
+        }
+    }
+
+    #[test]
+    fn threshold_approach_loop_momenta_starts_at_stored_threshold_point() {
+        let overlap_group_center: LoopMomenta<F<f64>> = vec![ThreeMomentum::new(
+            F::from_f64(5.0),
+            F::from_f64(7.0),
+            F::from_f64(9.0),
+        )]
+        .into_iter()
+        .collect();
+        let threshold_point = test_momentum_sample(vec![ThreeMomentum::new(
+            F::from_f64(1.0),
+            F::from_f64(3.0),
+            F::from_f64(5.0),
+        )]);
+
+        let at_threshold = threshold_approach_loop_momenta(
+            &overlap_group_center,
+            &threshold_point,
+            &F::from_f64(0.0),
+        );
+        let halfway = threshold_approach_loop_momenta(
+            &overlap_group_center,
+            &threshold_point,
+            &F::from_f64(0.5),
+        );
+        let at_center = threshold_approach_loop_momenta(
+            &overlap_group_center,
+            &threshold_point,
+            &F::from_f64(1.0),
+        );
+
+        assert_eq!(at_threshold, threshold_point.loop_moms().clone());
+        assert_eq!(
+            halfway,
+            vec![ThreeMomentum::new(
+                F::from_f64(3.0),
+                F::from_f64(5.0),
+                F::from_f64(7.0),
+            )]
+            .into_iter()
+            .collect()
+        );
+        assert_eq!(at_center, overlap_group_center);
+    }
+
+    #[test]
+    fn threshold_limit_builds_group_trajectories_for_matching_overlap_groups() {
+        let threshold_limit = ThresholdLimit {
+            esurface_id: EsurfaceID::from(7usize),
+        };
+        let threshold_point = test_momentum_sample(vec![ThreeMomentum::new(
+            F::from_f64(1.0),
+            F::from_f64(2.0),
+            F::from_f64(3.0),
+        )]);
+        let overlap_structure = OverlapStructureWithKinematics {
+            existing_esurfaces: ti_vec![
+                GroupEsurfaceId::from(0usize),
+                GroupEsurfaceId::from(1usize)
+            ],
+            overlap_groups_with_kinematics: vec![
+                crate::subtraction::amplitude_counterterm::OverlapGroupWithKinematics {
+                    overlap_group: crate::subtraction::overlap::OverlapGroup {
+                        existing_esurfaces: vec![ExistingEsurfaceId::from(1usize)],
+                        complement: vec![],
+                        center: vec![ThreeMomentum::new(
+                            F::from_f64(5.0),
+                            F::from_f64(6.0),
+                            F::from_f64(7.0),
+                        )]
+                        .into_iter()
+                        .collect(),
+                        prefactor_evaluator: None,
+                    },
+                    loop_momenta_at_esurface: ti_vec![Some(threshold_point.clone())],
+                },
+                crate::subtraction::amplitude_counterterm::OverlapGroupWithKinematics {
+                    overlap_group: crate::subtraction::overlap::OverlapGroup {
+                        existing_esurfaces: vec![ExistingEsurfaceId::from(0usize)],
+                        complement: vec![],
+                        center: vec![ThreeMomentum::new(
+                            F::from_f64(8.0),
+                            F::from_f64(9.0),
+                            F::from_f64(10.0),
+                        )]
+                        .into_iter()
+                        .collect(),
+                        prefactor_evaluator: None,
+                    },
+                    loop_momenta_at_esurface: ti_vec![Some(test_momentum_sample(vec![
+                        ThreeMomentum::new(F::from_f64(2.0), F::from_f64(3.0), F::from_f64(4.0),),
+                    ]))],
+                },
+            ],
+        };
+
+        let trajectories = threshold_limit
+            .get_momenta_per_overlap_group(
+                &overlap_structure,
+                ExistingEsurfaceId::from(1usize),
+                &test_ir_profile_settings(4),
+            )
+            .unwrap();
+
+        assert_eq!(trajectories.len(), 1);
+        assert_eq!(trajectories[0].0, "overlap group 0");
+        assert_eq!(trajectories[0].1.len(), 4);
+
+        for lambda_point in &trajectories[0].1 {
+            assert_eq!(
+                lambda_point.loop_momenta,
+                threshold_approach_loop_momenta(
+                    &overlap_structure.overlap_groups_with_kinematics[0]
+                        .overlap_group
+                        .center,
+                    &threshold_point,
+                    &lambda_point.lambda,
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn threshold_limit_rejects_group_missing_threshold_kinematics() {
+        let threshold_limit = ThresholdLimit {
+            esurface_id: EsurfaceID::from(7usize),
+        };
+        let overlap_structure: OverlapStructureWithKinematics<f64> =
+            OverlapStructureWithKinematics {
+                existing_esurfaces: ti_vec![GroupEsurfaceId::from(1usize)],
+                overlap_groups_with_kinematics: vec![
+                    crate::subtraction::amplitude_counterterm::OverlapGroupWithKinematics {
+                        overlap_group: crate::subtraction::overlap::OverlapGroup {
+                            existing_esurfaces: vec![ExistingEsurfaceId::from(0usize)],
+                            complement: vec![],
+                            center: vec![ThreeMomentum::new(
+                                F::from_f64(5.0),
+                                F::from_f64(6.0),
+                                F::from_f64(7.0),
+                            )]
+                            .into_iter()
+                            .collect(),
+                            prefactor_evaluator: None,
+                        },
+                        loop_momenta_at_esurface: ti_vec![None],
+                    },
+                ],
+            };
+
+        assert!(
+            threshold_limit
+                .get_momenta_per_overlap_group(
+                    &overlap_structure,
+                    ExistingEsurfaceId::from(0usize),
+                    &test_ir_profile_settings(3),
+                )
+                .is_err()
         );
     }
 

--- a/crates/gammalooprs/src/integrands/process/ir.rs
+++ b/crates/gammalooprs/src/integrands/process/ir.rs
@@ -1175,7 +1175,7 @@ impl CrossSectionIntegrand {
             self.settings.general.generate_events = true;
         }
 
-        let points_on_thrshold = vec![]; // threshold limits are not yet supported for cross-section IR profiling
+        let points_on_threshold = vec![]; // threshold limits are not yet supported for cross-section IR profiling
 
         let result = (|| {
             self.warm_up(model)?;
@@ -1185,7 +1185,7 @@ impl CrossSectionIntegrand {
                 model,
                 Self::enumerate_ir_limits,
                 Self::graph_cut_definitions,
-                &points_on_thrshold,
+                &points_on_threshold,
                 Self::test_single_ir_limit_impl,
             )
         })();

--- a/crates/gammalooprs/src/integrands/process/ir.rs
+++ b/crates/gammalooprs/src/integrands/process/ir.rs
@@ -1632,11 +1632,11 @@ impl<T: FloatLike> LimitData<T> {
             warn!("low r^2 value found for input data");
             warn!(
                 "x: {:?}",
-                x.iter().map(|value| value.into_f64()).collect_vec()
+                x.iter().map(|value| format!("{}", value)).collect_vec()
             );
             warn!(
                 "y: {:?}",
-                y.iter().map(|value| value.into_f64()).collect_vec()
+                y.iter().map(|value| format!("{}", value)).collect_vec()
             );
         }
 

--- a/crates/gammalooprs/src/integrands/process/ir.rs
+++ b/crates/gammalooprs/src/integrands/process/ir.rs
@@ -494,7 +494,7 @@ fn insert_limit_table_separators(rendered: String, separators_after_data_rows: &
 }
 
 fn ir_profile_completion_entries(
-    limits: Vec<(String, Vec<IrLimit>)>,
+    limits: Vec<(String, Vec<ProfileLimit>)>,
 ) -> Vec<(String, Vec<String>)> {
     limits
         .into_iter()
@@ -534,7 +534,7 @@ fn graph_id_by_name<I: ProcessIntegrandImpl>(integrand: &I, graph_name: &str) ->
 fn parse_select_limits_and_graphs<I: ProcessIntegrandImpl>(
     integrand: &I,
     input: &str,
-) -> Result<Vec<(String, Vec<IrLimit>)>> {
+) -> Result<Vec<(String, Vec<ProfileLimit>)>> {
     input
         .split(';')
         .map(|graph_info_string| {
@@ -551,13 +551,13 @@ fn parse_select_limits_and_graphs<I: ProcessIntegrandImpl>(
                 ));
             };
 
-            let ir_limits = parts
-                .map(IrLimit::parse_limit)
+            let profile_limits = parts
+                .map(ProfileLimit::parse_limit)
                 .collect::<Result<Vec<_>, _>>()?;
 
-            if ir_limits.is_empty() {
+            if profile_limits.is_empty() {
                 return Err(eyre!(
-                    "No IR limits specified for graph '{}' in select_limits_and_graphs",
+                    "No limits specified for graph '{}' in select_limits_and_graphs",
                     graph_name
                 ));
             }
@@ -568,14 +568,17 @@ fn parse_select_limits_and_graphs<I: ProcessIntegrandImpl>(
                 .loop_momentum_basis
                 .loop_edges
                 .len();
-            if ir_limits.iter().any(|limit| !limit.is_valid(loop_number).is_ok()) {
+            if profile_limits
+                .iter()
+                .any(|limit| !limit.is_valid(loop_number).is_ok())
+            {
                 return Err(eyre!(
-                    "One or more IR limits specified for graph '{}' in select_limits_and_graphs are not valid",
+                    "One or more limits specified for graph '{}' in select_limits_and_graphs are not valid",
                     graph_name
                 ));
             }
 
-            Ok((graph_name, ir_limits))
+            Ok((graph_name, profile_limits))
         })
         .collect::<Result<Vec<_>, _>>()
 }
@@ -642,12 +645,12 @@ fn run_ir_profile<I: ProcessIntegrandImpl>(
     integrand: &mut I,
     ir_profile_settings: &IRProfileSetting,
     model: &Model,
-    enumerate_limits: impl Fn(&I) -> Vec<(String, Vec<IrLimit>)>,
+    enumerate_limits: impl Fn(&I) -> Vec<(String, Vec<ProfileLimit>)>,
     graph_cut_definitions: impl Fn(&I, usize) -> Vec<GraphCutDefinition>,
     mut test_single_limit: impl FnMut(
         &mut I,
         usize,
-        &IrLimit,
+        &ProfileLimit,
         &mut MonteCarloRng,
         &IRProfileSetting,
         &Model,
@@ -749,13 +752,17 @@ impl AmplitudeIntegrand {
         result
     }
 
-    fn enumerate_ir_limits(&self) -> Vec<(String, Vec<IrLimit>)> {
+    fn enumerate_ir_limits(&self) -> Vec<(String, Vec<ProfileLimit>)> {
         self.data
             .graph_terms
             .iter()
             .map(|term| {
                 let graph_name = term.graph.name.clone();
-                let limits = term.enumerate_ir_limits();
+                let limits = term
+                    .enumerate_ir_limits()
+                    .into_iter()
+                    .map(ProfileLimit::Ir)
+                    .collect::<Vec<_>>();
                 (graph_name, limits)
             })
             .collect()
@@ -768,106 +775,122 @@ impl AmplitudeIntegrand {
     fn test_single_ir_limit_impl(
         &mut self,
         graph_id: usize,
-        ir_limit: &IrLimit,
+        profile_limit: &ProfileLimit,
         rng: &mut MonteCarloRng,
         approach_settings: &IRProfileSetting,
         model: &Model,
     ) -> Result<Vec<SingleLimitReport>> {
-        let edges_in_limit = ir_limit.get_all_edges()?;
-        let lmb = self.data.graph_terms[graph_id].lmb_with_loop_edges(edges_in_limit.as_slice())?;
-        let momenta = ir_limit.get_momenta(rng, &self.settings, approach_settings)?;
-        let non_limit_loops = lmb
-            .loop_edges
-            .iter_enumerated()
-            .filter_map(|(loop_id, edge_id)| {
-                if !edges_in_limit.contains(edge_id) {
-                    Some(loop_id)
-                } else {
-                    None
-                }
-            })
-            .collect_vec();
-
-        let non_limit_momenta = non_limit_loops
-            .iter()
-            .map(|loop_id| (*loop_id, sample_random_unit_vector(rng)))
-            .collect_vec();
-
-        let externals = self.data.graph_terms[graph_id]
-            .graph
-            .get_external_signature();
-
-        let dependent_momenta_constructor = DependentMomentaConstructor::Amplitude(&externals);
-
-        let loop_number = lmb.loop_edges.len();
-        let orientations = requested_orientations(self, graph_id, approach_settings)?;
-        let mut reports = Vec::with_capacity(orientations.len());
-
-        for (orientation, orientation_label) in orientations {
-            let mut limit_data = LimitData { data: Vec::new() };
-
-            for (loop_mom_id, lambda_point) in momenta.iter().cloned().enumerate() {
-                let mut loop_moms: LoopMomenta<F<_>> = (0..loop_number)
-                    .map(|_| {
-                        ThreeMomentum::new(F::from_f64(0.0), F::from_f64(0.0), F::from_f64(0.0))
+        match profile_limit {
+            ProfileLimit::Ir(ir_limit) => {
+                let edges_in_limit = ir_limit.get_all_edges()?;
+                let lmb = self.data.graph_terms[graph_id]
+                    .lmb_with_loop_edges(edges_in_limit.as_slice())?;
+                let momenta = ir_limit.get_momenta(rng, &self.settings, approach_settings)?;
+                let non_limit_loops = lmb
+                    .loop_edges
+                    .iter_enumerated()
+                    .filter_map(|(loop_id, edge_id)| {
+                        if !edges_in_limit.contains(edge_id) {
+                            Some(loop_id)
+                        } else {
+                            None
+                        }
                     })
-                    .collect();
+                    .collect_vec();
 
-                for (loop_id, momentum) in non_limit_momenta.iter() {
-                    loop_moms[*loop_id] = *momentum;
-                }
+                let non_limit_momenta = non_limit_loops
+                    .iter()
+                    .map(|loop_id| (*loop_id, sample_random_unit_vector(rng)))
+                    .collect_vec();
 
-                for tagged_momenta in &lambda_point.momenta {
-                    let edge_id = tagged_momenta.tag;
-                    let loop_id = lmb
-                        .loop_edges
-                        .iter()
-                        .position(|loop_edge| loop_edge == &edge_id)
-                        .unwrap_or_else(|| {
-                            unreachable!("corrupted lmb and ir limit: {}", ir_limit);
+                let externals = self.data.graph_terms[graph_id]
+                    .graph
+                    .get_external_signature();
+
+                let dependent_momenta_constructor =
+                    DependentMomentaConstructor::Amplitude(&externals);
+
+                let loop_number = lmb.loop_edges.len();
+                let orientations = requested_orientations(self, graph_id, approach_settings)?;
+                let mut reports = Vec::with_capacity(orientations.len());
+
+                for (orientation, orientation_label) in orientations {
+                    let mut limit_data = LimitData { data: Vec::new() };
+
+                    for (loop_mom_id, lambda_point) in momenta.iter().cloned().enumerate() {
+                        let mut loop_moms: LoopMomenta<F<_>> = (0..loop_number)
+                            .map(|_| {
+                                ThreeMomentum::new(
+                                    F::from_f64(0.0),
+                                    F::from_f64(0.0),
+                                    F::from_f64(0.0),
+                                )
+                            })
+                            .collect();
+
+                        for (loop_id, momentum) in non_limit_momenta.iter() {
+                            loop_moms[*loop_id] = *momentum;
+                        }
+
+                        for tagged_momenta in &lambda_point.momenta {
+                            let edge_id = tagged_momenta.tag;
+                            let loop_id = lmb
+                                .loop_edges
+                                .iter()
+                                .position(|loop_edge| loop_edge == &edge_id)
+                                .unwrap_or_else(|| {
+                                    unreachable!("corrupted lmb and ir limit: {}", ir_limit);
+                                });
+
+                            loop_moms[LoopIndex(loop_id)] = tagged_momenta.momentum;
+                        }
+
+                        let sample_in_cmb = MomentumSample::new(
+                            loop_moms,
+                            loop_mom_id,
+                            &self.settings.kinematics.externals,
+                            0,
+                            F::from_f64(1.0),
+                            dependent_momenta_constructor,
+                            orientation,
+                        )?;
+
+                        let sample = sample_in_cmb.lmb_transform(
+                            &lmb,
+                            &self.data.graph_terms[graph_id].graph.loop_momentum_basis,
+                        );
+
+                        limit_data.data.push(LambdaPointEval {
+                            lambda_point,
+                            value: evaluate_profile_momentum_point_arb(
+                                self,
+                                model,
+                                graph_id,
+                                orientation,
+                                sample.loop_moms().iter().cloned().collect_vec(),
+                                approach_settings.show_per_cut_info,
+                            )?,
                         });
+                    }
 
-                    loop_moms[LoopIndex(loop_id)] = tagged_momenta.momentum;
+                    let (power_law_fit, cut_fits) = limit_data.extract_power()?;
+                    reports.push(build_single_limit_report(
+                        ir_limit,
+                        orientation_label,
+                        power_law_fit,
+                        build_cut_limit_reports(ir_limit.num_soft(), cut_fits),
+                    ));
                 }
 
-                let sample_in_cmb = MomentumSample::new(
-                    loop_moms,
-                    loop_mom_id,
-                    &self.settings.kinematics.externals,
-                    0,
-                    F::from_f64(1.0),
-                    dependent_momenta_constructor,
-                    orientation,
-                )?;
-
-                let sample = sample_in_cmb.lmb_transform(
-                    &lmb,
-                    &self.data.graph_terms[graph_id].graph.loop_momentum_basis,
-                );
-
-                limit_data.data.push(LambdaPointEval {
-                    lambda_point,
-                    value: evaluate_profile_momentum_point_arb(
-                        self,
-                        model,
-                        graph_id,
-                        orientation,
-                        sample.loop_moms().iter().cloned().collect_vec(),
-                        approach_settings.show_per_cut_info,
-                    )?,
-                });
+                Ok(reports)
             }
-
-            let (power_law_fit, cut_fits) = limit_data.extract_power()?;
-            reports.push(build_single_limit_report(
-                ir_limit,
-                orientation_label,
-                power_law_fit,
-                build_cut_limit_reports(ir_limit.num_soft(), cut_fits),
-            ));
+            ProfileLimit::Threshold(threshold_limit) => {
+                return Err(eyre!(
+                    "Threshold limit '{}' is not yet supported in amplitude IR profiling",
+                    threshold_limit
+                ));
+            }
         }
-
-        Ok(reports)
     }
 }
 
@@ -915,13 +938,17 @@ impl CrossSectionIntegrand {
         result
     }
 
-    fn enumerate_ir_limits(&self) -> Vec<(String, Vec<IrLimit>)> {
+    fn enumerate_ir_limits(&self) -> Vec<(String, Vec<ProfileLimit>)> {
         self.data
             .graph_terms
             .iter()
             .map(|term| {
                 let graph_name = term.graph.name.clone();
-                let limits = term.enumerate_ir_limits();
+                let limits = term
+                    .enumerate_ir_limits()
+                    .into_iter()
+                    .map(ProfileLimit::Ir)
+                    .collect();
                 (graph_name, limits)
             })
             .collect()
@@ -934,11 +961,21 @@ impl CrossSectionIntegrand {
     fn test_single_ir_limit_impl(
         &mut self,
         graph_id: usize,
-        ir_limit: &IrLimit,
+        profile_limit: &ProfileLimit,
         rng: &mut MonteCarloRng,
         approach_settings: &IRProfileSetting,
         model: &Model,
     ) -> Result<Vec<SingleLimitReport>> {
+        let ir_limit = match profile_limit {
+            ProfileLimit::Ir(ir_limit) => ir_limit,
+            ProfileLimit::Threshold(threshold_limit) => {
+                return Err(eyre!(
+                    "Threshold limit '{}' is not yet supported in cross-section IR profiling",
+                    threshold_limit
+                ));
+            }
+        };
+
         let edges_in_limit = ir_limit.get_all_edges()?;
 
         // find cut that for that as all edges of the limit
@@ -1079,7 +1116,17 @@ impl CrossSectionIntegrand {
 struct IrLimit {
     colinear: Vec<Vec<HardOrSoft>>,
     soft: Vec<EdgeIndex>,
-    threshold: Vec<EsurfaceID>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct ThresholdLimit {
+    esurface_id: EsurfaceID,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum ProfileLimit {
+    Ir(IrLimit),
+    Threshold(ThresholdLimit),
 }
 
 enum MomentumBuilder<T: FloatLike> {
@@ -1116,130 +1163,53 @@ impl Display for IrLimit {
             write!(f, "S({})", soft)?;
         }
 
-        for threshold in self.threshold.iter() {
-            write!(f, "T(t{})", threshold.0)?;
-        }
-
         Ok(())
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum HardOrSoft {
-    Hard(EdgeIndex),
-    Soft(EdgeIndex),
-}
-
-impl HardOrSoft {
-    fn index(&self) -> EdgeIndex {
-        match self {
-            HardOrSoft::Hard(index) => *index,
-            HardOrSoft::Soft(index) => *index,
-        }
+impl Display for ThresholdLimit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "T(t{})", self.esurface_id.0)
     }
 }
 
-impl Display for HardOrSoft {
+impl Display for ProfileLimit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            HardOrSoft::Hard(index) => write!(f, "{}", index),
-            HardOrSoft::Soft(index) => write!(f, "S({})", index),
+            ProfileLimit::Ir(ir_limit) => write!(f, "{}", ir_limit),
+            ProfileLimit::Threshold(threshold_limit) => write!(f, "{}", threshold_limit),
         }
     }
 }
 
-impl IrLimit {
-    fn canonize(&mut self) {
-        for colinear_set in &mut self.colinear.iter_mut() {
-            colinear_set.sort();
+impl ThresholdLimit {
+    fn parse_threshold(threshold: &str) -> Result<Self> {
+        let mut threshold = String::from(threshold);
+        threshold = String::from(threshold.trim());
+
+        if threshold.len() < 2 {
+            return Err(eyre!("Threshold must be at least two characters long"));
         }
 
-        self.colinear.sort();
-        self.soft.sort();
-        self.threshold.sort();
-    }
-
-    fn new_pure_colinear(colinear_edges: Vec<EdgeIndex>) -> Self {
-        let colinear = vec![colinear_edges.into_iter().map(HardOrSoft::Hard).collect()];
-
-        let mut result = IrLimit {
-            colinear,
-            soft: Vec::new(),
-            threshold: Vec::new(),
-        };
-        result.canonize();
-        result
-    }
-
-    fn new_pure_soft(soft_edges: Vec<EdgeIndex>) -> Self {
-        let mut result = IrLimit {
-            colinear: Vec::new(),
-            soft: soft_edges,
-            threshold: Vec::new(),
-        };
-        result.canonize();
-        result
-    }
-
-    fn num_soft(&self) -> usize {
-        self.colinear
-            .iter()
-            .flatten()
-            .filter(|edge| matches!(edge, HardOrSoft::Soft(_)))
-            .count()
-            + self.soft.len()
-    }
-
-    fn check_min_colinear_size(&self) -> bool {
-        self.colinear
-            .iter()
-            .all(|colinear_set| colinear_set.len() >= 2)
-    }
-
-    fn is_valid(&self, loop_number: usize) -> Result<()> {
-        if !self.check_min_colinear_size() {
-            return Err(eyre!("colinear sets must have at least two edges"));
+        if threshold.remove(0) != 't' {
+            return Err(eyre!("Threshold must start with 't'"));
         }
 
-        let all_edges = self.get_all_edges()?;
+        let threshold_id: usize = threshold
+            .parse()
+            .map_err(|_| eyre!("Threshold must be a valid integer, got: {}", threshold))?;
 
-        if all_edges.len() > loop_number {
-            return Err(eyre!("not enough degrees of freedom to setup IR limit"));
-        }
-
-        Ok(())
+        Ok(Self {
+            esurface_id: EsurfaceID::from(threshold_id),
+        })
     }
+}
 
-    fn get_all_edges(&self) -> Result<Vec<EdgeIndex>> {
-        let colinear_edges = self
-            .colinear
-            .iter()
-            .flatten()
-            .map(HardOrSoft::index)
-            .collect_vec();
-        let soft_edges = self.soft.iter().copied().collect_vec();
-
-        let all_edges: Vec<EdgeIndex> = colinear_edges
-            .into_iter()
-            .chain(soft_edges)
-            .sorted()
-            .collect();
-
-        // check for duplicates
-        let mut unique_edges = all_edges.clone();
-        unique_edges.dedup();
-
-        if unique_edges.len() != all_edges.len() {
-            return Err(eyre!("Edges specified in ir limit must be unique")); // duplicates found
-        }
-
-        Ok(all_edges)
-    }
-
-    fn parse_limit(limit: &str) -> Result<IrLimit> {
+impl ProfileLimit {
+    fn parse_limit(limit: &str) -> Result<Self> {
         let mut colinear_sets = Vec::new();
         let mut soft_edges = Vec::new();
-        let mut thresholds = Vec::new();
+        let mut threshold_limit = None;
 
         let mut char_iter = limit.chars().enumerate();
 
@@ -1323,10 +1293,10 @@ impl IrLimit {
                                 ));
                             }
 
-                            let edge_index = Self::parse_edge(&edge_str)?;
+                            let edge_index = IrLimit::parse_edge(&edge_str)?;
                             colinear_set.push(HardOrSoft::Soft(edge_index));
                         } else {
-                            let edge_index = Self::parse_edge(trimmed_edge)?;
+                            let edge_index = IrLimit::parse_edge(trimmed_edge)?;
                             colinear_set.push(HardOrSoft::Hard(edge_index));
                         }
                     }
@@ -1367,10 +1337,14 @@ impl IrLimit {
                         ));
                     }
 
-                    let edge_index = Self::parse_edge(&edge_str)?;
+                    let edge_index = IrLimit::parse_edge(&edge_str)?;
                     soft_edges.push(edge_index);
                 }
                 'T' => {
+                    if threshold_limit.is_some() {
+                        return Err(eyre!("Only one threshold limit can be specified"));
+                    }
+
                     let (_opening_bracket_position, opening_bracket) =
                         char_iter.next().ok_or_else(|| {
                             eyre!(
@@ -1405,8 +1379,7 @@ impl IrLimit {
                         ));
                     }
 
-                    let threshold_id = Self::parse_threshold(&threshold_str)?;
-                    thresholds.push(threshold_id);
+                    threshold_limit = Some(ThresholdLimit::parse_threshold(&threshold_str)?);
                 }
                 _ => {
                     return Err(eyre!(
@@ -1418,15 +1391,141 @@ impl IrLimit {
             }
         }
 
+        if let Some(threshold_limit) = threshold_limit {
+            if !colinear_sets.is_empty() || !soft_edges.is_empty() {
+                return Err(eyre!(
+                    "Threshold limits cannot be combined with soft or colinear limits"
+                ));
+            }
+
+            return Ok(ProfileLimit::Threshold(threshold_limit));
+        }
+
         let mut ir_limit = IrLimit {
             colinear: colinear_sets,
             soft: soft_edges,
-            threshold: thresholds,
         };
 
         ir_limit.canonize();
 
-        Ok(ir_limit)
+        Ok(ProfileLimit::Ir(ir_limit))
+    }
+
+    fn is_valid(&self, loop_number: usize) -> Result<()> {
+        match self {
+            ProfileLimit::Ir(ir_limit) => ir_limit.is_valid(loop_number),
+            ProfileLimit::Threshold(_) => Ok(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum HardOrSoft {
+    Hard(EdgeIndex),
+    Soft(EdgeIndex),
+}
+
+impl HardOrSoft {
+    fn index(&self) -> EdgeIndex {
+        match self {
+            HardOrSoft::Hard(index) => *index,
+            HardOrSoft::Soft(index) => *index,
+        }
+    }
+}
+
+impl Display for HardOrSoft {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HardOrSoft::Hard(index) => write!(f, "{}", index),
+            HardOrSoft::Soft(index) => write!(f, "S({})", index),
+        }
+    }
+}
+
+impl IrLimit {
+    fn canonize(&mut self) {
+        for colinear_set in &mut self.colinear.iter_mut() {
+            colinear_set.sort();
+        }
+
+        self.colinear.sort();
+        self.soft.sort();
+    }
+
+    fn new_pure_colinear(colinear_edges: Vec<EdgeIndex>) -> Self {
+        let colinear = vec![colinear_edges.into_iter().map(HardOrSoft::Hard).collect()];
+
+        let mut result = IrLimit {
+            colinear,
+            soft: Vec::new(),
+        };
+        result.canonize();
+        result
+    }
+
+    fn new_pure_soft(soft_edges: Vec<EdgeIndex>) -> Self {
+        let mut result = IrLimit {
+            colinear: Vec::new(),
+            soft: soft_edges,
+        };
+        result.canonize();
+        result
+    }
+
+    fn num_soft(&self) -> usize {
+        self.colinear
+            .iter()
+            .flatten()
+            .filter(|edge| matches!(edge, HardOrSoft::Soft(_)))
+            .count()
+            + self.soft.len()
+    }
+
+    fn check_min_colinear_size(&self) -> bool {
+        self.colinear
+            .iter()
+            .all(|colinear_set| colinear_set.len() >= 2)
+    }
+
+    fn is_valid(&self, loop_number: usize) -> Result<()> {
+        if !self.check_min_colinear_size() {
+            return Err(eyre!("colinear sets must have at least two edges"));
+        }
+
+        let all_edges = self.get_all_edges()?;
+
+        if all_edges.len() > loop_number {
+            return Err(eyre!("not enough degrees of freedom to setup IR limit"));
+        }
+
+        Ok(())
+    }
+
+    fn get_all_edges(&self) -> Result<Vec<EdgeIndex>> {
+        let colinear_edges = self
+            .colinear
+            .iter()
+            .flatten()
+            .map(HardOrSoft::index)
+            .collect_vec();
+        let soft_edges = self.soft.iter().copied().collect_vec();
+
+        let all_edges: Vec<EdgeIndex> = colinear_edges
+            .into_iter()
+            .chain(soft_edges)
+            .sorted()
+            .collect();
+
+        // check for duplicates
+        let mut unique_edges = all_edges.clone();
+        unique_edges.dedup();
+
+        if unique_edges.len() != all_edges.len() {
+            return Err(eyre!("Edges specified in ir limit must be unique")); // duplicates found
+        }
+
+        Ok(all_edges)
     }
 
     fn parse_edge(edge: &str) -> Result<EdgeIndex> {
@@ -1446,25 +1545,6 @@ impl IrLimit {
             .map_err(|_| eyre!("Edge must be a valid integer, got: {}", edge))?;
 
         Ok(EdgeIndex::from(edge_id))
-    }
-
-    fn parse_threshold(threshold: &str) -> Result<EsurfaceID> {
-        let mut threshold = String::from(threshold);
-        threshold = String::from(threshold.trim());
-
-        if threshold.len() < 2 {
-            return Err(eyre!("Threshold must be at least two characters long"));
-        }
-
-        if threshold.remove(0) != 't' {
-            return Err(eyre!("Threshold must start with 't'"));
-        }
-
-        let threshold_id: usize = threshold
-            .parse()
-            .map_err(|_| eyre!("Threshold must be a valid integer, got: {}", threshold))?;
-
-        Ok(EsurfaceID::from(threshold_id))
     }
 
     fn get_momentum_builders(&self, rng: &mut MonteCarloRng) -> Vec<MomentumBuilder<f64>> {
@@ -1765,11 +1845,22 @@ mod tests {
                 ],
             ],
             soft: vec![EdgeIndex::from(6), EdgeIndex::from(7)],
-            threshold: vec![EsurfaceID::from(8usize)],
         };
 
         let display = ir_limit.to_string();
-        let expected = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7)T(t8)";
+        let expected = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7)";
+
+        assert_eq!(display, expected);
+    }
+
+    #[test]
+    fn test_threshold_display() {
+        let threshold_limit = ThresholdLimit {
+            esurface_id: EsurfaceID::from(8usize),
+        };
+
+        let display = threshold_limit.to_string();
+        let expected = "T(t8)";
 
         assert_eq!(display, expected);
     }
@@ -1793,27 +1884,30 @@ mod tests {
     #[test]
     fn parse_threshold() {
         let threshold_str = "t5";
-        let threshold_id = IrLimit::parse_threshold(threshold_str).unwrap();
-        assert_eq!(threshold_id, EsurfaceID::from(5usize));
+        let threshold_limit = ThresholdLimit::parse_threshold(threshold_str).unwrap();
+        assert_eq!(threshold_limit.esurface_id, EsurfaceID::from(5usize));
 
         let invalid_threshold_str = "5"; // missing 't'
-        assert!(IrLimit::parse_threshold(invalid_threshold_str).is_err());
+        assert!(ThresholdLimit::parse_threshold(invalid_threshold_str).is_err());
 
         let invalid_threshold_str2 = "t"; // too short
-        assert!(IrLimit::parse_threshold(invalid_threshold_str2).is_err());
+        assert!(ThresholdLimit::parse_threshold(invalid_threshold_str2).is_err());
 
         let invalid_threshold_str3 = "t5a"; // not a valid integer
-        assert!(IrLimit::parse_threshold(invalid_threshold_str3).is_err());
+        assert!(ThresholdLimit::parse_threshold(invalid_threshold_str3).is_err());
     }
 
     #[test]
     fn parse_limit() {
-        let limit_str = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7)T(t8)";
-        let ir_limit = IrLimit::parse_limit(limit_str).unwrap();
+        let limit_str = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7)";
+        let limit = ProfileLimit::parse_limit(limit_str).unwrap();
+        let ir_limit = match limit {
+            ProfileLimit::Ir(ir_limit) => ir_limit,
+            ProfileLimit::Threshold(_) => panic!("Expected an IR limit"),
+        };
 
         assert_eq!(ir_limit.colinear.len(), 2, "Expected two colinear sets");
         assert_eq!(ir_limit.soft.len(), 2, "Expected two soft edges");
-        assert_eq!(ir_limit.threshold.len(), 1, "Expected one threshold");
 
         assert_eq!(
             ir_limit.colinear[0],
@@ -1838,28 +1932,44 @@ mod tests {
             vec![EdgeIndex::from(6), EdgeIndex::from(7)],
             "Soft edges do not match"
         );
+
+        let threshold_limit = ProfileLimit::parse_limit("T(t8)").unwrap();
         assert_eq!(
-            ir_limit.threshold,
-            vec![EsurfaceID::from(8usize)],
-            "Thresholds do not match"
+            threshold_limit,
+            ProfileLimit::Threshold(ThresholdLimit {
+                esurface_id: EsurfaceID::from(8usize),
+            }),
+            "Threshold limit does not match"
         );
 
-        let invalid_limit_str = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7, e8)T(t8)";
+        let invalid_limit_str = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7, e8)";
         assert!(
-            IrLimit::parse_limit(invalid_limit_str).is_err(),
+            ProfileLimit::parse_limit(invalid_limit_str).is_err(),
             "Expected error"
         );
 
-        let invalid_limit_str2 = "C[e1,e2,e3C[e4,S(e5)]S(e6)T(t8)";
+        let invalid_limit_str2 = "C[e1,e2,e3C[e4,S(e5)]S(e6)";
         assert!(
-            IrLimit::parse_limit(invalid_limit_str2).is_err(),
+            ProfileLimit::parse_limit(invalid_limit_str2).is_err(),
             "Expected error for unmatched brackets"
         );
 
         let invalid_limit_str3 = "C[e1,e2,e3]T(e8)";
         assert!(
-            IrLimit::parse_limit(invalid_limit_str3).is_err(),
+            ProfileLimit::parse_limit(invalid_limit_str3).is_err(),
             "Expected error for invalid threshold syntax"
+        );
+
+        let invalid_limit_str4 = "C[e1,e2,e3]T(t8)";
+        assert!(
+            ProfileLimit::parse_limit(invalid_limit_str4).is_err(),
+            "Expected error for mixed threshold and IR limit syntax"
+        );
+
+        let invalid_limit_str5 = "T(t8)T(t9)";
+        assert!(
+            ProfileLimit::parse_limit(invalid_limit_str5).is_err(),
+            "Expected error for multiple threshold limits"
         );
     }
 

--- a/crates/gammalooprs/src/integrands/process/ir.rs
+++ b/crates/gammalooprs/src/integrands/process/ir.rs
@@ -15,6 +15,7 @@ use tracing::warn;
 
 use crate::{
     DependentMomentaConstructor,
+    cff::esurface::EsurfaceID,
     graph::{FeynmanGraph, LmbError, lmb::LMBwithEdges},
     integrands::{
         evaluation::PreciseEvaluationResult,
@@ -1078,6 +1079,7 @@ impl CrossSectionIntegrand {
 struct IrLimit {
     colinear: Vec<Vec<HardOrSoft>>,
     soft: Vec<EdgeIndex>,
+    threshold: Vec<EsurfaceID>,
 }
 
 enum MomentumBuilder<T: FloatLike> {
@@ -1112,6 +1114,10 @@ impl Display for IrLimit {
 
         for soft in self.soft.iter() {
             write!(f, "S({})", soft)?;
+        }
+
+        for threshold in self.threshold.iter() {
+            write!(f, "T(t{})", threshold.0)?;
         }
 
         Ok(())
@@ -1150,6 +1156,7 @@ impl IrLimit {
 
         self.colinear.sort();
         self.soft.sort();
+        self.threshold.sort();
     }
 
     fn new_pure_colinear(colinear_edges: Vec<EdgeIndex>) -> Self {
@@ -1158,6 +1165,7 @@ impl IrLimit {
         let mut result = IrLimit {
             colinear,
             soft: Vec::new(),
+            threshold: Vec::new(),
         };
         result.canonize();
         result
@@ -1167,6 +1175,7 @@ impl IrLimit {
         let mut result = IrLimit {
             colinear: Vec::new(),
             soft: soft_edges,
+            threshold: Vec::new(),
         };
         result.canonize();
         result
@@ -1230,6 +1239,7 @@ impl IrLimit {
     fn parse_limit(limit: &str) -> Result<IrLimit> {
         let mut colinear_sets = Vec::new();
         let mut soft_edges = Vec::new();
+        let mut thresholds = Vec::new();
 
         let mut char_iter = limit.chars().enumerate();
 
@@ -1360,6 +1370,44 @@ impl IrLimit {
                     let edge_index = Self::parse_edge(&edge_str)?;
                     soft_edges.push(edge_index);
                 }
+                'T' => {
+                    let (_opening_bracket_position, opening_bracket) =
+                        char_iter.next().ok_or_else(|| {
+                            eyre!(
+                                "Expected opening bracket '(' after 'T' at position {}",
+                                char_position
+                            )
+                        })?;
+
+                    if opening_bracket != '(' {
+                        return Err(eyre!(
+                            "Expected '(' after 'T' at position {}, found '{}'",
+                            char_position,
+                            opening_bracket
+                        ));
+                    }
+
+                    let mut threshold_str = String::new();
+                    let mut closing_bracket_found = false;
+
+                    for (_next_char_position, next_char) in char_iter.by_ref() {
+                        if next_char == ')' {
+                            closing_bracket_found = true;
+                            break;
+                        }
+                        threshold_str.push(next_char);
+                    }
+
+                    if !closing_bracket_found {
+                        return Err(eyre!(
+                            "Expected closing bracket ')' for threshold at position {}",
+                            char_position
+                        ));
+                    }
+
+                    let threshold_id = Self::parse_threshold(&threshold_str)?;
+                    thresholds.push(threshold_id);
+                }
                 _ => {
                     return Err(eyre!(
                         "Unexpected character '{}' at position {}",
@@ -1373,6 +1421,7 @@ impl IrLimit {
         let mut ir_limit = IrLimit {
             colinear: colinear_sets,
             soft: soft_edges,
+            threshold: thresholds,
         };
 
         ir_limit.canonize();
@@ -1397,6 +1446,25 @@ impl IrLimit {
             .map_err(|_| eyre!("Edge must be a valid integer, got: {}", edge))?;
 
         Ok(EdgeIndex::from(edge_id))
+    }
+
+    fn parse_threshold(threshold: &str) -> Result<EsurfaceID> {
+        let mut threshold = String::from(threshold);
+        threshold = String::from(threshold.trim());
+
+        if threshold.len() < 2 {
+            return Err(eyre!("Threshold must be at least two characters long"));
+        }
+
+        if threshold.remove(0) != 't' {
+            return Err(eyre!("Threshold must start with 't'"));
+        }
+
+        let threshold_id: usize = threshold
+            .parse()
+            .map_err(|_| eyre!("Threshold must be a valid integer, got: {}", threshold))?;
+
+        Ok(EsurfaceID::from(threshold_id))
     }
 
     fn get_momentum_builders(&self, rng: &mut MonteCarloRng) -> Vec<MomentumBuilder<f64>> {
@@ -1697,10 +1765,11 @@ mod tests {
                 ],
             ],
             soft: vec![EdgeIndex::from(6), EdgeIndex::from(7)],
+            threshold: vec![EsurfaceID::from(8usize)],
         };
 
         let display = ir_limit.to_string();
-        let expected = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7)";
+        let expected = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7)T(t8)";
 
         assert_eq!(display, expected);
     }
@@ -1722,12 +1791,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_threshold() {
+        let threshold_str = "t5";
+        let threshold_id = IrLimit::parse_threshold(threshold_str).unwrap();
+        assert_eq!(threshold_id, EsurfaceID::from(5usize));
+
+        let invalid_threshold_str = "5"; // missing 't'
+        assert!(IrLimit::parse_threshold(invalid_threshold_str).is_err());
+
+        let invalid_threshold_str2 = "t"; // too short
+        assert!(IrLimit::parse_threshold(invalid_threshold_str2).is_err());
+
+        let invalid_threshold_str3 = "t5a"; // not a valid integer
+        assert!(IrLimit::parse_threshold(invalid_threshold_str3).is_err());
+    }
+
+    #[test]
     fn parse_limit() {
-        let limit_str = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7)";
+        let limit_str = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7)T(t8)";
         let ir_limit = IrLimit::parse_limit(limit_str).unwrap();
 
         assert_eq!(ir_limit.colinear.len(), 2, "Expected two colinear sets");
         assert_eq!(ir_limit.soft.len(), 2, "Expected two soft edges");
+        assert_eq!(ir_limit.threshold.len(), 1, "Expected one threshold");
 
         assert_eq!(
             ir_limit.colinear[0],
@@ -1752,17 +1838,28 @@ mod tests {
             vec![EdgeIndex::from(6), EdgeIndex::from(7)],
             "Soft edges do not match"
         );
+        assert_eq!(
+            ir_limit.threshold,
+            vec![EsurfaceID::from(8usize)],
+            "Thresholds do not match"
+        );
 
-        let invalid_limit_str = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7, e8)";
+        let invalid_limit_str = "C[e1,e2,e3]C[e4,S(e5)]S(e6)S(e7, e8)T(t8)";
         assert!(
             IrLimit::parse_limit(invalid_limit_str).is_err(),
             "Expected error"
         );
 
-        let invalid_limit_str2 = "C[e1,e2,e3C[e4,S(e5)]S(e6)";
+        let invalid_limit_str2 = "C[e1,e2,e3C[e4,S(e5)]S(e6)T(t8)";
         assert!(
             IrLimit::parse_limit(invalid_limit_str2).is_err(),
             "Expected error for unmatched brackets"
+        );
+
+        let invalid_limit_str3 = "C[e1,e2,e3]T(e8)";
+        assert!(
+            IrLimit::parse_limit(invalid_limit_str3).is_err(),
+            "Expected error for invalid threshold syntax"
         );
     }
 

--- a/crates/gammalooprs/src/integrands/process/ir.rs
+++ b/crates/gammalooprs/src/integrands/process/ir.rs
@@ -5,12 +5,8 @@ use colored::Colorize;
 use eyre::eyre;
 use itertools::Itertools;
 use linnet::half_edge::involution::{EdgeIndex, Orientation};
-use nalgebra::DVector;
 use rand::Rng;
-use symbolica::{
-    domains::float::{Real, RealLike},
-    numerical_integration::MonteCarloRng,
-};
+use symbolica::numerical_integration::MonteCarloRng;
 use tabled::{builder::Builder, settings::Style};
 use tracing::warn;
 
@@ -18,12 +14,12 @@ use crate::{
     DependentMomentaConstructor,
     graph::{FeynmanGraph, LmbError, lmb::LMBwithEdges},
     integrands::{
-        evaluation::EvaluationResult,
+        evaluation::PreciseEvaluationResult,
         process::{
             GraphTerm, OrientationProfileMode, ProcessIntegrandImpl,
             amplitude::{AmplitudeGraphTerm, AmplitudeIntegrand},
             cross_section::{CrossSectionGraphTerm, CrossSectionIntegrand},
-            evaluate_profile_momentum_point, orientation_labels_for_graph,
+            evaluate_profile_momentum_point_precise, orientation_labels_for_graph,
         },
     },
     model::Model,
@@ -38,11 +34,10 @@ use crate::{
             ParameterizationMode, ParameterizationSettings,
         },
     },
-    utils::{F, FloatLike, box_muller},
-    uv::profile::logspace,
-};
-use varpro::{
-    prelude::SeparableModelBuilder, problem::SeparableProblemBuilder, solvers::levmar::LevMarSolver,
+    utils::{
+        ArbPrec, F, FloatLike, box_muller,
+        fitting::{constant_dropped_fit_points, log_log_slope_constant_dropped},
+    },
 };
 
 /// The range is from 10^start to 10^end.
@@ -261,8 +256,6 @@ impl Display for GraphIRLimitReport {
             "orientation",
             "scaling",
             "p",
-            "coefficient",
-            "const_offset",
             "r_squared",
             "n_soft",
         ]);
@@ -283,8 +276,6 @@ impl Display for GraphIRLimitReport {
                     .unwrap_or_else(|| "sum".to_string()),
                 format!("{:+.4}", report.scaling),
                 format!("{:+.4}", report.power_law_fit.exponent),
-                format!("{:+.4e}", report.power_law_fit.coefficient),
-                format!("{:+.4e}", report.power_law_fit.constant_offset),
                 format!("{:.4}", report.power_law_fit.r_squared),
                 report.num_soft.to_string(),
             ]);
@@ -306,7 +297,7 @@ impl Display for SingleLimitReport {
 
         write!(
             f,
-            "{} {}{} | scaling={:+.4} | p={:+.4} | coeff={:+.4e} | const={:+.4e} | R²={:.4} | n_soft={}",
+            "{} {}{} | scaling={:+.4} | p={:+.4} | R²={:.4} | n_soft={}",
             status,
             self.limit_name,
             self.orientation_label
@@ -315,8 +306,6 @@ impl Display for SingleLimitReport {
                 .unwrap_or_default(),
             self.scaling,
             self.power_law_fit.exponent,
-            self.power_law_fit.coefficient,
-            self.power_law_fit.constant_offset,
             self.power_law_fit.r_squared,
             self.num_soft
         )
@@ -541,7 +530,7 @@ impl AmplitudeIntegrand {
     ) -> Result<Vec<SingleLimitReport>> {
         let edges_in_limit = ir_limit.get_all_edges()?;
         let lmb = self.data.graph_terms[graph_id].lmb_with_loop_edges(edges_in_limit.as_slice())?;
-        let momenta = ir_limit.get_momenta(rng, &self.settings, approach_settings);
+        let momenta = ir_limit.get_momenta(rng, &self.settings, approach_settings)?;
         let non_limit_loops = lmb
             .loop_edges
             .iter_enumerated()
@@ -613,13 +602,12 @@ impl AmplitudeIntegrand {
 
                 limit_data.data.push(LambdaPointEval {
                     lambda_point,
-                    value: evaluate_profile_momentum_point(
+                    value: evaluate_profile_momentum_point_arb(
                         self,
                         model,
                         graph_id,
                         orientation,
                         sample.loop_moms().iter().cloned().collect_vec(),
-                        false,
                     )?,
                 });
             }
@@ -725,7 +713,7 @@ impl CrossSectionIntegrand {
             .collect_vec();
 
         let lmb = self.data.graph_terms[graph_id].lmb_with_loop_edges(edges_in_limit.as_slice())?;
-        let momenta = ir_limit.get_momenta(rng, &self.settings, approach_settings);
+        let momenta = ir_limit.get_momenta(rng, &self.settings, approach_settings)?;
         let non_limit_loops = lmb
             .loop_edges
             .iter_enumerated()
@@ -797,13 +785,12 @@ impl CrossSectionIntegrand {
 
                 limit_data.data.push(LambdaPointEval {
                     lambda_point,
-                    value: evaluate_profile_momentum_point(
+                    value: evaluate_profile_momentum_point_arb(
                         self,
                         model,
                         graph_id,
                         orientation,
                         sample.loop_moms().iter().cloned().collect_vec(),
-                        false,
                     )?,
                 });
             }
@@ -1192,20 +1179,16 @@ impl IrLimit {
         rng: &mut MonteCarloRng,
         settings: &RuntimeSettings,
         approach_settings: &IRProfileSetting,
-    ) -> Vec<LambdaPoint<f64>> {
+    ) -> Result<Vec<LambdaPoint<f64>>> {
         let momentum_builders = self.get_momentum_builders(rng);
 
-        let lambda_values: Vec<F<f64>> = logspace(
-            approach_settings.lambda_exp_start,
-            approach_settings.lambda_exp_end,
+        let lambda_values = constant_dropped_fit_points(
+            &F::from_f64(10.0_f64.powf(approach_settings.lambda_exp_start)),
+            &F::from_f64(10.0_f64.powf(approach_settings.lambda_exp_end)),
             approach_settings.steps,
-            10.0,
-        )
-        .into_iter()
-        .map(F::from_f64)
-        .collect();
+        )?;
 
-        lambda_values
+        Ok(lambda_values
             .into_iter()
             .map(|lambda| LambdaPoint {
                 momenta: momentum_builders
@@ -1243,7 +1226,32 @@ impl IrLimit {
                     .collect(),
                 lambda,
             })
-            .collect()
+            .collect())
+    }
+}
+
+fn evaluate_profile_momentum_point_arb<I: ProcessIntegrandImpl>(
+    integrand: &mut I,
+    model: &Model,
+    graph_id: usize,
+    orientation: Option<usize>,
+    loop_momenta: Vec<ThreeMomentum<F<f64>>>,
+) -> Result<F<ArbPrec>> {
+    match evaluate_profile_momentum_point_precise(
+        integrand,
+        model,
+        graph_id,
+        orientation,
+        loop_momenta,
+        true,
+    )? {
+        PreciseEvaluationResult::Arb(result) => Ok(result.integrand_result.re),
+        PreciseEvaluationResult::Double(_) => Err(eyre!(
+            "IR profiling requested arbitrary precision but received a double-precision result"
+        )),
+        PreciseEvaluationResult::Quad(_) => Err(eyre!(
+            "IR profiling requested arbitrary precision but received a quad-precision result"
+        )),
     }
 }
 
@@ -1275,7 +1283,7 @@ struct LambdaPoint<T: FloatLike> {
 
 struct LambdaPointEval<T: FloatLike> {
     lambda_point: LambdaPoint<T>,
-    value: EvaluationResult,
+    value: F<ArbPrec>,
 }
 
 struct LimitData<T: FloatLike> {
@@ -1287,21 +1295,27 @@ impl<T: FloatLike> LimitData<T> {
         let x = self
             .data
             .iter()
-            .map(|point_eval| point_eval.lambda_point.lambda.to_f64())
+            .map(|point_eval| F::<ArbPrec>::from_ff64(point_eval.lambda_point.lambda.into_ff64()))
             .collect_vec();
 
         let y = self
             .data
             .iter()
-            .map(|point_eval| point_eval.value.integrand_result.re.to_f64())
+            .map(|point_eval| point_eval.value.clone())
             .collect_vec();
 
         let result = fit_power_law(x.clone(), y.clone())?;
 
         if result.r_squared < 0.9 {
             warn!("low r^2 value found for input data");
-            warn!("x: {:?}", x);
-            warn!("y: {:?}", y);
+            warn!(
+                "x: {:?}",
+                x.iter().map(|value| value.into_f64()).collect_vec()
+            );
+            warn!(
+                "y: {:?}",
+                y.iter().map(|value| value.into_f64()).collect_vec()
+            );
         }
 
         Ok(result)
@@ -1311,176 +1325,34 @@ impl<T: FloatLike> LimitData<T> {
 #[derive(Debug, Clone)]
 pub struct PowerLawFit {
     exponent: f64,
-    coefficient: f64,
-    constant_offset: f64,
     r_squared: f64,
 }
 
-// using varpro fit  y =  a x^p + c
-fn fit_power_law(x: Vec<f64>, y: Vec<f64>) -> Result<PowerLawFit> {
+fn fit_power_law(x: Vec<F<ArbPrec>>, y: Vec<F<ArbPrec>>) -> Result<PowerLawFit> {
     if x.len() != y.len() {
         return Err(eyre!(
             "fit_power_law requires x and y to have the same length"
         ));
     }
-    if x.len() < 2 {
-        return Err(eyre!("fit_power_law requires at least two observations"));
+    if x.len() < 3 {
+        return Err(eyre!("fit_power_law requires at least three observations"));
     }
-    if x.iter().any(|value| !value.is_finite() || *value <= 0.0) {
+    if x.iter()
+        .any(|value| value.is_nan() || value.is_infinite() || value <= &value.zero())
+    {
         return Err(eyre!(
             "fit_power_law requires strictly positive, finite x values"
         ));
     }
-    if y.iter().any(|value| !value.is_finite()) {
+    if y.iter().any(|value| value.is_nan() || value.is_infinite()) {
         return Err(eyre!("fit_power_law requires finite y values"));
     }
 
-    let x_scale = (x.iter().map(|value| value.ln()).sum::<f64>() / x.len() as f64).exp();
-    if !x_scale.is_finite() || x_scale <= 0.0 {
-        return Err(eyre!(
-            "fit_power_law could not determine a valid x rescaling factor"
-        ));
-    }
-
-    let x_normalized = x.iter().map(|value| value / x_scale).collect::<Vec<_>>();
-
-    let x_data = DVector::from_vec(x_normalized.clone());
-    let y_data = DVector::from_vec(y.clone());
-
-    let initial_exponent = {
-        let mut log_x = Vec::new();
-        let mut log_y_shifted = Vec::new();
-        let min_y = y.iter().copied().fold(f64::INFINITY, f64::min);
-        let y_shift = if min_y <= 0.0 { 1.0 - min_y } else { 0.0 };
-        for (xv, yv) in x.iter().zip(y.iter()) {
-            let shifted = yv + y_shift;
-            if shifted > 0.0 {
-                log_x.push(xv.ln());
-                log_y_shifted.push(shifted.ln());
-            }
-        }
-
-        if log_x.len() >= 2 {
-            let mean_x = log_x.iter().sum::<f64>() / log_x.len() as f64;
-            let mean_y = log_y_shifted.iter().sum::<f64>() / log_y_shifted.len() as f64;
-            let covariance = log_x
-                .iter()
-                .zip(log_y_shifted.iter())
-                .map(|(xv, yv)| (xv - mean_x) * (yv - mean_y))
-                .sum::<f64>();
-            let variance = log_x.iter().map(|xv| (xv - mean_x).powi(2)).sum::<f64>();
-            if variance > 0.0 {
-                covariance / variance
-            } else {
-                -1.0
-            }
-        } else {
-            -1.0
-        }
-    };
-
-    const LARGE_FINITE_GUARD: f64 = 1.0e200;
-
-    let model = SeparableModelBuilder::new(["p"])
-        .initial_parameters(vec![initial_exponent])
-        .independent_variable(x_data)
-        .function(["p"], |x: &DVector<f64>, p: f64| {
-            x.map(|xv| {
-                let value = xv.powf(p);
-                if value.is_finite() {
-                    value
-                } else if value.is_nan() {
-                    LARGE_FINITE_GUARD
-                } else if value.is_sign_negative() {
-                    -LARGE_FINITE_GUARD
-                } else {
-                    LARGE_FINITE_GUARD
-                }
-            })
-        })
-        .partial_deriv("p", |x: &DVector<f64>, p: f64| {
-            x.map(|xv| {
-                let deriv = xv.powf(p) * xv.ln();
-                if deriv.is_finite() {
-                    deriv
-                } else if deriv.is_nan() {
-                    LARGE_FINITE_GUARD
-                } else if deriv.is_sign_negative() {
-                    -LARGE_FINITE_GUARD
-                } else {
-                    LARGE_FINITE_GUARD
-                }
-            })
-        })
-        .invariant_function(|x: &DVector<f64>| DVector::from_element(x.len(), 1.0))
-        .build()
-        .map_err(|error| eyre!("could not build varpro model for power-law fit: {error}"))?;
-
-    let problem = SeparableProblemBuilder::new(model)
-        .observations(y_data)
-        .build()
-        .map_err(|error| eyre!("could not build varpro problem for power-law fit: {error}"))?;
-
-    let fit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        LevMarSolver::default().solve(problem)
-    }))
-    .map_err(|_| eyre!("varpro/nalgebra panicked while solving power-law fit"))?
-    .map_err(|error| eyre!("varpro solve failed for power-law fit: {:?}", error))?;
-
-    if !fit_result.minimization_report.termination.was_successful() {
-        return Err(eyre!(
-            "varpro did not terminate successfully in power-law fit"
-        ));
-    }
-
-    let exponent = fit_result.nonlinear_parameters()[0];
-    let coefficients = fit_result
-        .linear_coefficients()
-        .ok_or_else(|| eyre!("varpro did not return linear coefficients"))?;
-    let coefficient_normalized = coefficients[0];
-    let constant_offset = coefficients[1];
-
-    let exponent = if exponent.is_finite() {
-        exponent
-    } else {
-        return Err(eyre!("power-law fit returned non-finite exponent"));
-    };
-
-    let coefficient_scale = x_scale.powf(-exponent);
-    if !coefficient_scale.is_finite() {
-        return Err(eyre!(
-            "power-law fit produced non-finite coefficient rescaling"
-        ));
-    }
-
-    let coefficient = coefficient_normalized * coefficient_scale;
-    if !coefficient.is_finite() || !constant_offset.is_finite() {
-        return Err(eyre!(
-            "power-law fit returned non-finite linear coefficients"
-        ));
-    }
-
-    let mean_y = y.iter().sum::<f64>() / y.len() as f64;
-    let ss_tot = y.iter().map(|yv| (yv - mean_y).powi(2)).sum::<f64>();
-    let ss_res = x
-        .iter()
-        .zip(y.iter())
-        .map(|(xv, yv)| {
-            let prediction = coefficient * xv.powf(&exponent) + constant_offset;
-            (yv - prediction).powi(2)
-        })
-        .sum::<f64>();
-    let r_squared = if ss_tot > 0.0 {
-        1.0 - ss_res / ss_tot
-    } else {
-        1.0
-    };
+    let fit = log_log_slope_constant_dropped(&x, &y)?;
 
     Ok(PowerLawFit {
-        exponent,
-        coefficient,
-        constant_offset,
-        r_squared,
+        exponent: fit.slope.into_f64(),
+        r_squared: fit.r_squared().into_f64(),
     })
 }
 
@@ -1574,71 +1446,46 @@ mod tests {
 
     #[test]
     fn fit_power_law_recovers_known_parameters() {
-        let exponent = -1.75;
-        let coefficient = 3.2;
-        let offset = 0.6;
+        let exponent = -1.75_f64;
+        let coefficient = 3.2_f64;
+        let offset = 0.6_f64;
 
-        let x = vec![0.2, 0.35, 0.5, 0.8, 1.1, 1.7, 2.4, 3.3];
+        let x = constant_dropped_fit_points(
+            &F::<ArbPrec>::from_f64(0.2_f64 * 1.6_f64.powi(7)),
+            &F::<ArbPrec>::from_f64(0.2_f64),
+            8,
+        )
+        .expect("geometric fit points should be generated");
         let y = x
             .iter()
-            .map(|xv| coefficient * xv.powf(&exponent) + offset)
+            .map(|xv| F::<ArbPrec>::from_f64(coefficient * xv.into_f64().powf(exponent) + offset))
             .collect::<Vec<_>>();
 
         let fit = fit_power_law(x, y).expect("power-law fit should succeed");
 
-        assert!((fit.exponent - exponent).abs() < 1e-3);
-        assert!((fit.coefficient - coefficient).abs() < 1e-3);
+        assert!((fit.exponent - exponent).abs() < 1e-10);
         assert!(fit.r_squared > 0.999_999);
     }
 
     #[test]
-    fn fit_power_law_on_panicking_data() {
-        let x = vec![
-            0.001,
-            0.0007847599703514615,
-            0.0006158482110660267,
-            0.0004832930238571752,
-            0.000379269019073225,
-            0.00029763514416313193,
-            0.00023357214690901214,
-            0.00018329807108324357,
-            0.0001438449888287663,
-            0.00011288378916846895,
-            8.858667904100833e-5,
-            6.951927961775606e-5,
-            5.4555947811685143e-5,
-            4.281332398719396e-5,
-            3.359818286283781e-5,
-            2.6366508987303556e-5,
-            2.06913808111479e-5,
-            1.6237767391887242e-5,
-            1.2742749857031348e-5,
-            1e-5,
-        ];
+    fn fit_power_law_rejects_non_geometric_grid() {
+        let exponent = -1.75_f64;
+        let coefficient = 3.2_f64;
+        let offset = 0.6_f64;
 
-        let y = vec![
-            0.002950535397303611,
-            0.004802153664059006,
-            0.007811787818354787,
-            0.012702615924354177,
-            0.020646917328122072,
-            0.033559978182893246,
-            0.05451887019444257,
-            0.08857211912982166,
-            0.14386785496026278,
-            0.2341369427740574,
-            0.378563791513443,
-            0.6228243708610535,
-            1.0381001830101013,
-            1.609904408454895,
-            2.4859671592712402,
-            4.144830703735352,
-            7.431371688842773,
-            8.509048461914063,
-            -28.14263916015625,
-            90.61788940429688,
-        ];
+        let x = [
+            0.2_f64, 0.37_f64, 0.55_f64, 0.92_f64, 1.3_f64, 1.85_f64, 2.75_f64, 3.6_f64,
+        ]
+        .into_iter()
+        .map(F::<ArbPrec>::from_f64)
+        .collect::<Vec<_>>();
+        let y = x
+            .iter()
+            .map(|xv| F::<ArbPrec>::from_f64(coefficient * xv.into_f64().powf(exponent) + offset))
+            .collect::<Vec<_>>();
 
-        let _ = fit_power_law(x, y).is_ok();
+        let fit = fit_power_law(x, y);
+
+        assert!(fit.is_err());
     }
 }

--- a/crates/gammalooprs/src/integrands/process/ir.rs
+++ b/crates/gammalooprs/src/integrands/process/ir.rs
@@ -32,6 +32,7 @@ use crate::{
         ThreeMomentum,
         sample::{LoopIndex, LoopMomenta, MomentumSample},
     },
+    observables::events::AdditionalWeightKey,
     settings::{
         RuntimeSettings, SamplingSettings,
         runtime::{
@@ -181,11 +182,19 @@ pub struct SingleLimitReport {
     pub power_law_fit: PowerLawFit,
     pub scaling: f64,
     pub per_cut_reports: Vec<CutLimitReport>,
+    pub display_only_reports: Vec<DisplayOnlyLimitReport>,
     num_soft: usize,
 }
 
 pub struct CutLimitReport {
     pub cut_id: usize,
+    pub power_law_fit: Option<PowerLawFit>,
+    pub scaling: Option<f64>,
+    pub fit_error: Option<String>,
+}
+
+pub struct DisplayOnlyLimitReport {
+    pub label: String,
     pub power_law_fit: Option<PowerLawFit>,
     pub scaling: Option<f64>,
     pub fit_error: Option<String>,
@@ -283,12 +292,11 @@ impl Display for GraphIRLimitReport {
             "status",
             "limit",
             "orientation",
-            "cut",
+            "item",
             "scaling",
             "p",
             "r_squared",
             "n_soft",
-            "note",
         ]);
 
         for (report_index, report) in self.single_limit_reports.iter().enumerate() {
@@ -310,27 +318,40 @@ impl Display for GraphIRLimitReport {
                 format!("{:+.4}", report.power_law_fit.exponent),
                 format!("{:.4}", report.power_law_fit.r_squared),
                 report.num_soft.to_string(),
-                String::new(),
             ]);
             data_row_count += 1;
 
-            if !report.per_cut_reports.is_empty() {
+            if !report.per_cut_reports.is_empty() || !report.display_only_reports.is_empty() {
                 separators_after_data_rows.push(data_row_count);
             }
 
             for cut_report in &report.per_cut_reports {
-                let [cut_id, scaling, exponent, r_squared, note] =
-                    cut_report_display_row(cut_report);
+                let [item, scaling, exponent, r_squared] = cut_report_display_row(cut_report);
                 limit_table.push_record([
                     "INFO".cyan().bold().to_string(),
                     String::new(),
                     String::new(),
-                    cut_id,
+                    item,
                     scaling,
                     exponent,
                     r_squared,
                     String::new(),
-                    note,
+                ]);
+                data_row_count += 1;
+            }
+
+            for display_only_report in &report.display_only_reports {
+                let [item, scaling, exponent, r_squared] =
+                    display_only_report_display_row(display_only_report);
+                limit_table.push_record([
+                    "INFO".cyan().bold().to_string(),
+                    String::new(),
+                    String::new(),
+                    item,
+                    scaling,
+                    exponent,
+                    r_squared,
+                    String::new(),
                 ]);
                 data_row_count += 1;
             }
@@ -374,7 +395,8 @@ impl Display for SingleLimitReport {
             self.num_soft
         )?;
 
-        render_per_cut_reports(f, self, "")
+        render_per_cut_reports(f, self, "")?;
+        render_display_only_reports(f, self, "")
     }
 }
 
@@ -400,7 +422,7 @@ fn render_per_cut_reports(
     )?;
 
     let mut cut_table = Builder::new();
-    cut_table.push_record(["cut", "scaling", "p", "r_squared", "note"]);
+    cut_table.push_record(["cut", "scaling", "p", "r_squared"]);
 
     for cut_report in &report.per_cut_reports {
         cut_table.push_record(cut_report_display_row(cut_report));
@@ -432,35 +454,78 @@ fn render_graph_cut_definitions(
     writeln!(f, "{}", cut_table.build().with(Style::rounded()))
 }
 
-fn cut_report_display_row(cut_report: &CutLimitReport) -> [String; 5] {
-    let (scaling, exponent, r_squared, note) =
-        match (&cut_report.power_law_fit, &cut_report.fit_error) {
-            (Some(fit), None) => (
-                format!("{:+.4}", cut_report.scaling.unwrap_or(fit.exponent)),
-                format!("{:+.4}", fit.exponent),
-                format!("{:.4}", fit.r_squared),
-                String::new(),
-            ),
-            (None, Some(error)) => (
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                error.clone(),
-            ),
-            _ => (
-                "-".to_string(),
-                "-".to_string(),
-                "-".to_string(),
-                "missing cut fit".to_string(),
-            ),
-        };
+fn render_display_only_reports(
+    f: &mut std::fmt::Formatter<'_>,
+    report: &SingleLimitReport,
+    indent: &str,
+) -> std::fmt::Result {
+    if report.display_only_reports.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(f)?;
+    writeln!(
+        f,
+        "\n{indent}display-only fits for {}{}",
+        report.limit_name,
+        report
+            .orientation_label
+            .as_ref()
+            .map(|label| format!(" @ {label}"))
+            .unwrap_or_default(),
+    )?;
+
+    let mut display_only_table = Builder::new();
+    display_only_table.push_record(["component", "scaling", "p", "r_squared"]);
+
+    for display_only_report in &report.display_only_reports {
+        display_only_table.push_record(display_only_report_display_row(display_only_report));
+    }
+
+    write!(f, "{}", display_only_table.build().with(Style::rounded()))
+}
+
+fn cut_report_display_row(cut_report: &CutLimitReport) -> [String; 4] {
+    let (scaling, exponent, r_squared) = match (&cut_report.power_law_fit, &cut_report.fit_error) {
+        (Some(fit), None) => (
+            format!("{:+.4}", cut_report.scaling.unwrap_or(fit.exponent)),
+            format!("{:+.4}", fit.exponent),
+            format!("{:.4}", fit.r_squared),
+        ),
+        (None, Some(_)) => ("-".to_string(), "-".to_string(), "-".to_string()),
+        _ => ("-".to_string(), "-".to_string(), "-".to_string()),
+    };
 
     [
-        cut_report.cut_id.to_string(),
+        format!("cut {}", cut_report.cut_id),
         scaling,
         exponent,
         r_squared,
-        note,
+    ]
+}
+
+fn display_only_report_display_row(display_only_report: &DisplayOnlyLimitReport) -> [String; 4] {
+    let (scaling, exponent, r_squared) = match (
+        &display_only_report.power_law_fit,
+        &display_only_report.fit_error,
+    ) {
+        (Some(fit), None) => (
+            format!(
+                "{:+.4}",
+                display_only_report.scaling.unwrap_or(fit.exponent)
+            ),
+            format!("{:+.4}", fit.exponent),
+            format!("{:.4}", fit.r_squared),
+        ),
+        (None, Some(_)) => ("-".to_string(), "-".to_string(), "-".to_string()),
+        _ => ("-".to_string(), "-".to_string(), "-".to_string()),
+    };
+
+    [
+        display_only_report.label.clone(),
+        scaling,
+        exponent,
+        r_squared,
     ]
 }
 
@@ -616,6 +681,7 @@ fn build_single_limit_report(
         power_law_fit: slope,
         scaling,
         per_cut_reports,
+        display_only_reports: Vec::new(),
         num_soft,
     }
 }
@@ -634,6 +700,7 @@ fn build_threshold_limit_report(
         power_law_fit: slope,
         scaling,
         per_cut_reports,
+        display_only_reports: Vec::new(),
         num_soft: 0,
     }
 }
@@ -659,6 +726,38 @@ fn build_cut_limit_reports(
             },
         })
         .collect()
+}
+
+fn build_display_only_limit_reports(
+    component_fits: Vec<(AdditionalWeightKey, Result<PowerLawFit>)>,
+) -> Vec<DisplayOnlyLimitReport> {
+    component_fits
+        .into_iter()
+        .map(|(key, fit)| match fit {
+            Ok(power_law_fit) => DisplayOnlyLimitReport {
+                label: display_only_limit_label(key),
+                scaling: Some(power_law_fit.exponent),
+                power_law_fit: Some(power_law_fit),
+                fit_error: None,
+            },
+            Err(error) => DisplayOnlyLimitReport {
+                label: display_only_limit_label(key),
+                scaling: None,
+                power_law_fit: None,
+                fit_error: Some(error.to_string()),
+            },
+        })
+        .collect()
+}
+
+fn display_only_limit_label(key: AdditionalWeightKey) -> String {
+    match key {
+        AdditionalWeightKey::Original => "original".to_string(),
+        AdditionalWeightKey::ThresholdCounterterm { subset_index } => {
+            format!("ct_{subset_index}")
+        }
+        AdditionalWeightKey::FullMultiplicativeFactor => "full multiplicative factor".to_string(),
+    }
 }
 
 fn threshold_approach_loop_momenta<T: FloatLike>(
@@ -765,9 +864,10 @@ impl AmplitudeIntegrand {
         });
 
         let previous_generate_events = self.settings.general.generate_events;
-        if ir_profile_settings.show_per_cut_info {
-            self.settings.general.generate_events = true;
-        }
+        let previous_store_additional_weights =
+            self.settings.general.store_additional_weights_in_event;
+        self.settings.general.generate_events = true;
+        self.settings.general.store_additional_weights_in_event = true;
 
         let result = (|| {
             self.warm_up(model)?;
@@ -812,6 +912,12 @@ impl AmplitudeIntegrand {
 
         if self.settings.general.generate_events != previous_generate_events {
             self.settings.general.generate_events = previous_generate_events;
+        }
+        if self.settings.general.store_additional_weights_in_event
+            != previous_store_additional_weights
+        {
+            self.settings.general.store_additional_weights_in_event =
+                previous_store_additional_weights;
         }
 
         result
@@ -950,13 +1056,15 @@ impl AmplitudeIntegrand {
                         });
                     }
 
-                    let (power_law_fit, cut_fits) = limit_data.extract_power()?;
-                    reports.push(build_single_limit_report(
+                    let (power_law_fit, cut_fits, component_fits) = limit_data.extract_power()?;
+                    let mut report = build_single_limit_report(
                         ir_limit,
                         orientation_label,
                         power_law_fit,
                         build_cut_limit_reports(ir_limit.num_soft(), cut_fits),
-                    ));
+                    );
+                    report.display_only_reports = build_display_only_limit_reports(component_fits);
+                    reports.push(report);
                 }
 
                 Ok(reports)
@@ -1016,7 +1124,8 @@ impl AmplitudeIntegrand {
                             });
                         }
 
-                        let (power_law_fit, cut_fits) = limit_data.extract_power()?;
+                        let (power_law_fit, cut_fits, component_fits) =
+                            limit_data.extract_power()?;
                         let context_label = Some(match orientation_label.as_deref() {
                             Some(orientation_label) => {
                                 format!("{overlap_group_label} / {orientation_label}")
@@ -1024,12 +1133,15 @@ impl AmplitudeIntegrand {
                             None => overlap_group_label.clone(),
                         });
 
-                        reports.push(build_threshold_limit_report(
+                        let mut report = build_threshold_limit_report(
                             threshold_limit,
                             context_label,
                             power_law_fit,
                             build_cut_limit_reports(0, cut_fits),
-                        ));
+                        );
+                        report.display_only_reports =
+                            build_display_only_limit_reports(component_fits);
+                        reports.push(report);
                     }
                 }
 
@@ -1248,7 +1360,7 @@ impl CrossSectionIntegrand {
                 });
             }
 
-            let (power_law_fit, cut_fits) = limit_data.extract_power()?;
+            let (power_law_fit, cut_fits, _component_fits) = limit_data.extract_power()?;
             reports.push(build_single_limit_report(
                 ir_limit,
                 orientation_label,
@@ -1379,12 +1491,10 @@ impl ThresholdLimit {
         existing_esurfaces
             .iter_enumerated()
             .find_map(|(existing_esurface_id, group_esurface_id)| {
-                esurface_map
-                    .get(*group_esurface_id)
-                    .and_then(|graph_map| {
-                        (graph_map[own_group_position] == Some(self.esurface_id))
-                            .then_some(existing_esurface_id)
-                    })
+                esurface_map.get(*group_esurface_id).and_then(|graph_map| {
+                    (graph_map[own_group_position] == Some(self.esurface_id))
+                        .then_some(existing_esurface_id)
+                })
             })
             .ok_or_else(|| {
                 eyre!(
@@ -1934,8 +2044,8 @@ fn evaluate_profile_momentum_point_arb<I: ProcessIntegrandImpl>(
         true,
     )? {
         PreciseEvaluationResult::Arb(result) => {
+            let zero = result.integrand_result.re.zero();
             let per_cut = if show_per_cut_info {
-                let zero = result.integrand_result.re.zero();
                 let mut per_cut = BTreeMap::new();
                 for event_group in result.event_groups.iter() {
                     for event in event_group.iter() {
@@ -1950,9 +2060,30 @@ fn evaluate_profile_momentum_point_arb<I: ProcessIntegrandImpl>(
                 BTreeMap::new()
             };
 
+            let mut display_only_components = BTreeMap::new();
+            for event_group in result.event_groups.iter() {
+                for event in event_group.iter() {
+                    for (key, weight) in &event.additional_weights.weights {
+                        if !matches!(
+                            key,
+                            AdditionalWeightKey::Original
+                                | AdditionalWeightKey::ThresholdCounterterm { .. }
+                        ) {
+                            continue;
+                        }
+
+                        let entry = display_only_components
+                            .entry(*key)
+                            .or_insert_with(|| zero.clone());
+                        *entry += weight.re.clone();
+                    }
+                }
+            }
+
             Ok(ProfilePointValue {
                 total: result.integrand_result.re,
                 per_cut,
+                display_only_components,
             })
         }
         PreciseEvaluationResult::Double(_) => Err(eyre!(
@@ -2004,6 +2135,7 @@ struct LambdaPointEval<T: FloatLike> {
 struct ProfilePointValue {
     total: F<ArbPrec>,
     per_cut: BTreeMap<usize, F<ArbPrec>>,
+    display_only_components: BTreeMap<AdditionalWeightKey, F<ArbPrec>>,
 }
 
 struct LimitData<T: FloatLike> {
@@ -2011,7 +2143,13 @@ struct LimitData<T: FloatLike> {
 }
 
 impl<T: FloatLike> LimitData<T> {
-    fn extract_power(&self) -> Result<(PowerLawFit, Vec<(usize, Result<PowerLawFit>)>)> {
+    fn extract_power(
+        &self,
+    ) -> Result<(
+        PowerLawFit,
+        Vec<(usize, Result<PowerLawFit>)>,
+        Vec<(AdditionalWeightKey, Result<PowerLawFit>)>,
+    )> {
         let x = self
             .data
             .iter()
@@ -2053,6 +2191,36 @@ impl<T: FloatLike> LimitData<T> {
             })
             .collect_vec();
 
+        let component_fits = self
+            .data
+            .iter()
+            .flat_map(|point_eval| point_eval.value.display_only_components.keys().copied())
+            .filter(|key| {
+                matches!(
+                    key,
+                    AdditionalWeightKey::Original
+                        | AdditionalWeightKey::ThresholdCounterterm { .. }
+                )
+            })
+            .unique()
+            .sorted()
+            .map(|key| {
+                let y = self
+                    .data
+                    .iter()
+                    .map(|point_eval| {
+                        point_eval
+                            .value
+                            .display_only_components
+                            .get(&key)
+                            .cloned()
+                            .unwrap_or_else(|| zero.clone())
+                    })
+                    .collect_vec();
+                (key, fit_power_law(x.clone(), y))
+            })
+            .collect_vec();
+
         if result.r_squared < 0.9 {
             warn!("low r^2 value found for input data");
             warn!(
@@ -2065,7 +2233,7 @@ impl<T: FloatLike> LimitData<T> {
             );
         }
 
-        Ok((result, cut_fits))
+        Ok((result, cut_fits, component_fits))
     }
 }
 
@@ -2672,6 +2840,39 @@ mod tests {
     }
 
     #[test]
+    fn single_limit_display_includes_display_only_table() {
+        let ir_limit = IrLimit::new_pure_soft(vec![EdgeIndex::from(1)]);
+        let total_fit = PowerLawFit {
+            exponent: -2.5,
+            r_squared: 0.999,
+        };
+        let mut report = build_single_limit_report(&ir_limit, None, total_fit, Vec::new());
+        report.display_only_reports = build_display_only_limit_reports(vec![
+            (
+                AdditionalWeightKey::Original,
+                Ok(PowerLawFit {
+                    exponent: -1.5,
+                    r_squared: 0.995,
+                }),
+            ),
+            (
+                AdditionalWeightKey::ThresholdCounterterm { subset_index: 0 },
+                Ok(PowerLawFit {
+                    exponent: -0.5,
+                    r_squared: 0.991,
+                }),
+            ),
+        ]);
+
+        let rendered = format!("{report}");
+
+        assert!(rendered.contains("display-only fits for"));
+        assert!(rendered.contains("original"));
+        assert!(rendered.contains("ct_0"));
+        assert!(!rendered.contains("note"));
+    }
+
+    #[test]
     fn graph_limit_display_weaves_per_cut_rows_into_limit_table() {
         let ir_limit = IrLimit::new_pure_soft(vec![EdgeIndex::from(1)]);
         let total_fit = PowerLawFit {
@@ -2698,7 +2899,23 @@ mod tests {
             ],
         );
 
-        let report = build_single_limit_report(&ir_limit, None, total_fit, cut_reports);
+        let mut report = build_single_limit_report(&ir_limit, None, total_fit, cut_reports);
+        report.display_only_reports = build_display_only_limit_reports(vec![
+            (
+                AdditionalWeightKey::Original,
+                Ok(PowerLawFit {
+                    exponent: -1.5,
+                    r_squared: 0.995,
+                }),
+            ),
+            (
+                AdditionalWeightKey::ThresholdCounterterm { subset_index: 0 },
+                Ok(PowerLawFit {
+                    exponent: -0.5,
+                    r_squared: 0.991,
+                }),
+            ),
+        ]);
         let second_report = build_single_limit_report(
             &ir_limit,
             Some("ori-1".to_string()),
@@ -2738,10 +2955,73 @@ mod tests {
         assert!(rendered.contains("edges"));
         assert!(rendered.contains("e1, e3"));
         assert!(rendered.find("cut definitions").unwrap() < rendered.find("status").unwrap());
-        assert!(rendered.contains("cut"));
+        assert!(rendered.contains("item"));
+        assert!(rendered.contains("cut 0"));
+        assert!(rendered.contains("original"));
+        assert!(rendered.contains("ct_0"));
+        assert!(!rendered.contains("note"));
         assert!(rendered.contains("sum"));
         assert!(rendered.contains("INFO"));
         assert!(!rendered.contains("per-cut fits for"));
         assert!(rendered.matches('├').count() >= 3);
+    }
+
+    #[test]
+    fn limit_data_extract_power_includes_display_only_component_fits() {
+        let lambdas = constant_dropped_fit_points(
+            &F::<f64>::from_f64(1.0e-3),
+            &F::<f64>::from_f64(1.0e-1),
+            5,
+        )
+        .unwrap();
+
+        let data = lambdas
+            .into_iter()
+            .map(|lambda| {
+                let lambda_f64 = lambda.into_ff64().0;
+                let mut display_only_components = BTreeMap::new();
+                display_only_components.insert(
+                    AdditionalWeightKey::Original,
+                    F::<ArbPrec>::from_f64(3.0 * lambda_f64.powf(-1.5) + 0.5),
+                );
+                display_only_components.insert(
+                    AdditionalWeightKey::ThresholdCounterterm { subset_index: 0 },
+                    F::<ArbPrec>::from_f64(5.0 * lambda_f64.powf(-0.5) + 1.0),
+                );
+                display_only_components.insert(
+                    AdditionalWeightKey::FullMultiplicativeFactor,
+                    F::<ArbPrec>::from_f64(7.0 * lambda_f64.powf(-2.5) + 1.0),
+                );
+
+                LambdaPointEval {
+                    lambda,
+                    value: ProfilePointValue {
+                        total: F::<ArbPrec>::from_f64(2.0 * lambda_f64.powf(-2.0) + 1.0),
+                        per_cut: BTreeMap::new(),
+                        display_only_components,
+                    },
+                }
+            })
+            .collect();
+
+        let (total_fit, _cut_fits, component_fits) = LimitData { data }.extract_power().unwrap();
+
+        assert!((total_fit.exponent + 2.0).abs() < 1.0e-10);
+        assert_eq!(component_fits.len(), 2);
+
+        let component_fits = component_fits.into_iter().collect::<BTreeMap<_, _>>();
+        let original_fit = component_fits
+            .get(&AdditionalWeightKey::Original)
+            .unwrap()
+            .as_ref()
+            .unwrap();
+        let ct_fit = component_fits
+            .get(&AdditionalWeightKey::ThresholdCounterterm { subset_index: 0 })
+            .unwrap()
+            .as_ref()
+            .unwrap();
+
+        assert!((original_fit.exponent + 1.5).abs() < 1.0e-10);
+        assert!((ct_fit.exponent + 0.5).abs() < 1.0e-10);
     }
 }

--- a/crates/gammalooprs/src/integrands/process/ir.rs
+++ b/crates/gammalooprs/src/integrands/process/ir.rs
@@ -876,14 +876,13 @@ impl AmplitudeIntegrand {
                 &self.data.graph_terms[0].graph.get_external_signature(),
             );
 
+            let mut rng = MonteCarloRng::new(ir_profile_settings.seed, 0);
             let random_loop_momenta = (0..self.data.graph_terms[0]
                 .graph
                 .loop_momentum_basis
                 .loop_edges
                 .len())
-                .map(|_| {
-                    sample_random_unit_vector(&mut MonteCarloRng::new(ir_profile_settings.seed, 0))
-                })
+                .map(|_| sample_random_unit_vector(&mut rng))
                 .collect();
 
             let momentum_sample = MomentumSample::new(

--- a/crates/gammalooprs/src/integrands/process/ir.rs
+++ b/crates/gammalooprs/src/integrands/process/ir.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashSet, fmt::Display};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt::Display,
+};
 
 use color_eyre::eyre::Result;
 use colored::Colorize;
@@ -48,6 +51,7 @@ pub struct IRProfileSetting {
     pub seed: u64,
     pub select_limits_and_graphs: Option<String>,
     pub orientation_mode: OrientationProfileMode,
+    pub show_per_cut_info: bool,
 }
 
 impl AmplitudeGraphTerm {
@@ -157,7 +161,14 @@ pub struct IrLimitTestReport {
 pub struct GraphIRLimitReport {
     pub graph_name: String,
     pub all_limits_passed: bool,
+    pub cut_definitions: Vec<GraphCutDefinition>,
     pub single_limit_reports: Vec<SingleLimitReport>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GraphCutDefinition {
+    pub cut_id: usize,
+    pub edges: Vec<EdgeIndex>,
 }
 
 pub struct SingleLimitReport {
@@ -166,7 +177,15 @@ pub struct SingleLimitReport {
     pub passed: bool,
     pub power_law_fit: PowerLawFit,
     pub scaling: f64,
+    pub per_cut_reports: Vec<CutLimitReport>,
     num_soft: usize,
+}
+
+pub struct CutLimitReport {
+    pub cut_id: usize,
+    pub power_law_fit: Option<PowerLawFit>,
+    pub scaling: Option<f64>,
+    pub fit_error: Option<String>,
 }
 
 impl Display for IrLimitTestReport {
@@ -249,18 +268,27 @@ impl Display for GraphIRLimitReport {
             self.single_limit_reports.len()
         )?;
 
+        if !self.cut_definitions.is_empty() {
+            render_graph_cut_definitions(f, &self.cut_definitions)?;
+            writeln!(f)?;
+        }
+
         let mut limit_table = Builder::new();
+        let mut separators_after_data_rows = Vec::new();
+        let mut data_row_count = 0;
         limit_table.push_record([
             "status",
             "limit",
             "orientation",
+            "cut",
             "scaling",
             "p",
             "r_squared",
             "n_soft",
+            "note",
         ]);
 
-        for report in &self.single_limit_reports {
+        for (report_index, report) in self.single_limit_reports.iter().enumerate() {
             let status = if report.passed {
                 "PASS".green().bold().to_string()
             } else {
@@ -274,14 +302,47 @@ impl Display for GraphIRLimitReport {
                     .orientation_label
                     .clone()
                     .unwrap_or_else(|| "sum".to_string()),
+                "sum".to_string(),
                 format!("{:+.4}", report.scaling),
                 format!("{:+.4}", report.power_law_fit.exponent),
                 format!("{:.4}", report.power_law_fit.r_squared),
                 report.num_soft.to_string(),
+                String::new(),
             ]);
+            data_row_count += 1;
+
+            if !report.per_cut_reports.is_empty() {
+                separators_after_data_rows.push(data_row_count);
+            }
+
+            for cut_report in &report.per_cut_reports {
+                let [cut_id, scaling, exponent, r_squared, note] =
+                    cut_report_display_row(cut_report);
+                limit_table.push_record([
+                    "INFO".cyan().bold().to_string(),
+                    String::new(),
+                    String::new(),
+                    cut_id,
+                    scaling,
+                    exponent,
+                    r_squared,
+                    String::new(),
+                    note,
+                ]);
+                data_row_count += 1;
+            }
+
+            if report_index + 1 < self.single_limit_reports.len() {
+                separators_after_data_rows.push(data_row_count);
+            }
         }
 
-        write!(f, "{}", limit_table.build().with(Style::rounded()))?;
+        let mut table = limit_table.build();
+        table.with(Style::rounded());
+        let rendered =
+            insert_limit_table_separators(table.to_string(), &separators_after_data_rows);
+
+        write!(f, "{rendered}")?;
 
         Ok(())
     }
@@ -308,8 +369,127 @@ impl Display for SingleLimitReport {
             self.power_law_fit.exponent,
             self.power_law_fit.r_squared,
             self.num_soft
-        )
+        )?;
+
+        render_per_cut_reports(f, self, "")
     }
+}
+
+fn render_per_cut_reports(
+    f: &mut std::fmt::Formatter<'_>,
+    report: &SingleLimitReport,
+    indent: &str,
+) -> std::fmt::Result {
+    if report.per_cut_reports.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(f)?;
+    writeln!(
+        f,
+        "\n{indent}per-cut fits for {}{}",
+        report.limit_name,
+        report
+            .orientation_label
+            .as_ref()
+            .map(|label| format!(" @ {label}"))
+            .unwrap_or_default(),
+    )?;
+
+    let mut cut_table = Builder::new();
+    cut_table.push_record(["cut", "scaling", "p", "r_squared", "note"]);
+
+    for cut_report in &report.per_cut_reports {
+        cut_table.push_record(cut_report_display_row(cut_report));
+    }
+
+    write!(f, "{}", cut_table.build().with(Style::rounded()))
+}
+
+fn render_graph_cut_definitions(
+    f: &mut std::fmt::Formatter<'_>,
+    cut_definitions: &[GraphCutDefinition],
+) -> std::fmt::Result {
+    writeln!(f, "  cut definitions")?;
+
+    let mut cut_table = Builder::new();
+    cut_table.push_record(["cut", "edges"]);
+
+    for cut_definition in cut_definitions {
+        cut_table.push_record([
+            cut_definition.cut_id.to_string(),
+            cut_definition
+                .edges
+                .iter()
+                .map(ToString::to_string)
+                .join(", "),
+        ]);
+    }
+
+    writeln!(f, "{}", cut_table.build().with(Style::rounded()))
+}
+
+fn cut_report_display_row(cut_report: &CutLimitReport) -> [String; 5] {
+    let (scaling, exponent, r_squared, note) =
+        match (&cut_report.power_law_fit, &cut_report.fit_error) {
+            (Some(fit), None) => (
+                format!("{:+.4}", cut_report.scaling.unwrap_or(fit.exponent)),
+                format!("{:+.4}", fit.exponent),
+                format!("{:.4}", fit.r_squared),
+                String::new(),
+            ),
+            (None, Some(error)) => (
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                error.clone(),
+            ),
+            _ => (
+                "-".to_string(),
+                "-".to_string(),
+                "-".to_string(),
+                "missing cut fit".to_string(),
+            ),
+        };
+
+    [
+        cut_report.cut_id.to_string(),
+        scaling,
+        exponent,
+        r_squared,
+        note,
+    ]
+}
+
+fn insert_limit_table_separators(rendered: String, separators_after_data_rows: &[usize]) -> String {
+    if separators_after_data_rows.is_empty() {
+        return rendered;
+    }
+
+    let lines = rendered.lines().collect_vec();
+    if lines.len() < 4 {
+        return rendered;
+    }
+
+    let line_count = lines.len();
+    let separator_line = lines[2].to_string();
+    let mut next_separator = separators_after_data_rows.iter().copied().peekable();
+    let mut output = Vec::with_capacity(lines.len() + separators_after_data_rows.len());
+    let mut seen_data_rows = 0;
+
+    for (line_index, line) in lines.into_iter().enumerate() {
+        output.push(line.to_string());
+
+        if line_index >= 3 && line_index + 1 < line_count {
+            seen_data_rows += 1;
+            while next_separator.peek().copied() == Some(seen_data_rows) {
+                output.push(separator_line.clone());
+                next_separator.next();
+            }
+        }
+    }
+
+    output.join("\n")
 }
 
 fn ir_profile_completion_entries(
@@ -322,6 +502,25 @@ fn ir_profile_completion_entries(
                 graph_name,
                 limits.into_iter().map(|limit| limit.to_string()).collect(),
             )
+        })
+        .collect()
+}
+
+fn graph_cut_definitions_for_cross_section_term(
+    graph_term: &CrossSectionGraphTerm,
+) -> Vec<GraphCutDefinition> {
+    graph_term
+        .cuts
+        .iter_enumerated()
+        .map(|(cut_id, cut)| GraphCutDefinition {
+            cut_id: cut_id.into(),
+            edges: graph_term
+                .graph
+                .underlying
+                .iter_edges_of(&cut.cut)
+                .map(|(_, edge_id, _)| edge_id)
+                .sorted()
+                .collect(),
         })
         .collect()
 }
@@ -400,6 +599,7 @@ fn build_single_limit_report(
     ir_limit: &IrLimit,
     orientation_label: Option<String>,
     slope: PowerLawFit,
+    per_cut_reports: Vec<CutLimitReport>,
 ) -> SingleLimitReport {
     let num_soft = ir_limit.num_soft();
     let scaling = slope.exponent + ((num_soft * 3) as f64);
@@ -409,8 +609,32 @@ fn build_single_limit_report(
         passed: scaling > 0.0,
         power_law_fit: slope,
         scaling,
+        per_cut_reports,
         num_soft,
     }
+}
+
+fn build_cut_limit_reports(
+    num_soft: usize,
+    cut_fits: Vec<(usize, Result<PowerLawFit>)>,
+) -> Vec<CutLimitReport> {
+    cut_fits
+        .into_iter()
+        .map(|(cut_id, fit)| match fit {
+            Ok(power_law_fit) => CutLimitReport {
+                cut_id,
+                scaling: Some(power_law_fit.exponent + ((num_soft * 3) as f64)),
+                power_law_fit: Some(power_law_fit),
+                fit_error: None,
+            },
+            Err(error) => CutLimitReport {
+                cut_id,
+                scaling: None,
+                power_law_fit: None,
+                fit_error: Some(error.to_string()),
+            },
+        })
+        .collect()
 }
 
 fn run_ir_profile<I: ProcessIntegrandImpl>(
@@ -418,6 +642,7 @@ fn run_ir_profile<I: ProcessIntegrandImpl>(
     ir_profile_settings: &IRProfileSetting,
     model: &Model,
     enumerate_limits: impl Fn(&I) -> Vec<(String, Vec<IrLimit>)>,
+    graph_cut_definitions: impl Fn(&I, usize) -> Vec<GraphCutDefinition>,
     mut test_single_limit: impl FnMut(
         &mut I,
         usize,
@@ -448,6 +673,7 @@ fn run_ir_profile<I: ProcessIntegrandImpl>(
         let mut graph_report = GraphIRLimitReport {
             graph_name: graph_name.clone(),
             all_limits_passed: false,
+            cut_definitions: graph_cut_definitions(integrand, graph_id),
             single_limit_reports: Vec::new(),
         };
 
@@ -498,14 +724,28 @@ impl AmplitudeIntegrand {
             }),
         });
 
-        self.warm_up(model)?;
-        run_ir_profile(
-            self,
-            ir_profile_settings,
-            model,
-            Self::enumerate_ir_limits,
-            Self::test_single_ir_limit_impl,
-        )
+        let previous_generate_events = self.settings.general.generate_events;
+        if ir_profile_settings.show_per_cut_info {
+            self.settings.general.generate_events = true;
+        }
+
+        let result = (|| {
+            self.warm_up(model)?;
+            run_ir_profile(
+                self,
+                ir_profile_settings,
+                model,
+                Self::enumerate_ir_limits,
+                Self::graph_cut_definitions,
+                Self::test_single_ir_limit_impl,
+            )
+        })();
+
+        if self.settings.general.generate_events != previous_generate_events {
+            self.settings.general.generate_events = previous_generate_events;
+        }
+
+        result
     }
 
     fn enumerate_ir_limits(&self) -> Vec<(String, Vec<IrLimit>)> {
@@ -518,6 +758,10 @@ impl AmplitudeIntegrand {
                 (graph_name, limits)
             })
             .collect()
+    }
+
+    fn graph_cut_definitions(&self, _graph_id: usize) -> Vec<GraphCutDefinition> {
+        Vec::new()
     }
 
     fn test_single_ir_limit_impl(
@@ -608,14 +852,17 @@ impl AmplitudeIntegrand {
                         graph_id,
                         orientation,
                         sample.loop_moms().iter().cloned().collect_vec(),
+                        approach_settings.show_per_cut_info,
                     )?,
                 });
             }
 
+            let (power_law_fit, cut_fits) = limit_data.extract_power()?;
             reports.push(build_single_limit_report(
                 ir_limit,
                 orientation_label,
-                limit_data.extract_power()?,
+                power_law_fit,
+                build_cut_limit_reports(ir_limit.num_soft(), cut_fits),
             ));
         }
 
@@ -643,14 +890,28 @@ impl CrossSectionIntegrand {
             }),
         });
 
-        self.warm_up(model)?;
-        run_ir_profile(
-            self,
-            ir_profile_settings,
-            model,
-            Self::enumerate_ir_limits,
-            Self::test_single_ir_limit_impl,
-        )
+        let previous_generate_events = self.settings.general.generate_events;
+        if ir_profile_settings.show_per_cut_info {
+            self.settings.general.generate_events = true;
+        }
+
+        let result = (|| {
+            self.warm_up(model)?;
+            run_ir_profile(
+                self,
+                ir_profile_settings,
+                model,
+                Self::enumerate_ir_limits,
+                Self::graph_cut_definitions,
+                Self::test_single_ir_limit_impl,
+            )
+        })();
+
+        if self.settings.general.generate_events != previous_generate_events {
+            self.settings.general.generate_events = previous_generate_events;
+        }
+
+        result
     }
 
     fn enumerate_ir_limits(&self) -> Vec<(String, Vec<IrLimit>)> {
@@ -663,6 +924,10 @@ impl CrossSectionIntegrand {
                 (graph_name, limits)
             })
             .collect()
+    }
+
+    fn graph_cut_definitions(&self, graph_id: usize) -> Vec<GraphCutDefinition> {
+        graph_cut_definitions_for_cross_section_term(&self.data.graph_terms[graph_id])
     }
 
     fn test_single_ir_limit_impl(
@@ -791,14 +1056,17 @@ impl CrossSectionIntegrand {
                         graph_id,
                         orientation,
                         sample.loop_moms().iter().cloned().collect_vec(),
+                        approach_settings.show_per_cut_info,
                     )?,
                 });
             }
 
+            let (power_law_fit, cut_fits) = limit_data.extract_power()?;
             reports.push(build_single_limit_report(
                 ir_limit,
                 orientation_label,
-                limit_data.extract_power()?,
+                power_law_fit,
+                build_cut_limit_reports(ir_limit.num_soft(), cut_fits),
             ));
         }
 
@@ -1236,7 +1504,8 @@ fn evaluate_profile_momentum_point_arb<I: ProcessIntegrandImpl>(
     graph_id: usize,
     orientation: Option<usize>,
     loop_momenta: Vec<ThreeMomentum<F<f64>>>,
-) -> Result<F<ArbPrec>> {
+    show_per_cut_info: bool,
+) -> Result<ProfilePointValue> {
     match evaluate_profile_momentum_point_precise(
         integrand,
         model,
@@ -1245,7 +1514,28 @@ fn evaluate_profile_momentum_point_arb<I: ProcessIntegrandImpl>(
         loop_momenta,
         true,
     )? {
-        PreciseEvaluationResult::Arb(result) => Ok(result.integrand_result.re),
+        PreciseEvaluationResult::Arb(result) => {
+            let per_cut = if show_per_cut_info {
+                let zero = result.integrand_result.re.zero();
+                let mut per_cut = BTreeMap::new();
+                for event_group in result.event_groups.iter() {
+                    for event in event_group.iter() {
+                        let entry = per_cut
+                            .entry(event.cut_info.cut_id)
+                            .or_insert_with(|| zero.clone());
+                        *entry += event.weight.re.clone();
+                    }
+                }
+                per_cut
+            } else {
+                BTreeMap::new()
+            };
+
+            Ok(ProfilePointValue {
+                total: result.integrand_result.re,
+                per_cut,
+            })
+        }
         PreciseEvaluationResult::Double(_) => Err(eyre!(
             "IR profiling requested arbitrary precision but received a double-precision result"
         )),
@@ -1283,7 +1573,12 @@ struct LambdaPoint<T: FloatLike> {
 
 struct LambdaPointEval<T: FloatLike> {
     lambda_point: LambdaPoint<T>,
-    value: F<ArbPrec>,
+    value: ProfilePointValue,
+}
+
+struct ProfilePointValue {
+    total: F<ArbPrec>,
+    per_cut: BTreeMap<usize, F<ArbPrec>>,
 }
 
 struct LimitData<T: FloatLike> {
@@ -1291,7 +1586,7 @@ struct LimitData<T: FloatLike> {
 }
 
 impl<T: FloatLike> LimitData<T> {
-    fn extract_power(&self) -> Result<PowerLawFit> {
+    fn extract_power(&self) -> Result<(PowerLawFit, Vec<(usize, Result<PowerLawFit>)>)> {
         let x = self
             .data
             .iter()
@@ -1301,10 +1596,37 @@ impl<T: FloatLike> LimitData<T> {
         let y = self
             .data
             .iter()
-            .map(|point_eval| point_eval.value.clone())
+            .map(|point_eval| point_eval.value.total.clone())
             .collect_vec();
 
         let result = fit_power_law(x.clone(), y.clone())?;
+
+        let zero = x
+            .first()
+            .map(|value| value.zero())
+            .unwrap_or_else(|| F::<ArbPrec>::from_f64(0.0));
+        let cut_fits = self
+            .data
+            .iter()
+            .flat_map(|point_eval| point_eval.value.per_cut.keys().copied())
+            .unique()
+            .sorted()
+            .map(|cut_id| {
+                let y = self
+                    .data
+                    .iter()
+                    .map(|point_eval| {
+                        point_eval
+                            .value
+                            .per_cut
+                            .get(&cut_id)
+                            .cloned()
+                            .unwrap_or_else(|| zero.clone())
+                    })
+                    .collect_vec();
+                (cut_id, fit_power_law(x.clone(), y))
+            })
+            .collect_vec();
 
         if result.r_squared < 0.9 {
             warn!("low r^2 value found for input data");
@@ -1318,7 +1640,7 @@ impl<T: FloatLike> LimitData<T> {
             );
         }
 
-        Ok(result)
+        Ok((result, cut_fits))
     }
 }
 
@@ -1487,5 +1809,140 @@ mod tests {
         let fit = fit_power_law(x, y);
 
         assert!(fit.is_err());
+    }
+
+    #[test]
+    fn negative_cut_scaling_does_not_fail_limit() {
+        let ir_limit = IrLimit::new_pure_soft(vec![EdgeIndex::from(1)]);
+        let total_fit = PowerLawFit {
+            exponent: -2.5,
+            r_squared: 0.999,
+        };
+        let cut_reports = build_cut_limit_reports(
+            ir_limit.num_soft(),
+            vec![
+                (
+                    0,
+                    Ok(PowerLawFit {
+                        exponent: -4.5,
+                        r_squared: 0.999,
+                    }),
+                ),
+                (
+                    1,
+                    Ok(PowerLawFit {
+                        exponent: -2.5,
+                        r_squared: 0.999,
+                    }),
+                ),
+            ],
+        );
+
+        let report = build_single_limit_report(&ir_limit, None, total_fit, cut_reports);
+
+        assert!(report.passed);
+        assert_eq!(report.per_cut_reports.len(), 2);
+        assert!(report.per_cut_reports[0].scaling.unwrap() < 0.0);
+        assert!(report.per_cut_reports[1].scaling.unwrap() > 0.0);
+    }
+
+    #[test]
+    fn single_limit_display_includes_per_cut_table() {
+        let ir_limit = IrLimit::new_pure_soft(vec![EdgeIndex::from(1)]);
+        let total_fit = PowerLawFit {
+            exponent: -2.5,
+            r_squared: 0.999,
+        };
+        let cut_reports = build_cut_limit_reports(
+            ir_limit.num_soft(),
+            vec![(
+                0,
+                Ok(PowerLawFit {
+                    exponent: -4.5,
+                    r_squared: 0.999,
+                }),
+            )],
+        );
+
+        let report = build_single_limit_report(&ir_limit, None, total_fit, cut_reports);
+        let rendered = format!("{report}");
+
+        assert!(rendered.contains("per-cut fits for"));
+        assert!(rendered.contains("cut"));
+        assert!(rendered.contains("r_squared"));
+    }
+
+    #[test]
+    fn graph_limit_display_weaves_per_cut_rows_into_limit_table() {
+        let ir_limit = IrLimit::new_pure_soft(vec![EdgeIndex::from(1)]);
+        let total_fit = PowerLawFit {
+            exponent: -2.5,
+            r_squared: 0.999,
+        };
+        let cut_reports = build_cut_limit_reports(
+            ir_limit.num_soft(),
+            vec![
+                (
+                    0,
+                    Ok(PowerLawFit {
+                        exponent: -4.5,
+                        r_squared: 0.999,
+                    }),
+                ),
+                (
+                    1,
+                    Ok(PowerLawFit {
+                        exponent: -2.5,
+                        r_squared: 0.999,
+                    }),
+                ),
+            ],
+        );
+
+        let report = build_single_limit_report(&ir_limit, None, total_fit, cut_reports);
+        let second_report = build_single_limit_report(
+            &ir_limit,
+            Some("ori-1".to_string()),
+            PowerLawFit {
+                exponent: -2.5,
+                r_squared: 0.999,
+            },
+            build_cut_limit_reports(
+                ir_limit.num_soft(),
+                vec![(
+                    2,
+                    Ok(PowerLawFit {
+                        exponent: -1.5,
+                        r_squared: 0.995,
+                    }),
+                )],
+            ),
+        );
+        let graph_report = GraphIRLimitReport {
+            graph_name: "GL0".to_string(),
+            all_limits_passed: true,
+            cut_definitions: vec![
+                GraphCutDefinition {
+                    cut_id: 0,
+                    edges: vec![EdgeIndex::from(1), EdgeIndex::from(3)],
+                },
+                GraphCutDefinition {
+                    cut_id: 1,
+                    edges: vec![EdgeIndex::from(2), EdgeIndex::from(4)],
+                },
+            ],
+            single_limit_reports: vec![report, second_report],
+        };
+        let rendered = format!("{graph_report}");
+
+        assert!(rendered.contains("cut definitions"));
+        assert!(rendered.contains("edges"));
+        assert!(rendered.contains("e1, e3"));
+        assert!(rendered.find("cut definitions").unwrap() < rendered.find("status").unwrap());
+        assert!(rendered.contains("cut"));
+        assert!(rendered.contains("sum"));
+        assert!(rendered.contains("INFO"));
+        assert!(!rendered.contains("per-cut fits for"));
+        assert!(rendered.matches('├').count() >= 3);
     }
 }

--- a/crates/gammalooprs/src/integrands/process/mod.rs
+++ b/crates/gammalooprs/src/integrands/process/mod.rs
@@ -1037,6 +1037,32 @@ pub(crate) fn evaluate_profile_momentum_point<I: ProcessIntegrandImpl>(
     )
 }
 
+pub(crate) fn evaluate_profile_momentum_point_precise<I: ProcessIntegrandImpl>(
+    integrand: &mut I,
+    model: &Model,
+    graph_id: usize,
+    orientation: Option<usize>,
+    loop_momenta: Vec<ThreeMomentum<F<f64>>>,
+    use_arb_prec: bool,
+) -> Result<PreciseEvaluationResult> {
+    let input = MomentumSpaceEvaluationInput {
+        loop_momenta,
+        integrator_weight: F(1.0),
+        graph_id: Some(graph_id),
+        group_id: None,
+        orientation,
+        channel_id: None,
+    };
+    evaluate_momentum_configuration_precise(
+        integrand,
+        model,
+        &input,
+        F(1.0),
+        use_arb_prec,
+        Complex::new_re(F(100.0 * integrand.get_settings().kinematics.e_cm)),
+    )
+}
+
 fn format_lmb_channel_label(edge_ids: &[usize]) -> String {
     let mut sorted = edge_ids.to_vec();
     sorted.sort_unstable();

--- a/crates/gammalooprs/src/subtraction/amplitude_counterterm.rs
+++ b/crates/gammalooprs/src/subtraction/amplitude_counterterm.rs
@@ -8,12 +8,15 @@ use symbolica::atom::Atom;
 
 use color_eyre::Result;
 use tracing::{debug, instrument};
-use typed_index_collections::TiVec;
+use typed_index_collections::{TiVec, ti_vec};
 
 use crate::{
     GammaLoopContext,
     cff::{
-        esurface::{Esurface, EsurfaceCollection, EsurfaceID, ExistingEsurfaceId, GroupEsurfaceId},
+        esurface::{
+            Esurface, EsurfaceCollection, EsurfaceID, ExistingEsurfaceId, ExistingEsurfaces,
+            GroupEsurfaceId,
+        },
         expression::OrientationID,
     },
     graph::{FeynmanGraph, Graph, GraphGroupPosition},
@@ -293,6 +296,73 @@ impl AmplitudeCountertermData {
             local_counterterms,
         })
     }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn kinematics_for_approach<T: FloatLike>(
+        &mut self,
+        momentum_sample: &MomentumSample<T>,
+        graph: &Graph,
+        model: &Model,
+        esurfaces: &EsurfaceCollection,
+        rotation: &Rotation,
+        settings: &RuntimeSettings,
+    ) -> Result<OverlapStructureWithKinematics<T>> {
+        let counter_term_builder = CounterTermBuilder::new(
+            graph,
+            model,
+            rotation,
+            settings,
+            esurfaces,
+            momentum_sample,
+            &self.overlap,
+            &self.evaluators,
+            self.own_group_position,
+            &self.esurface_map,
+        );
+
+        let mut overlap_sturcture_with_kinematics = OverlapStructureWithKinematics {
+            existing_esurfaces: self.overlap.existing_esurfaces.clone(),
+            overlap_groups_with_kinematics: Vec::new(),
+        };
+
+        for group in self.overlap.overlap_groups.iter() {
+            let overlap_builder = counter_term_builder.new_overlap_builder(group);
+
+            let mut loop_momenta_at_esurface: TiVec<ExistingEsurfaceId, Option<MomentumSample<T>>> =
+                ti_vec![];
+            for existing_esurface_id in group.existing_esurfaces.iter() {
+                let single_result = overlap_builder
+                    .new_esurface_builder(*existing_esurface_id)
+                    .map(|esurface_builder| -> Result<_> {
+                        self.ensure_active_esurface(esurface_builder.esurface_id)?;
+                        let rstar_sample = esurface_builder.solve_rstar().rstar_samples();
+                        Result::Ok(rstar_sample.rstar_sample)
+                    })
+                    .transpose()?;
+
+                loop_momenta_at_esurface.push(single_result);
+            }
+
+            overlap_sturcture_with_kinematics
+                .overlap_groups_with_kinematics
+                .push(OverlapGroupWithKinematics {
+                    overlap_group: group.clone(),
+                    loop_momenta_at_esurface,
+                });
+        }
+
+        Ok(overlap_sturcture_with_kinematics)
+    }
+}
+
+pub struct OverlapGroupWithKinematics<T: FloatLike> {
+    pub overlap_group: OverlapGroup,
+    pub loop_momenta_at_esurface: TiVec<ExistingEsurfaceId, Option<MomentumSample<T>>>,
+}
+
+pub struct OverlapStructureWithKinematics<T: FloatLike> {
+    pub existing_esurfaces: ExistingEsurfaces,
+    pub overlap_groups_with_kinematics: Vec<OverlapGroupWithKinematics<T>>,
 }
 
 struct CounterTermBuilder<'a, T: FloatLike> {

--- a/crates/gammalooprs/src/utils/fitting.rs
+++ b/crates/gammalooprs/src/utils/fitting.rs
@@ -37,7 +37,7 @@ pub fn constant_dropped_fit_points<T: FloatLike>(
         ));
     }
 
-    let ten = F::from_f64(10.0);
+    let ten = start.from_i64(10);
     let mut points = Vec::with_capacity(num);
     points.push(start.clone());
 
@@ -247,10 +247,7 @@ fn linear_regression<T: FloatLike>(samples: &[(F<T>, F<T>)]) -> Result<SlopeFit<
     if r_squared.is_nan() || r_squared.is_infinite() {
         Err(eyre!("log-log regression produced a non-finite r-squared"))
     } else {
-        Ok(SlopeFit {
-            slope,
-            r_suared: r_squared,
-        })
+        Ok(SlopeFit { slope, r_squared })
     }
 }
 

--- a/crates/gammalooprs/src/utils/fitting.rs
+++ b/crates/gammalooprs/src/utils/fitting.rs
@@ -21,19 +21,20 @@ pub fn constant_dropped_fit_points<T: FloatLike>(
         ));
     }
 
-    if stop <= start {
+    if stop == start {
         return Err(eyre!(
-            "fit point range must satisfy start < stop for multiplicative spacing"
+            "fit point range must have distinct bounds for multiplicative spacing"
         ));
     }
 
+    let is_ascending = stop > start;
     let log_start = start.log10();
     let log_stop = stop.log10();
     let step_count = start.from_usize(num - 1);
     let log_step = (&log_stop - &log_start) / &step_count;
-    if !log_step.positive() || log_step.is_nan() || log_step.is_infinite() {
+    if log_step.is_nan() || log_step.is_infinite() || log_step.abs().less_than_epsilon() {
         return Err(eyre!(
-            "fit point range must yield a finite positive log step"
+            "fit point range must yield a finite non-zero log step"
         ));
     }
 
@@ -48,18 +49,30 @@ pub fn constant_dropped_fit_points<T: FloatLike>(
         if point.is_nan() || point.is_infinite() {
             return Err(eyre!("generated a non-finite fit point"));
         }
-        if &point <= points.last().expect("point list is non-empty") {
+        let previous = points.last().expect("point list is non-empty");
+        let advances = if is_ascending {
+            &point > previous
+        } else {
+            &point < previous
+        };
+        if !advances {
             return Err(eyre!(
-                "range and point count collapse at current precision; generated fit points are not strictly increasing"
+                "range and point count collapse at current precision; generated fit points are not strictly monotonic"
             ));
         }
 
         points.push(point);
     }
 
-    if stop <= points.last().expect("point list is non-empty") {
+    let previous = points.last().expect("point list is non-empty");
+    let advances = if is_ascending {
+        stop > previous
+    } else {
+        stop < previous
+    };
+    if !advances {
         return Err(eyre!(
-            "range and point count collapse at current precision; final bound is not larger than the generated interior points"
+            "range and point count collapse at current precision; final bound does not preserve the requested monotonic direction"
         ));
     }
 
@@ -133,8 +146,11 @@ fn collect_log_difference_samples<T: FloatLike>(
     let reference_log_x = samples[0].0.log10();
     let next_log_x = samples[1].0.log10();
     let reference_step = &next_log_x - &reference_log_x;
-    if !reference_step.positive() {
-        return Err(eyre!("x grid must have a positive multiplicative spacing"));
+    if reference_step.is_nan()
+        || reference_step.is_infinite()
+        || reference_step.abs().less_than_epsilon()
+    {
+        return Err(eyre!("x grid must have a non-zero multiplicative spacing"));
     }
 
     let tolerance = {
@@ -274,6 +290,38 @@ mod tests {
 
         assert!((x_values[0] - 0.2_f64).abs() < 1.0e-12);
         assert!((x_values[7] - 0.2_f64 * ratio.powi(7)).abs() < 1.0e-12);
+        assert!((fit.slope.into_f64() - slope).abs() < 1.0e-10);
+        assert!(fit.r_squared().into_f64() > 0.999_999_999);
+    }
+
+    #[test]
+    fn constant_dropped_fit_supports_descending_geometric_grid() {
+        let coefficient = 3.2_f64;
+        let slope = -1.75_f64;
+        let offset = 0.6_f64;
+        let ratio: f64 = 1.6;
+
+        let x = constant_dropped_fit_points(
+            &F::from_f64(0.2_f64 * ratio.powi(7)),
+            &F::from_f64(0.2_f64),
+            8,
+        )
+        .expect("descending fit point generation should succeed");
+        let x_values = x
+            .iter()
+            .map(|x_value| x_value.into_f64())
+            .collect::<Vec<_>>();
+        let y = x
+            .iter()
+            .map(|x_value| coefficient * x_value.into_f64().powf(slope) + offset)
+            .collect::<Vec<_>>();
+
+        let fit = log_log_slope_constant_dropped(&x, &ff64_values(&y))
+            .expect("power-law fit should succeed on a descending geometric grid");
+
+        assert!((x_values[0] - 0.2_f64 * ratio.powi(7)).abs() < 1.0e-12);
+        assert!((x_values[7] - 0.2_f64).abs() < 1.0e-12);
+        assert!(x_values.windows(2).all(|window| window[0] > window[1]));
         assert!((fit.slope.into_f64() - slope).abs() < 1.0e-10);
         assert!(fit.r_squared().into_f64() > 0.999_999_999);
     }

--- a/crates/gammalooprs/src/utils/fitting.rs
+++ b/crates/gammalooprs/src/utils/fitting.rs
@@ -93,12 +93,12 @@ pub fn log_log_slope_constant_dropped<T: FloatLike>(x: &[F<T>], y: &[F<T>]) -> R
 
 pub struct SlopeFit<T: FloatLike> {
     pub slope: F<T>,
-    pub r_suared: F<T>,
+    pub r_squared: F<T>,
 }
 
 impl<T: FloatLike> SlopeFit<T> {
     pub fn r_squared(&self) -> &F<T> {
-        &self.r_suared
+        &self.r_squared
     }
 }
 

--- a/crates/gammalooprs/src/utils/fitting.rs
+++ b/crates/gammalooprs/src/utils/fitting.rs
@@ -1,7 +1,6 @@
 use crate::utils::{F, FloatLike};
 use color_eyre::eyre::{Result, eyre};
 use std::cmp::Ordering;
-use symbolica::domains::float::Real;
 
 pub fn constant_dropped_fit_points<T: FloatLike>(
     start: &F<T>,

--- a/crates/gammalooprs/src/utils/fitting.rs
+++ b/crates/gammalooprs/src/utils/fitting.rs
@@ -1,0 +1,310 @@
+use crate::utils::{F, FloatLike};
+use color_eyre::eyre::{Result, eyre};
+use std::cmp::Ordering;
+use symbolica::domains::float::Real;
+
+pub fn constant_dropped_fit_points<T: FloatLike>(
+    start: &F<T>,
+    stop: &F<T>,
+    num: usize,
+) -> Result<Vec<F<T>>> {
+    if num < 3 {
+        return Err(eyre!(
+            "need at least 3 points to generate a grid usable by the constant-dropped fit"
+        ));
+    }
+
+    if !start.0.is_finite() || !stop.0.is_finite() || start <= &start.zero() || stop <= &stop.zero()
+    {
+        return Err(eyre!(
+            "fit points must be generated from finite positive bounds"
+        ));
+    }
+
+    if stop <= start {
+        return Err(eyre!(
+            "fit point range must satisfy start < stop for multiplicative spacing"
+        ));
+    }
+
+    let log_start = start.log10();
+    let log_stop = stop.log10();
+    let step_count = start.from_usize(num - 1);
+    let log_step = (&log_stop - &log_start) / &step_count;
+    if !log_step.positive() || log_step.is_nan() || log_step.is_infinite() {
+        return Err(eyre!(
+            "fit point range must yield a finite positive log step"
+        ));
+    }
+
+    let ten = F::from_f64(10.0);
+    let mut points = Vec::with_capacity(num);
+    points.push(start.clone());
+
+    for index in 1..(num - 1) {
+        let step_index = log_step.from_usize(index);
+        let exponent = &log_start + &(&log_step * &step_index);
+        let point = ten.powf(&exponent);
+        if point.is_nan() || point.is_infinite() {
+            return Err(eyre!("generated a non-finite fit point"));
+        }
+        if &point <= points.last().expect("point list is non-empty") {
+            return Err(eyre!(
+                "range and point count collapse at current precision; generated fit points are not strictly increasing"
+            ));
+        }
+
+        points.push(point);
+    }
+
+    if stop <= points.last().expect("point list is non-empty") {
+        return Err(eyre!(
+            "range and point count collapse at current precision; final bound is not larger than the generated interior points"
+        ));
+    }
+
+    points.push(stop.clone());
+    Ok(points)
+}
+
+pub fn log_log_slope_constant_dropped<T: FloatLike>(x: &[F<T>], y: &[F<T>]) -> Result<SlopeFit<T>> {
+    let samples = collect_valid_samples(x, y)?;
+    if samples.len() < 3 {
+        return Err(eyre!(
+            "need at least 3 valid samples for constant-dropped slope fit"
+        ));
+    }
+
+    let transformed_samples = collect_log_difference_samples(&samples)?;
+    linear_regression(&transformed_samples)
+}
+
+pub struct SlopeFit<T: FloatLike> {
+    pub slope: F<T>,
+    pub r_suared: F<T>,
+}
+
+impl<T: FloatLike> SlopeFit<T> {
+    pub fn r_squared(&self) -> &F<T> {
+        &self.r_suared
+    }
+}
+
+fn collect_valid_samples<T: FloatLike>(x: &[F<T>], y: &[F<T>]) -> Result<Vec<(F<T>, F<T>)>> {
+    if x.len() != y.len() {
+        return Err(eyre!(
+            "x and y must have the same length, got {} and {}",
+            x.len(),
+            y.len()
+        ));
+    }
+
+    let mut samples = x
+        .iter()
+        .zip(y)
+        .filter_map(|(x_value, y_value)| {
+            if !x_value.0.is_finite() || !y_value.0.is_finite() || x_value <= &x_value.zero() {
+                return None;
+            }
+
+            Some((x_value.clone(), y_value.clone()))
+        })
+        .collect::<Vec<_>>();
+
+    samples.sort_by(|(lhs, _), (rhs, _)| lhs.partial_cmp(rhs).unwrap_or(Ordering::Equal));
+
+    let mut deduped = Vec::with_capacity(samples.len());
+    for sample in samples {
+        if deduped
+            .last()
+            .is_some_and(|(previous_x, _)| previous_x == &sample.0)
+        {
+            continue;
+        }
+        deduped.push(sample);
+    }
+
+    Ok(deduped)
+}
+
+fn collect_log_difference_samples<T: FloatLike>(
+    samples: &[(F<T>, F<T>)],
+) -> Result<Vec<(F<T>, F<T>)>> {
+    let reference_log_x = samples[0].0.log10();
+    let next_log_x = samples[1].0.log10();
+    let reference_step = &next_log_x - &reference_log_x;
+    if !reference_step.positive() {
+        return Err(eyre!("x grid must have a positive multiplicative spacing"));
+    }
+
+    let tolerance = {
+        let scale = &reference_step.abs() + &reference_step.one();
+        F::from_f64(1.0e-9) * scale
+    };
+
+    let mut transformed = Vec::with_capacity(samples.len().saturating_sub(1));
+    for pair in samples.windows(2) {
+        let left_log_x = pair[0].0.log10();
+        let right_log_x = pair[1].0.log10();
+        let step = &right_log_x - &left_log_x;
+        if (&step - &reference_step).abs() > tolerance {
+            return Err(eyre!(
+                "x grid must have constant multiplicative spacing for constant-dropped log-log fitting"
+            ));
+        }
+
+        let difference_magnitude = (&pair[1].1 - &pair[0].1).abs();
+        if !difference_magnitude.positive()
+            || difference_magnitude.is_nan()
+            || difference_magnitude.is_infinite()
+        {
+            return Err(eyre!(
+                "adjacent y differences must stay finite and non-zero after dropping the constant term"
+            ));
+        }
+
+        let log_difference = difference_magnitude.log10();
+        if log_difference.is_nan() || log_difference.is_infinite() {
+            return Err(eyre!(
+                "adjacent y differences must be positive in magnitude for the log transform"
+            ));
+        }
+
+        transformed.push((left_log_x, log_difference));
+    }
+
+    if transformed.len() < 2 {
+        return Err(eyre!(
+            "need at least 2 adjacent log-difference samples for linear regression"
+        ));
+    }
+
+    Ok(transformed)
+}
+
+fn linear_regression<T: FloatLike>(samples: &[(F<T>, F<T>)]) -> Result<SlopeFit<T>> {
+    let zero = samples[0].0.zero();
+    let one = zero.one();
+    let n = zero.from_usize(samples.len());
+
+    let mut sum_x = zero.clone();
+    let mut sum_y = zero.clone();
+    let mut sum_xy = zero.clone();
+    let mut sum_x2 = zero.clone();
+    for (x_value, y_value) in samples {
+        sum_x += x_value.clone();
+        sum_y += y_value.clone();
+        sum_xy += x_value * y_value;
+        sum_x2 += x_value * x_value;
+    }
+
+    let denominator = &(&n * &sum_x2) - &(&sum_x * &sum_x);
+    if denominator.abs().less_than_epsilon() {
+        return Err(eyre!(
+            "log-log regression is singular for the transformed difference samples"
+        ));
+    }
+
+    let slope = (&(&n * &sum_xy) - &(&sum_x * &sum_y)) / &denominator;
+    if slope.is_nan() || slope.is_infinite() {
+        return Err(eyre!("log-log regression produced a non-finite slope"));
+    }
+
+    let mean_y = &sum_y / &n;
+    let mut ss_tot = zero.clone();
+    let mut ss_res = zero;
+    let intercept = (&sum_y - &(&slope * &sum_x)) / &n;
+    for (x_value, y_value) in samples {
+        let prediction = &(&slope * x_value) + &intercept;
+        let centered = y_value - &mean_y;
+        let residual = y_value - &prediction;
+
+        ss_tot += &centered * &centered;
+        ss_res += &residual * &residual;
+    }
+
+    let r_squared = if ss_tot.less_than_epsilon() {
+        one
+    } else {
+        &one - &(&ss_res / &ss_tot)
+    };
+
+    if r_squared.is_nan() || r_squared.is_infinite() {
+        Err(eyre!("log-log regression produced a non-finite r-squared"))
+    } else {
+        Ok(SlopeFit {
+            slope,
+            r_suared: r_squared,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ff64_values(values: &[f64]) -> Vec<F<f64>> {
+        values.iter().copied().map(F::from_f64).collect()
+    }
+
+    #[test]
+    fn constant_dropped_fit_recovers_power_law_slope() {
+        let coefficient = 3.2_f64;
+        let slope = -1.75_f64;
+        let offset = 0.6_f64;
+        let ratio: f64 = 1.6;
+
+        let x = constant_dropped_fit_points(
+            &F::from_f64(0.2_f64),
+            &F::from_f64(0.2_f64 * ratio.powi(7)),
+            8,
+        )
+        .expect("fit point generation should succeed");
+        let x_values = x
+            .iter()
+            .map(|x_value| x_value.into_f64())
+            .collect::<Vec<_>>();
+        let y = x
+            .iter()
+            .map(|x_value| coefficient * x_value.into_f64().powf(slope) + offset)
+            .collect::<Vec<_>>();
+
+        let fit = log_log_slope_constant_dropped(&x, &ff64_values(&y))
+            .expect("power-law fit should succeed");
+
+        assert!((x_values[0] - 0.2_f64).abs() < 1.0e-12);
+        assert!((x_values[7] - 0.2_f64 * ratio.powi(7)).abs() < 1.0e-12);
+        assert!((fit.slope.into_f64() - slope).abs() < 1.0e-10);
+        assert!(fit.r_squared().into_f64() > 0.999_999_999);
+    }
+
+    #[test]
+    fn constant_dropped_fit_points_require_strict_positive_range() {
+        let points = constant_dropped_fit_points(
+            &F::<f64>::from_f64(1.0_f64),
+            &F::<f64>::from_f64(1.0_f64),
+            8,
+        );
+
+        assert!(points.is_err());
+    }
+
+    #[test]
+    fn constant_dropped_fit_rejects_non_geometric_grid() {
+        let coefficient = 3.2_f64;
+        let slope = -1.75_f64;
+        let offset = 0.6_f64;
+
+        let x = [
+            0.2_f64, 0.37_f64, 0.55_f64, 0.92_f64, 1.3_f64, 1.85_f64, 2.75_f64, 3.6_f64,
+        ];
+        let y = x
+            .iter()
+            .map(|x_value| coefficient * (*x_value).powf(slope) + offset)
+            .collect::<Vec<_>>();
+
+        let fit = log_log_slope_constant_dropped(&ff64_values(&x), &ff64_values(&y));
+
+        assert!(fit.is_err());
+    }
+}

--- a/crates/gammalooprs/src/utils/mod.rs
+++ b/crates/gammalooprs/src/utils/mod.rs
@@ -1993,6 +1993,10 @@ impl<T: FloatLike> F<T> {
         F(self.0.sqrt())
     }
 
+    pub(crate) fn powf(&self, e: &Self) -> Self {
+        F(self.0.powf(&e.0))
+    }
+
     pub(crate) fn log10(&self) -> Self {
         let ten = self.from_i64(10);
         self.ln() / ten.ln()

--- a/crates/gammalooprs/src/utils/mod.rs
+++ b/crates/gammalooprs/src/utils/mod.rs
@@ -77,6 +77,7 @@ use typed_index_collections::TiVec;
 use git_version::git_version;
 pub const GIT_VERSION: &str = git_version!(fallback = "unavailable");
 pub const VERSION: &str = "0.0.1";
+pub mod fitting;
 pub mod hyperdual_utils;
 pub mod representations;
 pub mod serde_utils;

--- a/tests/resources/graphs/massless_triangle.dot
+++ b/tests/resources/graphs/massless_triangle.dot
@@ -1,9 +1,9 @@
 digraph massless_triangle_0 {
 ext [style=invis]
-ext -> v4 [pdg=1000, name=p1, mom=p1];
-v5 -> ext [pdg=1000, name=p2, mom=p2];
-v6 -> ext [pdg=1000, name=p3, mom=p3];
-v4 -> v5 [pdg=1000, name=q1];
-v5 -> v6 [pdg=1000, name=q2, lmb_index=0];
-v6 -> v4 [pdg=1000, name=q3];
+ext -> v4 [pdg=1000];
+v5 -> ext [pdg=1000];
+v6 -> ext [pdg=1000];
+v4 -> v5 [pdg=1000];
+v5 -> v6 [pdg=1000];
+v6 -> v4 [pdg=1000];
 }

--- a/tests/resources/run_cards/generate_massless_triangle.toml
+++ b/tests/resources/run_cards/generate_massless_triangle.toml
@@ -1,0 +1,26 @@
+commands = [
+	"import model scalars",
+	"import graphs ./tests/resources/graphs/massless_triangle.dot",
+	"generate",
+	"profile bulk",
+	"quit -n",
+]
+[default_runtime_settings.kinematics]
+e_cm = 4.0
+
+[default_runtime_settings.kinematics.externals]
+type = "constant"
+
+[default_runtime_settings.kinematics.externals.data]
+momenta = [[4.0, 0.0, 0.0, 2.0], [4.0, 0.0, 0.0, -2.0], "dependent"]
+helicities = []
+
+[cli_settings.global.generation.threshold_subtraction]
+enable_thresholds = true
+
+[default_runtime_settings.subtraction]
+disable_threshold_subtraction = false
+
+[cli_settings.global.generation.tropical_subgraph_table]
+panic_on_fail = true
+disable_tropical_generation = true

--- a/tests/tests/test_runs.rs
+++ b/tests/tests/test_runs.rs
@@ -9,7 +9,7 @@ pub(crate) use gammaloop_api::{
         evaluate_samples::{EvaluateSamples, evaluate_sample},
         inspect::Inspect,
         integrate::Integrate,
-        profile::UltraVioletProfile,
+        profile::{InfraRedProfile, UltraVioletProfile},
     },
     state::{ProcessRef, SyncSettings},
 };
@@ -53,6 +53,8 @@ mod integrations;
 mod multi_integrand;
 #[path = "test_runs/photonic.rs"]
 mod photonic;
+#[path = "test_runs/profile_bulk.rs"]
+mod profile_bulk;
 #[path = "test_runs/smoke.rs"]
 mod smoke;
 #[path = "test_runs/spin_sums.rs"]

--- a/tests/tests/test_runs/profile_bulk.rs
+++ b/tests/tests/test_runs/profile_bulk.rs
@@ -1,0 +1,45 @@
+use super::*;
+use gammaloop_integration_tests::run_card;
+
+#[test]
+fn massless_triangle_bulk_profile_passes() -> Result<()> {
+    let state_path = get_tests_workspace_path().join("massless_triangle_bulk_profile");
+    let run_history = run_card("generate_massless_triangle.toml")?;
+    let setup_commands = run_history
+        .commands
+        .iter()
+        .map(|command| {
+            command
+                .raw_string
+                .as_deref()
+                .expect("run-card commands loaded from strings should retain raw strings")
+        })
+        .take_while(|command| *command != "profile bulk")
+        .collect_vec();
+
+    assert!(
+        run_history
+            .commands
+            .iter()
+            .any(|command| command.raw_string.as_deref() == Some("profile bulk")),
+        "expected tests/resources/run_cards/generate_massless_triangle.toml to contain the profile bulk command"
+    );
+    assert_eq!(setup_commands.last().copied(), Some("generate"));
+
+    let mut cli = get_test_cli(None, &state_path, None, true)?;
+    cli.cli_settings = run_history.cli_settings.clone();
+    cli.cli_settings.state.folder = state_path.clone();
+    cli.cli_settings.sync_settings()?;
+    cli.default_runtime_settings = run_history.default_runtime_settings.clone();
+
+    run_commands(&mut cli, &setup_commands)?;
+
+    let profile_result = Profile::InfraRed(InfraRedProfile::default())
+        .run(&mut cli.state, &cli.cli_settings)?
+        .unwrap_ir();
+
+    assert!(profile_result.all_passed, "{profile_result}");
+
+    clean_test(&cli.cli_settings.state.folder);
+    Ok(())
+}


### PR DESCRIPTION
- Change fitting code to no longer use complicated dependencies, fitting can now be done in arbitrary precision. 
- Add per cut fits for cross sections 
- Add threshold limits for amplitudes 
- Per threshold fits for amplitudes
- Rename profile infra-red to profile bulk  