### PR TITLE
Update example run cards

### DIFF
--- a/crates/gammaloop-api/src/lib.rs
+++ b/crates/gammaloop-api/src/lib.rs
@@ -953,10 +953,38 @@ impl OneShot {
         )
     }
 
-    /// Parse from env args *and* capture ArgMatches (explicit vs defaults).
-    pub fn parse_env_with_capture() -> Result<Parsed, clap::Error> {
+    fn is_inline_run_command_flag(arg: &OsString) -> bool {
+        let arg = arg.to_string_lossy();
+        arg == "-c" || arg == "--commands" || arg.starts_with("--commands=")
+    }
+
+    fn legacy_post_card_inline_run_argv(argv: &[OsString]) -> Option<Vec<OsString>> {
+        let inline_command_index = argv.iter().position(Self::is_inline_run_command_flag)?;
+        let prefix = &argv[..inline_command_index];
+        if prefix.len() < 2 {
+            return None;
+        }
+
+        let prefix_cli = OneShot::try_parse_from(prefix.to_vec()).ok()?;
+        if prefix_cli.boot_commands_path.is_none() || prefix_cli.command.is_some() {
+            return None;
+        }
+
+        let mut expanded = Vec::with_capacity(argv.len() + 1);
+        expanded.extend(prefix.iter().cloned());
+        expanded.push(OsString::from("run"));
+        expanded.extend(argv[inline_command_index..].iter().cloned());
+        Some(expanded)
+    }
+
+    fn parse_args_with_capture<I, T>(args: I) -> Result<Parsed, clap::Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString>,
+    {
         let argv: Vec<OsString> = command_parser::normalize_clap_args(
-            std::env::args_os()
+            args.into_iter()
+                .map(Into::into)
                 .map(|arg| arg.to_string_lossy().into_owned())
                 .collect(),
         )
@@ -966,7 +994,18 @@ impl OneShot {
 
         // Build a Command (same as derive(Parser)) and get matches
         let mut cmd = <OneShot as CommandFactory>::command();
-        let matches = cmd.clone().try_get_matches_from(&argv)?;
+        let (matches, argv) = match cmd.clone().try_get_matches_from(&argv) {
+            Ok(matches) => (matches, argv),
+            Err(err) => {
+                let Some(expanded_argv) = Self::legacy_post_card_inline_run_argv(&argv) else {
+                    return Err(err);
+                };
+                match cmd.clone().try_get_matches_from(&expanded_argv) {
+                    Ok(matches) => (matches, expanded_argv),
+                    Err(_) => return Err(err),
+                }
+            }
+        };
 
         let cli = <OneShot as FromArgMatches>::from_arg_matches(&matches)
             .map_err(|e| e.format(&mut cmd))?;
@@ -980,6 +1019,11 @@ impl OneShot {
             matches,
             cli,
         })
+    }
+
+    /// Parse from env args *and* capture ArgMatches (explicit vs defaults).
+    pub fn parse_env_with_capture() -> Result<Parsed, clap::Error> {
+        Self::parse_args_with_capture(std::env::args_os())
     }
 
     fn resolve_initial_state_folder(
@@ -1942,6 +1986,21 @@ mod tests {
         assert_eq!(parsed.boot_commands_path, Some(PathBuf::from("card.toml")));
         assert_eq!(parsed.state_folder, PathBuf::from("./GL_OUTPUT/triangle"));
         assert!(matches!(parsed.command, Some(Commands::Run(_))));
+    }
+
+    #[test]
+    fn oneshot_allows_post_card_inline_run_command_shortcut() {
+        let parsed =
+            OneShot::parse_args_with_capture(["gammaloop", "card.toml", "-c", "quit -n"]).unwrap();
+
+        assert_eq!(
+            parsed.cli.boot_commands_path,
+            Some(PathBuf::from("card.toml"))
+        );
+        let Some(Commands::Run(run)) = parsed.cli.command else {
+            panic!("expected run command");
+        };
+        assert_eq!(run.commands.as_deref(), Some("quit -n"));
     }
 
     #[test]

--- a/crates/gammalooprs/src/cff/generation.rs
+++ b/crates/gammalooprs/src/cff/generation.rs
@@ -314,18 +314,14 @@ impl Graph {
             let mut orientation_iterator = orientation.into_iter();
 
             let global_orientation = self.new_edgevec(|_, edge_id, hedge_pair| {
-                if hedge_pair.is_unpaired() {
+                if hedge_pair.is_unpaired() || contract_edges.contains(&edge_id) {
                     Orientation::Undirected
+                } else if edges_in_initial_state_cut.contains(&edge_id) {
+                    Orientation::Default
                 } else {
-                    if contract_edges.contains(&edge_id) {
-                        Orientation::Undirected
-                    } else if edges_in_initial_state_cut.contains(&edge_id) {
-                        Orientation::Default
-                    } else {
-                        orientation_iterator
-                            .next()
-                            .expect("orientation generation corrupted, not enough edges")
-                    }
+                    orientation_iterator
+                        .next()
+                        .expect("orientation generation corrupted, not enough edges")
                 }
             });
 

--- a/examples/api/python/epem_a_ddxg_xs_LO/run.toml
+++ b/examples/api/python/epem_a_ddxg_xs_LO/run.toml
@@ -17,6 +17,10 @@
 # - reusable display examples for quantities, observables, and selectors
 # - a local state under ./state
 
+commands = []
+
+[[command_blocks]]
+name = "default"
 commands = [
   "import model sm-default",
   "run generate",

--- a/examples/api/rust/epem_a_ddxg_xs_LO/run.toml
+++ b/examples/api/rust/epem_a_ddxg_xs_LO/run.toml
@@ -17,6 +17,10 @@
 # - reusable display examples for quantities, observables, and selectors
 # - a local state under ./state
 
+commands = []
+
+[[command_blocks]]
+name = "default"
 commands = [
   "import model sm-default",
   "run generate",

--- a/examples/cli/aa_aa/1L/aa_aa.toml
+++ b/examples/cli/aa_aa/1L/aa_aa.toml
@@ -1,6 +1,6 @@
 [cli_settings]
 [cli_settings.state]
-folder = "./examples/cli/aa_aa/1L/state"
+folder = "./examples/cli/aa_aa/1L/gammaloop_state"
 
 [[command_blocks]]
 name = "generate"

--- a/examples/cli/aa_aa/2L/aa_aa.toml
+++ b/examples/cli/aa_aa/2L/aa_aa.toml
@@ -1,7 +1,7 @@
 [cli_settings]
 [cli_settings.state]
 name = "aa_aa_2L"
-folder = "./examples/cli/aa_aa/2L/state"
+folder = "./examples/cli/aa_aa/2L/gammaloop_state"
 
 [[command_blocks]]
 name = "generate_diagrams"

--- a/examples/cli/epem_a_ttxh/NLO/epem_a_tth_NLO.toml
+++ b/examples/cli/epem_a_ttxh/NLO/epem_a_tth_NLO.toml
@@ -1,6 +1,6 @@
 [cli_settings]
 [cli_settings.state]
-folder = "./examples/cli/epem_a_ttxh/NLO/state"
+folder = "./examples/cli/epem_a_ttxh/NLO/gammaloop_state"
 
 #[cli_settings.global]
 #logfile_directive = "info,gammalooprs[kernel]=debug,gammalooprs[orientation_parametric_exprs]=debug,symbolica=off"  # ,gammalooprs[kernel]=debug,gammalooprs[final_integrand]=debug,symbolica=off,gammalooprs[local_3d]=debug"  # ,gammalooprs[build_original_parametric_integrand]=debug"

--- a/examples/cli/gg_hhh/2L/gg_hhh_2L.toml
+++ b/examples/cli/gg_hhh/2L/gg_hhh_2L.toml
@@ -1,3 +1,7 @@
+commands = []
+
+[[command_blocks]]
+name = "default"
 commands = [
   "run generate",
   "quit -o"

--- a/examples/cli/gg_hhh/3L/gg_hhh_3L.toml
+++ b/examples/cli/gg_hhh/3L/gg_hhh_3L.toml
@@ -1,3 +1,7 @@
+commands = []
+
+[[command_blocks]]
+name = "default"
 commands = [
   "run generate",
   "quit -o"

--- a/examples/cli/scalar_topologies/bubble.toml
+++ b/examples/cli/scalar_topologies/bubble.toml
@@ -2,7 +2,7 @@ commands = []
 
 [cli_settings]
 [cli_settings.state]
-folder = "./examples/cli/scalar_topologies/bubble_state"
+folder = "./examples/cli/scalar_topologies/gammaloop_state/bubble"
 name = "bubble_state"
 
 [[command_blocks]]

--- a/examples/cli/scalar_topologies/bubble_dod1.dot
+++ b/examples/cli/scalar_topologies/bubble_dod1.dot
@@ -1,0 +1,15 @@
+digraph GL0{
+    num = "1";
+    overall_factor = "(AutG(2))^(-1)*ExternalFermionOrderingSign(1)";
+    overall_factor_evaluated = "1/2";
+    projector = "1";
+
+	0 [dod="0" int_id="V_3_SCALAR_122" num="UFO::SCALAR_COUPLING"];
+	1 [dod="0" int_id="V_3_SCALAR_122" num="UFO::SCALAR_COUPLING"];
+	exte0	 [style=invis];
+	exte0	-> 1:0	 [id=0 dir=none sink=0  dod="-2" is_dummy="false" lmb_rep="P(0,a___)" name="e0" num="1𝑖" particle="scalar_1" pin="x:@-left"];
+	exte1	 [style=invis];
+	0:1	-> exte1	 [id=1 dir=none source=0  dod="-2" is_dummy="false" lmb_rep="P(0,a___)" name="e1" num="1𝑖" particle="scalar_1" pin="x:@+right"];
+	0:2	-> 1:3	 [id=2 dir=none source=1 sink=1  dod="-1" is_dummy="false" lmb_id="0" lmb_rep="K(0,a___)" name="e2" num="1𝑖*Q(0,spenso::mink(4,edge(2,1)))*Q(2,spenso::mink(4,edge(2,1)))" particle="scalar_2"];
+	0:4	-> 1:5	 [id=3 dir=none source=2 sink=2  dod="-2" is_dummy="false" lmb_rep="-1*K(0,a___)+-1*P(0,a___)" name="e3" num="-1𝑖" particle="scalar_2"];
+}

--- a/examples/cli/scalar_topologies/bubble_dod1.toml
+++ b/examples/cli/scalar_topologies/bubble_dod1.toml
@@ -13,14 +13,14 @@ commands = [
 
     "remove processes",
 	"set global kv global.generation.uv.generate_integrated=true",
-	"import graphs ./bubble_dod1.dot -p bubble_dod1 -i scalar_bubble_below_thres",
+	"import graphs ./examples/cli/scalar_topologies/bubble_dod1.dot -p bubble_dod1 -i scalar_bubble_below_thres",
 	#"import graphs ./tests/resources/graphs/scalar/dod1_bubble.dot -p bubble_dod1 -i scalar_bubble_below_thres",
 	"generate existing -p bubble_dod1 -i scalar_bubble_below_thres",
     "duplicate integrand -p bubble_dod1 -i scalar_bubble_below_thres --output_process_name bubble_dod1 --output_integrand_name scalar_bubble_above_thres",
     "save dot",
 
     "set global kv global.generation.uv.generate_integrated=false",
-    "import graphs ./bubble_dod1.dot -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres",
+    "import graphs ./examples/cli/scalar_topologies/bubble_dod1.dot -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres",
     #"import graphs ./tests/resources/graphs/scalar/dod1_bubble.dot -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres",
     "generate existing -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres",
     "duplicate integrand -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres --output_process_name bubble_dod1_no_integrated_UV --output_integrand_name scalar_bubble_above_thres",

--- a/examples/cli/scalar_topologies/bubble_dod1.toml
+++ b/examples/cli/scalar_topologies/bubble_dod1.toml
@@ -1,0 +1,184 @@
+commands = []
+
+[cli_settings]
+[cli_settings.state]
+folder = "./examples/cli/scalar_topologies/gammaloop_state/bubble_dod1"
+name = "bubble_dod1_state"
+
+[[command_blocks]]
+name = "generate"
+commands = [
+
+    "import model scalars-default.json",
+
+    "remove processes",
+	"set global kv global.generation.uv.generate_integrated=true",
+	"import graphs ./bubble_dod1.dot -p bubble_dod1 -i scalar_bubble_below_thres",
+	#"import graphs ./tests/resources/graphs/scalar/dod1_bubble.dot -p bubble_dod1 -i scalar_bubble_below_thres",
+	"generate existing -p bubble_dod1 -i scalar_bubble_below_thres",
+    "duplicate integrand -p bubble_dod1 -i scalar_bubble_below_thres --output_process_name bubble_dod1 --output_integrand_name scalar_bubble_above_thres",
+    "save dot",
+
+    "set global kv global.generation.uv.generate_integrated=false",
+    "import graphs ./bubble_dod1.dot -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres",
+    #"import graphs ./tests/resources/graphs/scalar/dod1_bubble.dot -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres",
+    "generate existing -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres",
+    "duplicate integrand -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres --output_process_name bubble_dod1_no_integrated_UV --output_integrand_name scalar_bubble_above_thres",
+
+	"save standalone --json",
+
+    "set model mass_scalar_2=2.0",
+
+	"set process kv general.mu_r=3.0 general.m_uv=20.0",
+
+    """set process -p bubble_dod1 -i scalar_bubble_below_thres string '
+[kinematics.externals]
+type = "constant"
+
+[kinematics.externals.data]
+momenta = [
+   	[1.0, 0.0, 0.0,  0.0],
+    "dependent"
+]
+helicities = [
+    0,
+	0,
+]
+    '""",
+
+    """set process -p bubble_dod1 -i scalar_bubble_above_thres string '
+[kinematics.externals]
+type = "constant"
+
+[kinematics.externals.data]
+momenta = [
+   	[10.0, 0.0, 0.0,  0.0],
+    "dependent"
+]
+helicities = [
+    0,
+	0,
+]
+    '""",
+
+    """set process -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres string '
+[kinematics.externals]
+type = "constant"
+
+[kinematics.externals.data]
+momenta = [
+   	[1.0, 0.0, 0.0,  0.0],
+    "dependent"
+]
+helicities = [
+    0,
+	0,
+]
+    '""",
+
+    """set process -p bubble_dod1_no_integrated_UV -i scalar_bubble_above_thres string '
+[kinematics.externals]
+type = "constant"
+
+[kinematics.externals.data]
+momenta = [
+   	[10.0, 0.0, 0.0,  0.0],
+    "dependent"
+]
+helicities = [
+    0,
+	0,
+]
+    '""",
+
+    "save state -o",
+
+]
+
+
+[[command_blocks]]
+name = "uv_profile"
+commands = [
+	"display integrand",
+]
+
+[[command_blocks]]
+name = "integrate_bubble_below_threshold"
+commands = [
+
+    """set process kv
+		integrator.target_relative_accuracy=0.00001
+		integrator.n_increase=0 integrator.n_start=1000000
+		integrator.n_max=200000000000
+		integrator.seed=1337
+	""",
+
+	"""integrate -p bubble_dod1_no_integrated_UV -i scalar_bubble_below_thres -p bubble_dod1 -i scalar_bubble_below_thres --n-cores 10
+	             --target bubble_dod1_no_integrated_UV@scalar_bubble_below_thres=7.358320108607984e-3,0.0 bubble_dod1@scalar_bubble_below_thres=1.3514937842276269e-3,0.0
+                 --restart
+    """,
+]
+
+[[command_blocks]]
+name = "integrate_bubble_above_threshold"
+commands = [
+
+    """set process kv
+		integrator.target_relative_accuracy=0.00001
+		integrator.n_increase=0 integrator.n_start=1000000
+		integrator.n_max=200000000000
+		integrator.seed=1337
+	""",
+
+	"""integrate -p bubble_dod1_no_integrated_UV -i scalar_bubble_above_thres -p bubble_dod1 -i scalar_bubble_above_thres --n-cores 1
+	             --target bubble_dod1_no_integrated_UV@scalar_bubble_above_thres=0.5910159226920848,0.4558372337156246 bubble_dod1@scalar_bubble_above_thres=-9.6667097459509e-3,0.4558372337156246
+                 --restart
+    """,
+]
+
+[cli_settings.global.log_style]
+include_fields = true
+
+[default_runtime_settings.sampling]
+graphs = "monte_carlo"
+orientations = "monte_carlo"
+lmb_multichanneling = false
+lmb_channels = "summed"
+coordinate_system = "spherical"
+mapping = "linear"
+b = 1.0
+
+[cli_settings.global.generation.evaluator]
+iterative_orientation_optimization = false
+store_atom = true
+compile = false
+summed = false
+summed_function_map = true
+
+[cli_settings.global.generation.threshold_subtraction]
+enable_thresholds = true
+check_esurface_at_generation = false
+
+[default_runtime_settings.subtraction]
+disable_threshold_subtraction = false
+
+[[default_runtime_settings.stability.rotation_axis]]
+type = "z"
+
+[[default_runtime_settings.stability.levels]]
+precision = "Double"
+required_precision_for_re = 0.0000000001
+required_precision_for_im = 0.0000000001
+escalate_for_large_weight_threshold = 0.9
+
+[[default_runtime_settings.stability.levels]]
+precision = "Quad"
+required_precision_for_re = 0.00001
+required_precision_for_im = 0.00001
+escalate_for_large_weight_threshold = -1.0
+
+[[default_runtime_settings.stability.levels]]
+precision = "Arb"
+required_precision_for_re = 0.00001
+required_precision_for_im = 0.00001
+escalate_for_large_weight_threshold = -1.0

--- a/examples/cli/scalar_topologies/bubble_dod2.dot
+++ b/examples/cli/scalar_topologies/bubble_dod2.dot
@@ -1,0 +1,16 @@
+digraph GL0{
+    num = "1";
+    overall_factor = "(AutG(2))^(-1)*ExternalFermionOrderingSign(1)";
+    overall_factor_evaluated = "1/2";
+    projector = "1";
+
+	0 [dod="0" int_id="V_3_SCALAR_122" num="UFO::SCALAR_COUPLING"];
+	1 [dod="0" int_id="V_3_SCALAR_122" num="UFO::SCALAR_COUPLING"];
+	exte0	 [style=invis];
+	exte0	-> 1:0	 [id=0 dir=none sink=0  dod="-2" is_dummy="false" lmb_rep="P(0,a___)" name="e0" num="1𝑖" particle="scalar_1" pin="x:@-left"];
+	exte1	 [style=invis];
+	0:1	-> exte1	 [id=1 dir=none source=0  dod="-2" is_dummy="false" lmb_rep="P(0,a___)" name="e1" num="1𝑖" particle="scalar_1" pin="x:@+right"];
+
+	0:2	-> 1:3	 [id=2 dir=none source=1 sink=1  dod="0" is_dummy="false" lmb_id="0" lmb_rep="K(0,a___)" name="e2" num="1𝑖 * Q(2,spenso::mink(4,edge(2,1))) * Q(0,spenso::mink(4,edge(2,1)))" particle="scalar_2"];
+	0:4	-> 1:5	 [id=3 dir=none source=2 sink=2  dod="0" is_dummy="false" lmb_rep="-1*K(0,a___)+-1*P(0,a___)" name="e3" num="-1𝑖 * ( Q(3,spenso::mink(4,edge(3,1))) + Q(0,spenso::mink(4,edge(3,1))) ) * Q(0,spenso::mink(4,edge(3,1)))" particle="scalar_2"];
+}

--- a/examples/cli/scalar_topologies/bubble_dod2.toml
+++ b/examples/cli/scalar_topologies/bubble_dod2.toml
@@ -1,0 +1,182 @@
+commands = []
+
+[cli_settings]
+[cli_settings.state]
+folder = "./examples/cli/scalar_topologies/gammaloop_state/bubble_dod2"
+name = "bubble_dod2_state"
+
+[[command_blocks]]
+name = "generate"
+commands = [
+
+    "import model scalars-default.json",
+
+    "remove processes",
+	"set global kv global.generation.uv.generate_integrated=true",
+	"import graphs ./bubble_dod2.dot -p bubble_dod2 -i scalar_bubble_below_thres",
+	"generate existing -p bubble_dod2 -i scalar_bubble_below_thres",
+    "duplicate integrand -p bubble_dod2 -i scalar_bubble_below_thres --output_process_name bubble_dod2 --output_integrand_name scalar_bubble_above_thres",
+    "save dot",
+
+    "set global kv global.generation.uv.generate_integrated=false",
+    "import graphs ./bubble_dod2.dot -p bubble_dod2_no_integrated_UV -i scalar_bubble_below_thres",
+    "generate existing -p bubble_dod2_no_integrated_UV -i scalar_bubble_below_thres",
+    "duplicate integrand -p bubble_dod2_no_integrated_UV -i scalar_bubble_below_thres --output_process_name bubble_dod2_no_integrated_UV --output_integrand_name scalar_bubble_above_thres",
+
+	"save standalone --json",
+
+    "set model mass_scalar_2=2.0",
+
+	"set process kv general.mu_r=3.0 general.m_uv=0.1",
+
+    """set process -p bubble_dod2 -i scalar_bubble_below_thres string '
+[kinematics.externals]
+type = "constant"
+
+[kinematics.externals.data]
+momenta = [
+   	[1.0, 0.0, 0.0,  0.0],
+    "dependent"
+]
+helicities = [
+    0,
+	0,
+]
+    '""",
+
+    """set process -p bubble_dod2 -i scalar_bubble_above_thres string '
+[kinematics.externals]
+type = "constant"
+
+[kinematics.externals.data]
+momenta = [
+   	[10.0, 0.0, 0.0,  0.0],
+    "dependent"
+]
+helicities = [
+    0,
+	0,
+]
+    '""",
+
+    """set process -p bubble_dod2_no_integrated_UV -i scalar_bubble_below_thres string '
+[kinematics.externals]
+type = "constant"
+
+[kinematics.externals.data]
+momenta = [
+   	[1.0, 0.0, 0.0,  0.0],
+    "dependent"
+]
+helicities = [
+    0,
+	0,
+]
+    '""",
+
+    """set process -p bubble_dod2_no_integrated_UV -i scalar_bubble_above_thres string '
+[kinematics.externals]
+type = "constant"
+
+[kinematics.externals.data]
+momenta = [
+   	[10.0, 0.0, 0.0,  0.0],
+    "dependent"
+]
+helicities = [
+    0,
+	0,
+]
+    '""",
+
+    "save state -o",
+
+]
+
+
+[[command_blocks]]
+name = "uv_profile"
+commands = [
+	"display integrand",
+]
+
+[[command_blocks]]
+name = "integrate_bubble_below_threshold"
+commands = [
+
+    """set process kv
+		integrator.target_relative_accuracy=0.00001
+		integrator.n_increase=0 integrator.n_start=1000000
+		integrator.n_max=200000000000
+		integrator.seed=1337
+	""",
+
+	"""integrate -p bubble_dod2_no_integrated_UV -i scalar_bubble_below_thres -p bubble_dod2 -i scalar_bubble_below_thres --n-cores 10
+	             --target bubble_dod2_no_integrated_UV@scalar_bubble_below_thres=-0.5940830828502411,0.0 bubble_dod2@scalar_bubble_below_thres=1.2143596454658382e-2,0.0
+                 --restart
+    """,
+]
+
+[[command_blocks]]
+name = "integrate_bubble_above_threshold"
+commands = [
+
+    """set process kv
+		integrator.target_relative_accuracy=0.00001
+		integrator.n_increase=0 integrator.n_start=1000000
+		integrator.n_max=200000000000
+		integrator.seed=1337
+	""",
+
+	"""integrate -p bubble_dod2_no_integrated_UV -i scalar_bubble_above_thres -p bubble_dod2 -i scalar_bubble_above_thres --n-cores 1
+	             --target bubble_dod2_no_integrated_UV@scalar_bubble_above_thres=-3.022542815585027e1,2.279186168578123e1 bubble_dod2@scalar_bubble_above_thres=6.6344946895691e-1,2.279186168578123e1
+                 --restart
+    """,
+]
+
+[cli_settings.global.log_style]
+include_fields = true
+
+[default_runtime_settings.sampling]
+graphs = "monte_carlo"
+orientations = "monte_carlo"
+lmb_multichanneling = false
+lmb_channels = "summed"
+coordinate_system = "spherical"
+mapping = "linear"
+b = 1.0
+
+[cli_settings.global.generation.evaluator]
+iterative_orientation_optimization = false
+store_atom = true
+compile = false
+summed = false
+summed_function_map = true
+
+[cli_settings.global.generation.threshold_subtraction]
+enable_thresholds = true
+check_esurface_at_generation = false
+
+[default_runtime_settings.subtraction]
+disable_threshold_subtraction = false
+
+[[default_runtime_settings.stability.rotation_axis]]
+type = "z"
+
+[[default_runtime_settings.stability.levels]]
+precision = "Double"
+required_precision_for_re = 0.0000000001
+required_precision_for_im = 0.0000000001
+escalate_for_large_weight_threshold = 0.9
+
+[[default_runtime_settings.stability.levels]]
+precision = "Quad"
+required_precision_for_re = 0.00001
+required_precision_for_im = 0.00001
+escalate_for_large_weight_threshold = -1.0
+
+[[default_runtime_settings.stability.levels]]
+precision = "Arb"
+required_precision_for_re = 0.00001
+required_precision_for_im = 0.00001
+escalate_for_large_weight_threshold = -1.0

--- a/examples/cli/scalar_topologies/bubble_dod2.toml
+++ b/examples/cli/scalar_topologies/bubble_dod2.toml
@@ -13,13 +13,13 @@ commands = [
 
     "remove processes",
 	"set global kv global.generation.uv.generate_integrated=true",
-	"import graphs ./bubble_dod2.dot -p bubble_dod2 -i scalar_bubble_below_thres",
+	"import graphs ./examples/cli/scalar_topologies/bubble_dod2.dot -p bubble_dod2 -i scalar_bubble_below_thres",
 	"generate existing -p bubble_dod2 -i scalar_bubble_below_thres",
     "duplicate integrand -p bubble_dod2 -i scalar_bubble_below_thres --output_process_name bubble_dod2 --output_integrand_name scalar_bubble_above_thres",
     "save dot",
 
     "set global kv global.generation.uv.generate_integrated=false",
-    "import graphs ./bubble_dod2.dot -p bubble_dod2_no_integrated_UV -i scalar_bubble_below_thres",
+    "import graphs ./examples/cli/scalar_topologies/bubble_dod2.dot -p bubble_dod2_no_integrated_UV -i scalar_bubble_below_thres",
     "generate existing -p bubble_dod2_no_integrated_UV -i scalar_bubble_below_thres",
     "duplicate integrand -p bubble_dod2_no_integrated_UV -i scalar_bubble_below_thres --output_process_name bubble_dod2_no_integrated_UV --output_integrand_name scalar_bubble_above_thres",
 

--- a/examples/cli/scalar_topologies/multi_scalar_integrands.toml
+++ b/examples/cli/scalar_topologies/multi_scalar_integrands.toml
@@ -1,3 +1,7 @@
+commands = []
+
+[[command_blocks]]
+name = "default"
 commands = [
   "run generate",
   #"run integrate_triangle_below_threshold",  

--- a/tests/tests/test_runs/examples.rs
+++ b/tests/tests/test_runs/examples.rs
@@ -1,4 +1,68 @@
 use super::*;
+use gammaloop_api::state::RunHistory;
+use gammaloop_integration_tests::workspace_root;
+use std::fs;
+
+fn is_generated_state_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.contains("state"))
+}
+
+fn is_ignored_old_card(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("OLD_"))
+}
+
+fn discover_toml_cards(root: &Path, cards: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            if !is_generated_state_dir(&path) {
+                discover_toml_cards(&path, cards)?;
+            }
+        } else if !is_ignored_old_card(&path)
+            && path.extension().and_then(|extension| extension.to_str()) == Some("toml")
+        {
+            cards.push(path);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn all_example_toml_cards_are_loadable() -> Result<()> {
+    let workspace_root = workspace_root();
+    let mut cards = Vec::new();
+    for examples_dir in ["examples/api", "examples/cli"] {
+        discover_toml_cards(&workspace_root.join(examples_dir), &mut cards)?;
+    }
+    cards.sort();
+    if cards.is_empty() {
+        return Err(eyre::eyre!("No example TOML cards were discovered"));
+    }
+
+    let failures = cards
+        .iter()
+        .filter_map(|card| {
+            RunHistory::load(card).err().map(|err| {
+                let display_path = card.strip_prefix(&workspace_root).unwrap_or(card);
+                format!("{}:\n{err:?}", display_path.display())
+            })
+        })
+        .collect_vec();
+
+    if !failures.is_empty() {
+        return Err(eyre::eyre!(
+            "Failed to load {} example TOML card(s):\n\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        ));
+    }
+    Ok(())
+}
 
 #[test]
 fn test_scalar_bubble_example_cli() -> Result<()> {
@@ -41,7 +105,7 @@ fn test_aa_aa_example_card() -> Result<()> {
     );
     assert_eq!(
         run_history.cli_settings.state.folder,
-        PathBuf::from("./examples/cli/aa_aa/1L/state")
+        PathBuf::from("./examples/cli/aa_aa/1L/gammaloop_state")
     );
     assert_eq!(run_history.default_runtime_settings.kinematics.e_cm, 300.0);
     Ok(())


### PR DESCRIPTION
## Summary
- update example TOML cards so they load cleanly with the current run-history schema
- add support for the parse-only `./gammaloop <card> -c "quit -n"` shortcut
- add a Rust integration test that dynamically discovers example TOML cards under `examples/api` and `examples/cli` and verifies they load via `RunHistory::load`

## Tests
- `just fmt`
- `cargo check --workspace`
- `cargo test -p gammaloop-integration-tests --test test_runs all_example_toml_cards_are_loadable`
- `cargo test -p gammaloop-integration-tests --test test_runs test_aa_aa_example_card`
- `just clippy`
- `just build-cli`
- all discovered cards pass `./gammaloop <path_to_card> -c "quit -n"`