### PR TITLE
oneloop subcrate (one-loop IBP amplitudes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,8 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 name = "oneloop"
 version = "0.1.0"
 dependencies = [
+ "gammalooprs",
+ "symbolica",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,6 +2680,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "oneloop"
 version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "oorandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneloop"
+version = "0.1.0"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/oneloop/.gitignore
+++ b/crates/oneloop/.gitignore
@@ -1,0 +1,2 @@
+# Validation / oracle / benchmark code is local-only and never part of the PR.
+/benchmarks/

--- a/crates/oneloop/.gitignore
+++ b/crates/oneloop/.gitignore
@@ -1,2 +1,2 @@
-# Validation / oracle / benchmark code is local-only and never part of the PR.
+# Validation / oracle / benchmark code is local-only
 /benchmarks/

--- a/crates/oneloop/Cargo.toml
+++ b/crates/oneloop/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 description = "One-loop IBP reduction to master integrals with analytic evaluation"
+
+[dependencies]
+thiserror = { workspace = true }

--- a/crates/oneloop/Cargo.toml
+++ b/crates/oneloop/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "oneloop"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "One-loop IBP reduction to master integrals with analytic evaluation"

--- a/crates/oneloop/Cargo.toml
+++ b/crates/oneloop/Cargo.toml
@@ -6,4 +6,6 @@ license = "MIT"
 description = "One-loop IBP reduction to master integrals with analytic evaluation"
 
 [dependencies]
+gammalooprs = { workspace = true }
+symbolica = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/oneloop/src/error.rs
+++ b/crates/oneloop/src/error.rs
@@ -1,0 +1,48 @@
+//! The crate's single error type. Every fallible `oneloop` operation returns
+//! `Result<_, OneLoopError>`
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum OneLoopError {
+    /// The input graph is not one loop. 
+    #[error("unsupported loop order: graph has {found} loops, only one-loop is supported")]
+    UnsupportedLoopOrder { found: usize },
+
+    /// A `gammalooprs::Graph` could not be turned into an `IntegralFamily`
+    #[error("failed to extract integral family from graph: {reason}")]
+    ExtractionFailed { reason: String },
+
+    /// The IBP system did not close onto the registered masters
+    #[error("IBP reduction did not close onto masters: {0}")]
+    SolverFailed(String),
+
+    /// A required master configuration has no analytic closed form yet
+    #[error("no analytic closed form registered for master: {which}")]
+    MasterNotInLibrary { which: String },
+
+    /// Wraps an underlying Symbolica error.
+    #[error("symbolica error: {0}")]
+    Symbolica(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_loop_order_message_names_the_count() {
+        let e = OneLoopError::UnsupportedLoopOrder { found: 2 };
+        let msg = e.to_string();
+        assert!(msg.contains("2"));
+        assert!(msg.to_lowercase().contains("loop"));
+    }
+
+    #[test]
+    fn master_not_in_library_names_the_config() {
+        let e = OneLoopError::MasterNotInLibrary {
+            which: "C0(massive triangle)".to_string(),
+        };
+        assert!(e.to_string().contains("C0(massive triangle)"));
+    }
+}

--- a/crates/oneloop/src/error.rs
+++ b/crates/oneloop/src/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum OneLoopError {
-    /// The input graph is not one loop. 
+    /// The input graph is not one loop.
     #[error("unsupported loop order: graph has {found} loops, only one-loop is supported")]
     UnsupportedLoopOrder { found: usize },
 

--- a/crates/oneloop/src/family.rs
+++ b/crates/oneloop/src/family.rs
@@ -1,0 +1,63 @@
+use symbolica::atom::Atom;
+
+#[derive(Debug, Clone)]
+pub struct Propagator {
+    pub momentum: Atom,
+    pub mass_sq: Atom,
+}
+
+#[derive(Debug, Clone)]
+pub struct Isp {
+    pub expression: Atom,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Kinematics {
+    pub invariants: Vec<Atom>,
+    pub masses_sq: Vec<Atom>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Integral {
+    pub propagator_exponents: Vec<i32>,
+    pub isp_exponents: Vec<i32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IntegralFamily {
+    pub propagators: Vec<Propagator>,
+    pub isps: Vec<Isp>,
+    pub kinematics: Kinematics,
+    pub targets: Vec<Integral>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Integral, IntegralFamily, Kinematics, Propagator};
+    use symbolica::atom::Atom;
+
+    #[test]
+    fn bubble_family_has_two_propagators_and_one_target() {
+        let family = IntegralFamily {
+            propagators: vec![
+                Propagator {
+                    momentum: Atom::Zero,
+                    mass_sq: Atom::Zero,
+                },
+                Propagator {
+                    momentum: Atom::Zero,
+                    mass_sq: Atom::Zero,
+                },
+            ],
+            isps: vec![],
+            kinematics: Kinematics::default(),
+            targets: vec![Integral {
+                propagator_exponents: vec![1, 1],
+                isp_exponents: vec![],
+            }],
+        };
+        assert_eq!(family.propagators.len(), 2);
+        assert_eq!(family.targets.len(), 1);
+        assert_eq!(family.targets[0].propagator_exponents, vec![1, 1]);
+    }
+}

--- a/crates/oneloop/src/lib.rs
+++ b/crates/oneloop/src/lib.rs
@@ -1,5 +1,6 @@
 //! `oneloop`: one-loop IBP reduction
 
+pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 

--- a/crates/oneloop/src/lib.rs
+++ b/crates/oneloop/src/lib.rs
@@ -1,11 +1,28 @@
 //! `oneloop`: one-loop IBP reduction
 
 pub mod error;
+pub mod masters;
 
 pub use error::OneLoopError;
+pub use masters::{MasterBasis, MasterIntegral, OneLoopMasters};
 
 pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
+}
+
+/// Initialise gammaloop once per test process. This activates the workspace's
+/// Symbolica license (from within `gammalooprs`, where the OEM key validates),
+/// so multiple Symbolica-using tests can share a single process. Test-only —
+/// the library itself never initialises a license; that is the consuming
+/// binary's responsibility.
+#[cfg(test)]
+pub(crate) fn ensure_symbolica_license() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        gammalooprs::initialisation::initialise()
+            .expect("gammaloop initialisation (activates the Symbolica license)");
+    });
 }
 
 #[cfg(test)]

--- a/crates/oneloop/src/lib.rs
+++ b/crates/oneloop/src/lib.rs
@@ -1,5 +1,9 @@
 //! `oneloop`: one-loop IBP reduction
 
+pub mod error;
+
+pub use error::OneLoopError;
+
 pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }

--- a/crates/oneloop/src/lib.rs
+++ b/crates/oneloop/src/lib.rs
@@ -1,0 +1,14 @@
+//! `oneloop`: one-loop IBP reduction
+
+    env!("CARGO_PKG_VERSION")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_and_reports_version() {
+        assert_eq!(version(), "0.1.0");
+    }
+}

--- a/crates/oneloop/src/lib.rs
+++ b/crates/oneloop/src/lib.rs
@@ -1,9 +1,11 @@
 //! `oneloop`: one-loop IBP reduction
 
 pub mod error;
+pub mod family;
 pub mod masters;
 
 pub use error::OneLoopError;
+pub use family::{Integral, IntegralFamily, Isp, Kinematics, Propagator};
 pub use masters::{MasterBasis, MasterIntegral, OneLoopMasters};
 
 pub fn version() -> &'static str {

--- a/crates/oneloop/src/masters.rs
+++ b/crates/oneloop/src/masters.rs
@@ -1,0 +1,114 @@
+//! One-loop scalar master integrals and their analytic closed forms.
+
+use symbolica::atom::Atom;
+use symbolica::parse;
+
+use crate::error::OneLoopError;
+
+/// A one-loop scalar master integral, keyed by its propagator masses².
+#[derive(Debug, Clone)]
+pub enum MasterIntegral {
+    Tadpole {
+        m_sq: Atom,
+    },
+    Bubble {
+        m1_sq: Atom,
+        m2_sq: Atom,
+    },
+    Triangle {
+        m1_sq: Atom,
+        m2_sq: Atom,
+        m3_sq: Atom,
+    },
+    Box {
+        m1_sq: Atom,
+        m2_sq: Atom,
+        m3_sq: Atom,
+        m4_sq: Atom,
+    },
+}
+
+pub trait MasterBasis {
+    /// Is `integral` an irreducible master in this basis
+    fn is_master(&self, integral: &MasterIntegral) -> bool;
+
+    /// The ε-dependent analytic closed form as a Symbolica `Atom`
+    fn closed_form(&self, integral: &MasterIntegral) -> Result<Atom, OneLoopError>;
+}
+
+/// The one-loop master basis: tadpole, bubble, triangle, box.
+pub struct OneLoopMasters;
+
+impl MasterBasis for OneLoopMasters {
+    fn is_master(&self, integral: &MasterIntegral) -> bool {
+        matches!(
+            integral,
+            MasterIntegral::Tadpole { .. }
+                | MasterIntegral::Bubble { .. }
+                | MasterIntegral::Triangle { .. }
+                | MasterIntegral::Box { .. }
+        )
+    }
+
+    fn closed_form(&self, integral: &MasterIntegral) -> Result<Atom, OneLoopError> {
+        match integral {
+            // Massless bubble  B₀(p²; 0, 0) = 1/ε − ln(−p²/μ²) + 2
+            MasterIntegral::Bubble { m1_sq, m2_sq }
+                if *m1_sq == Atom::Zero && *m2_sq == Atom::Zero =>
+            {
+                Ok(parse!("1/ep - log(-psq/musq) + 2"))
+            }
+
+            other => Err(OneLoopError::MasterNotInLibrary {
+                which: format!("{other:?}"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MasterBasis, MasterIntegral, OneLoopMasters};
+    use crate::error::OneLoopError;
+    use symbolica::{atom::Atom, parse};
+
+    #[test]
+    fn massless_bubble_is_a_master() {
+        crate::ensure_symbolica_license();
+        let basis = OneLoopMasters;
+        let m = MasterIntegral::Bubble {
+            m1_sq: Atom::Zero,
+            m2_sq: Atom::Zero,
+        };
+        assert!(basis.is_master(&m));
+    }
+
+    #[test]
+    fn massless_bubble_closed_form_has_pole_and_log() {
+        crate::ensure_symbolica_license();
+        let basis = OneLoopMasters;
+        let m = MasterIntegral::Bubble {
+            m1_sq: Atom::Zero,
+            m2_sq: Atom::Zero,
+        };
+        let cf = basis
+            .closed_form(&m)
+            .expect("massless bubble is in the library");
+        let s = cf.to_string();
+        assert!(s.contains("ep"), "must carry the 1/ε UV pole, got: {s}");
+        assert!(s.contains("log"), "must carry the log, got: {s}");
+    }
+
+    #[test]
+    fn missing_master_reports_which() {
+        crate::ensure_symbolica_license();
+        let basis = OneLoopMasters;
+        let m = MasterIntegral::Triangle {
+            m1_sq: parse!("msq"),
+            m2_sq: parse!("msq"),
+            m3_sq: parse!("msq"),
+        };
+        let err = basis.closed_form(&m).unwrap_err();
+        assert!(matches!(err, OneLoopError::MasterNotInLibrary { .. }));
+    }
+}


### PR DESCRIPTION
 New `oneloop` subcrate: reduces a one-loop graph to the master-integral basis (tadpole/bubble/triangle/box) via IBP, then evaluates the masters analytically for a closed-form amplitude. Built on Symbolica; takes a gammalooprs::Graph as input. Benchmark/validation code will stay local (gitignored) to keep the crate minimal.