### PR TITLE
Add configurable symbolic parallelism

### DIFF
--- a/crates/spenso/src/network/mod.rs
+++ b/crates/spenso/src/network/mod.rs
@@ -355,23 +355,30 @@ where
             );
         }
 
-        let merged = entries
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_par_iter()
-            .filter_map(|(index, atoms)| {
-                let atom = match atoms.len() {
-                    0 => Atom::Zero,
-                    1 => atoms
-                        .into_iter()
-                        .next()
-                        .expect("single atom exists")
-                        .to_owned(),
-                    _ => Atom::add_many(&atoms),
-                };
-                (!atom.as_view().is_zero()).then_some((index, atom))
-            })
-            .collect::<Vec<_>>();
+        let entries = entries.into_iter().collect::<Vec<_>>();
+        let merge_entry = |(index, atoms): (FlatIndex, Vec<AtomView<'_>>)| {
+            let atom = match atoms.len() {
+                0 => Atom::Zero,
+                1 => atoms
+                    .into_iter()
+                    .next()
+                    .expect("single atom exists")
+                    .to_owned(),
+                _ => Atom::add_many(&atoms),
+            };
+            (!atom.as_view().is_zero()).then_some((index, atom))
+        };
+        let merged = if crate::symbolic_parallelism::symbolica_rayon_enabled() {
+            entries
+                .into_par_iter()
+                .filter_map(merge_entry)
+                .collect::<Vec<_>>()
+        } else {
+            entries
+                .into_iter()
+                .filter_map(merge_entry)
+                .collect::<Vec<_>>()
+        };
 
         let mut elements = HashMap::with_capacity(merged.len());
         for (index, atom) in merged {
@@ -903,10 +910,18 @@ where
                 .map(|term| FastTensorSumContract::ScaledTerms(vec![term]))
         } else if terms.len() >= MIN_LAZY_FUSED_NUMERIC_CONTRACT_TERMS {
             let start = profile::enabled().then(std::time::Instant::now);
-            let contracted_terms = terms
-                .par_iter()
-                .map(|term| plan.contract_term(term))
-                .collect::<Result<Vec<_>, _>>()?;
+            let contract_term = |term: &&ParamTensor<_>| plan.contract_term(term);
+            let contracted_terms = if crate::symbolic_parallelism::symbolica_rayon_enabled() {
+                terms
+                    .par_iter()
+                    .map(contract_term)
+                    .collect::<Result<Vec<_>, _>>()?
+            } else {
+                terms
+                    .iter()
+                    .map(contract_term)
+                    .collect::<Result<Vec<_>, _>>()?
+            };
             if let Some(start) = start {
                 let output_entries = contracted_terms
                     .iter()
@@ -1199,30 +1214,40 @@ where
         &self,
         groups: HashMap<(FlatIndex, usize, bool), Vec<AtomView<'_>>>,
     ) -> Result<ParamTensor<S>, ContractionError> {
-        let contributions = groups
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_par_iter()
-            .filter_map(|((flat_index, coefficient_class, left_negative), atoms)| {
-                let mut contribution = match atoms.len() {
-                    0 => Atom::Zero,
-                    1 => atoms
-                        .into_iter()
-                        .next()
-                        .expect("single grouped atom exists")
-                        .to_owned(),
-                    _ => Atom::add_many(&atoms),
-                };
-                if left_negative {
-                    contribution = -contribution;
-                }
-                contribution = multiply_atom_by_numeric_coefficient(
-                    contribution,
-                    &self.coefficient_classes[coefficient_class],
-                );
-                (!contribution.as_view().is_zero()).then_some((flat_index, contribution))
-            })
-            .collect::<Vec<_>>();
+        let groups = groups.into_iter().collect::<Vec<_>>();
+        let finish_group = |((flat_index, coefficient_class, left_negative), atoms): (
+            (FlatIndex, usize, bool),
+            Vec<AtomView<'_>>,
+        )| {
+            let mut contribution = match atoms.len() {
+                0 => Atom::Zero,
+                1 => atoms
+                    .into_iter()
+                    .next()
+                    .expect("single grouped atom exists")
+                    .to_owned(),
+                _ => Atom::add_many(&atoms),
+            };
+            if left_negative {
+                contribution = -contribution;
+            }
+            contribution = multiply_atom_by_numeric_coefficient(
+                contribution,
+                &self.coefficient_classes[coefficient_class],
+            );
+            (!contribution.as_view().is_zero()).then_some((flat_index, contribution))
+        };
+        let contributions = if crate::symbolic_parallelism::symbolica_rayon_enabled() {
+            groups
+                .into_par_iter()
+                .filter_map(finish_group)
+                .collect::<Vec<_>>()
+        } else {
+            groups
+                .into_iter()
+                .filter_map(finish_group)
+                .collect::<Vec<_>>()
+        };
 
         Ok(ParamTensor::composite(DataTensor::Sparse(SparseTensor {
             elements: self.collect_output_groups(contributions),
@@ -1235,29 +1260,39 @@ where
         &self,
         groups: HashMap<(FlatIndex, usize, bool), Vec<Atom>>,
     ) -> Result<ParamTensor<S>, ContractionError> {
-        let contributions = groups
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_par_iter()
-            .filter_map(|((flat_index, coefficient_class, left_negative), atoms)| {
-                let mut contribution = match atoms.len() {
-                    0 => Atom::Zero,
-                    1 => atoms
-                        .into_iter()
-                        .next()
-                        .expect("single grouped atom exists"),
-                    _ => Atom::add_many(&atoms),
-                };
-                if left_negative {
-                    contribution = -contribution;
-                }
-                contribution = multiply_atom_by_numeric_coefficient(
-                    contribution,
-                    &self.coefficient_classes[coefficient_class],
-                );
-                (!contribution.as_view().is_zero()).then_some((flat_index, contribution))
-            })
-            .collect::<Vec<_>>();
+        let groups = groups.into_iter().collect::<Vec<_>>();
+        let finish_group = |((flat_index, coefficient_class, left_negative), atoms): (
+            (FlatIndex, usize, bool),
+            Vec<Atom>,
+        )| {
+            let mut contribution = match atoms.len() {
+                0 => Atom::Zero,
+                1 => atoms
+                    .into_iter()
+                    .next()
+                    .expect("single grouped atom exists"),
+                _ => Atom::add_many(&atoms),
+            };
+            if left_negative {
+                contribution = -contribution;
+            }
+            contribution = multiply_atom_by_numeric_coefficient(
+                contribution,
+                &self.coefficient_classes[coefficient_class],
+            );
+            (!contribution.as_view().is_zero()).then_some((flat_index, contribution))
+        };
+        let contributions = if crate::symbolic_parallelism::symbolica_rayon_enabled() {
+            groups
+                .into_par_iter()
+                .filter_map(finish_group)
+                .collect::<Vec<_>>()
+        } else {
+            groups
+                .into_iter()
+                .filter_map(finish_group)
+                .collect::<Vec<_>>()
+        };
 
         Ok(ParamTensor::composite(DataTensor::Sparse(SparseTensor {
             elements: self.collect_output_groups(contributions),
@@ -1278,19 +1313,26 @@ where
                 .push(contribution);
         }
 
-        output_groups
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_par_iter()
-            .filter_map(|(flat_index, atoms)| {
-                let atom = match atoms.len() {
-                    0 => Atom::Zero,
-                    1 => atoms.into_iter().next().expect("single output atom exists"),
-                    _ => Atom::add_many(&atoms),
-                };
-                (!atom.as_view().is_zero()).then_some((flat_index, atom))
-            })
-            .collect::<HashMap<_, _>>()
+        let output_groups = output_groups.into_iter().collect::<Vec<_>>();
+        let finish_group = |(flat_index, atoms): (FlatIndex, Vec<Atom>)| {
+            let atom = match atoms.len() {
+                0 => Atom::Zero,
+                1 => atoms.into_iter().next().expect("single output atom exists"),
+                _ => Atom::add_many(&atoms),
+            };
+            (!atom.as_view().is_zero()).then_some((flat_index, atom))
+        };
+        if crate::symbolic_parallelism::symbolica_rayon_enabled() {
+            output_groups
+                .into_par_iter()
+                .filter_map(finish_group)
+                .collect::<HashMap<_, _>>()
+        } else {
+            output_groups
+                .into_iter()
+                .filter_map(finish_group)
+                .collect::<HashMap<_, _>>()
+        }
     }
 }
 
@@ -4052,6 +4094,18 @@ impl Parallel {
         FK: Clone + Debug + Display + Send + Sync,
         Aind: AbsInd + Send + Sync,
     {
+        #[cfg(feature = "shadowing")]
+        if !crate::symbolic_parallelism::symbolica_rayon_enabled() {
+            return <Sequential as ExecutionStrategy<
+                NetworkStore<T, Sc>,
+                FL,
+                L,
+                K,
+                FK,
+                Aind,
+            >>::execute_all::<C>(executor, graph, lib, fnlib);
+        }
+
         if <C as ContractionStrategy<NetworkStore<T, Sc>, L, K, FK, Aind>>::SUPPORTS_PARTIAL_GRAPH_REWRITE
         {
             return <Sequential as ExecutionStrategy<

--- a/crates/spenso/src/network/tests.rs
+++ b/crates/spenso/src/network/tests.rs
@@ -52,8 +52,7 @@ fn auto_serializes_unlicensed_symbolic_fast_tensor_sum() {
             representation::{Euclidean, RepName},
         },
         symbolic_parallelism::{
-            SymbolicParallelism, set_symbolica_rayon_enabled, set_symbolica_rayon_enabled_for_test,
-            symbolica_rayon_enabled,
+            SymbolicParallelism, scoped_symbolica_rayon_setting_for_test, symbolica_rayon_enabled,
         },
         tensors::{
             data::{DataTensor, SparseTensor},
@@ -64,7 +63,7 @@ fn auto_serializes_unlicensed_symbolic_fast_tensor_sum() {
     // The repository's Symbolica build may itself be licensed. Injecting the
     // unlicensed result makes this failure mode deterministic while exercising
     // the exact same Auto resolution and cached global used in production.
-    set_symbolica_rayon_enabled_for_test(SymbolicParallelism::Auto, || false);
+    let _guard = scoped_symbolica_rayon_setting_for_test(SymbolicParallelism::Auto, || false);
     assert!(!symbolica_rayon_enabled());
 
     let structure: OrderedStructure<Euclidean> =
@@ -88,8 +87,6 @@ fn auto_serializes_unlicensed_symbolic_fast_tensor_sum() {
     };
     assert_eq!(result.elements[&FlatIndex::from(0)], parse!("a+x"));
     assert_eq!(result.elements[&FlatIndex::from(1)], parse!("b+y"));
-
-    set_symbolica_rayon_enabled(SymbolicParallelism::Parallel);
 }
 
 #[test]

--- a/crates/spenso/src/network/tests.rs
+++ b/crates/spenso/src/network/tests.rs
@@ -37,6 +37,61 @@ fn scalar_alias_refs_resolve_to_original_atom() {
     );
 }
 
+#[cfg(feature = "shadowing")]
+#[test]
+fn auto_serializes_unlicensed_symbolic_fast_tensor_sum() {
+    use std::collections::HashMap;
+
+    use symbolica::{atom::Atom, parse};
+
+    use crate::{
+        network::FastTensorSum,
+        structure::{
+            OrderedStructure,
+            concrete_index::FlatIndex,
+            representation::{Euclidean, RepName},
+        },
+        symbolic_parallelism::{
+            SymbolicParallelism, set_symbolica_rayon_enabled, set_symbolica_rayon_enabled_for_test,
+            symbolica_rayon_enabled,
+        },
+        tensors::{
+            data::{DataTensor, SparseTensor},
+            parametric::ParamTensor,
+        },
+    };
+
+    // The repository's Symbolica build may itself be licensed. Injecting the
+    // unlicensed result makes this failure mode deterministic while exercising
+    // the exact same Auto resolution and cached global used in production.
+    set_symbolica_rayon_enabled_for_test(SymbolicParallelism::Auto, || false);
+    assert!(!symbolica_rayon_enabled());
+
+    let structure: OrderedStructure<Euclidean> =
+        OrderedStructure::new(vec![Euclidean {}.new_slot(2, 1)]).structure;
+    let tensor = |first: Atom, second: Atom| {
+        ParamTensor::composite(DataTensor::Sparse(SparseTensor {
+            elements: HashMap::from([(FlatIndex::from(0), first), (FlatIndex::from(1), second)]),
+            zero: Atom::Zero,
+            structure: structure.clone(),
+        }))
+    };
+    let left = tensor(parse!("x"), parse!("y"));
+    let right = tensor(parse!("a"), parse!("b"));
+
+    // Each output entry contains two atoms, so this executes the guarded
+    // Atom::add_many path that previously always ran on a Rayon worker.
+    let result = <ParamTensor<_> as FastTensorSum>::fast_tensor_sum(&[&left, &right], None)
+        .expect("two compatible sparse tensors should use the fast symbolic sum");
+    let DataTensor::Sparse(result) = result.tensor else {
+        panic!("the fast sparse sum should remain sparse");
+    };
+    assert_eq!(result.elements[&FlatIndex::from(0)], parse!("a+x"));
+    assert_eq!(result.elements[&FlatIndex::from(1)], parse!("b+y"));
+
+    set_symbolica_rayon_enabled(SymbolicParallelism::Parallel);
+}
+
 #[test]
 fn executed_scaled_tensors_add_distinct_tensors() {
     use crate::{

--- a/crates/spenso/src/spenso.rs
+++ b/crates/spenso/src/spenso.rs
@@ -36,6 +36,8 @@ pub mod tensors;
 #[cfg(feature = "shadowing")]
 pub mod shadowing;
 #[cfg(feature = "shadowing")]
+pub mod symbolic_parallelism;
+#[cfg(feature = "shadowing")]
 pub mod symbolica_init;
 
 pub mod utils;

--- a/crates/spenso/src/symbolic_parallelism.rs
+++ b/crates/spenso/src/symbolic_parallelism.rs
@@ -1,0 +1,113 @@
+use std::sync::{
+    OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
+
+use symbolica::LicenseManager;
+
+/// Policy used to configure Rayon for operations that manipulate Symbolica atoms.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SymbolicParallelism {
+    /// Enable Rayon only when Symbolica is licensed at configuration time.
+    Auto,
+    /// Keep symbolic operations on the calling thread.
+    Serial,
+    /// Allow symbolic operations to use Rayon workers.
+    Parallel,
+}
+
+static SYMBOLICA_RAYON_ENABLED: OnceLock<AtomicBool> = OnceLock::new();
+
+fn cached_setting() -> &'static AtomicBool {
+    SYMBOLICA_RAYON_ENABLED.get_or_init(|| {
+        AtomicBool::new(SymbolicParallelism::Auto.resolve_with(LicenseManager::is_licensed))
+    })
+}
+
+impl SymbolicParallelism {
+    fn resolve_with(self, is_licensed: impl FnOnce() -> bool) -> bool {
+        match self {
+            Self::Auto => is_licensed(),
+            Self::Serial => false,
+            Self::Parallel => true,
+        }
+    }
+}
+
+/// Configure whether operations involving Symbolica atoms may use Rayon.
+///
+/// [`SymbolicParallelism::Auto`] queries the Symbolica license exactly once,
+/// when this function is called. Later operations only read the cached boolean.
+/// Configure this before starting tensor operations; changing it concurrently
+/// with an active operation is not supported.
+pub fn set_symbolica_rayon_enabled(policy: SymbolicParallelism) {
+    set_symbolica_rayon_enabled_with(policy, LicenseManager::is_licensed);
+}
+
+fn set_symbolica_rayon_enabled_with(
+    policy: SymbolicParallelism,
+    is_licensed: impl FnOnce() -> bool,
+) {
+    let enabled = policy.resolve_with(is_licensed);
+    SYMBOLICA_RAYON_ENABLED
+        .get_or_init(|| AtomicBool::new(enabled))
+        .store(enabled, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+pub(crate) fn set_symbolica_rayon_enabled_for_test(
+    policy: SymbolicParallelism,
+    is_licensed: impl FnOnce() -> bool,
+) {
+    set_symbolica_rayon_enabled_with(policy, is_licensed);
+}
+
+/// Return the resolved symbolic Rayon setting without querying the license.
+pub fn symbolica_rayon_enabled() -> bool {
+    cached_setting().load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn auto_checks_the_license_once_when_resolved() {
+        let calls = Cell::new(0);
+        let enabled = SymbolicParallelism::Auto.resolve_with(|| {
+            calls.set(calls.get() + 1);
+            false
+        });
+
+        assert!(!enabled);
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn explicit_policies_do_not_check_the_license() {
+        for (policy, expected) in [
+            (SymbolicParallelism::Serial, false),
+            (SymbolicParallelism::Parallel, true),
+        ] {
+            let calls = Cell::new(0);
+            let enabled = policy.resolve_with(|| {
+                calls.set(calls.get() + 1);
+                !expected
+            });
+
+            assert_eq!(enabled, expected);
+            assert_eq!(calls.get(), 0);
+        }
+    }
+
+    #[test]
+    fn setter_caches_the_resolved_boolean() {
+        set_symbolica_rayon_enabled(SymbolicParallelism::Serial);
+        assert!(!symbolica_rayon_enabled());
+
+        set_symbolica_rayon_enabled(SymbolicParallelism::Parallel);
+        assert!(symbolica_rayon_enabled());
+    }
+}

--- a/crates/spenso/src/symbolic_parallelism.rs
+++ b/crates/spenso/src/symbolic_parallelism.rs
@@ -55,14 +55,42 @@ fn set_symbolica_rayon_enabled_with(
 }
 
 #[cfg(test)]
-pub(crate) fn set_symbolica_rayon_enabled_for_test(
-    policy: SymbolicParallelism,
-    is_licensed: impl FnOnce() -> bool,
-) {
-    set_symbolica_rayon_enabled_with(policy, is_licensed);
+pub(crate) struct SymbolicParallelismTestGuard {
+    previous: bool,
+    _lock: std::sync::MutexGuard<'static, ()>,
 }
 
-/// Return the resolved symbolic Rayon setting without querying the license.
+#[cfg(test)]
+static SYMBOLIC_PARALLELISM_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+impl Drop for SymbolicParallelismTestGuard {
+    fn drop(&mut self) {
+        cached_setting().store(self.previous, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn scoped_symbolica_rayon_setting_for_test(
+    policy: SymbolicParallelism,
+    is_licensed: impl FnOnce() -> bool,
+) -> SymbolicParallelismTestGuard {
+    let lock = SYMBOLIC_PARALLELISM_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let previous = symbolica_rayon_enabled();
+    set_symbolica_rayon_enabled_with(policy, is_licensed);
+    SymbolicParallelismTestGuard {
+        previous,
+        _lock: lock,
+    }
+}
+
+/// Return the resolved symbolic Rayon setting.
+///
+/// If no policy has been configured yet, this performs the default
+/// [`SymbolicParallelism::Auto`] initialization and queries the license once.
+/// Subsequent reads only load the cached boolean.
 pub fn symbolica_rayon_enabled() -> bool {
     cached_setting().load(Ordering::Relaxed)
 }
@@ -104,7 +132,7 @@ mod tests {
 
     #[test]
     fn setter_caches_the_resolved_boolean() {
-        set_symbolica_rayon_enabled(SymbolicParallelism::Serial);
+        let _guard = scoped_symbolica_rayon_setting_for_test(SymbolicParallelism::Serial, || false);
         assert!(!symbolica_rayon_enabled());
 
         set_symbolica_rayon_enabled(SymbolicParallelism::Parallel);

--- a/crates/spenso/src/tensors/parametric.rs
+++ b/crates/spenso/src/tensors/parametric.rs
@@ -2146,13 +2146,15 @@ where
         other_iter.reset();
     }
 
-    let elements = grouped
-        .into_par_iter()
-        .filter_map(|(index, terms)| {
-            let value = grouped_atom_sum(terms);
-            (!value.as_view().is_zero()).then_some((index, value))
-        })
-        .collect();
+    let finish_group = |(index, terms)| {
+        let value = grouped_atom_sum(terms);
+        (!value.as_view().is_zero()).then_some((index, value))
+    };
+    let elements = if crate::symbolic_parallelism::symbolica_rayon_enabled() {
+        grouped.into_par_iter().filter_map(finish_group).collect()
+    } else {
+        grouped.into_iter().filter_map(finish_group).collect()
+    };
 
     Ok(SparseTensor {
         zero: Atom::Zero,
@@ -2227,13 +2229,15 @@ where
         other_iter.reset();
     }
 
-    let elements = grouped
-        .into_par_iter()
-        .filter_map(|(index, terms)| {
-            let value = grouped_atom_sum(terms);
-            (!value.as_view().is_zero()).then_some((index, value))
-        })
-        .collect();
+    let finish_group = |(index, terms)| {
+        let value = grouped_atom_sum(terms);
+        (!value.as_view().is_zero()).then_some((index, value))
+    };
+    let elements = if crate::symbolic_parallelism::symbolica_rayon_enabled() {
+        grouped.into_par_iter().filter_map(finish_group).collect()
+    } else {
+        grouped.into_iter().filter_map(finish_group).collect()
+    };
 
     Ok(SparseTensor {
         zero: Atom::Zero,

--- a/crates/spynso3/src/lib.rs
+++ b/crates/spynso3/src/lib.rs
@@ -52,6 +52,9 @@ use symbolica::api::python::PythonExpression;
 #[cfg(feature = "python_stubgen")]
 use pyo3_stub_gen::{PyStubType, TypeInfo, define_stub_info_gatherer, derive::*};
 
+#[cfg(feature = "python_stubgen")]
+use pyo3_stub_gen::derive::{gen_stub_pyclass_enum, gen_stub_pyfunction};
+
 pub mod library;
 pub mod library_tensor;
 pub mod network;
@@ -65,6 +68,43 @@ trait ModuleInit: PyClass {
 
 pub struct SpensoModule;
 
+/// Policy for Rayon operations that manipulate Symbolica expressions.
+#[cfg_attr(feature = "python_stubgen", gen_stub_pyclass_enum)]
+#[pyclass(from_py_object, eq, eq_int, module = "symbolica.community.spenso")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SymbolicParallelism {
+    /// Resolve the setting from the Symbolica license when configured.
+    Auto,
+    /// Keep symbolic operations on the calling thread.
+    Serial,
+    /// Allow symbolic operations to use Rayon workers.
+    Parallel,
+}
+
+impl From<SymbolicParallelism> for spenso::symbolic_parallelism::SymbolicParallelism {
+    fn from(value: SymbolicParallelism) -> Self {
+        match value {
+            SymbolicParallelism::Auto => Self::Auto,
+            SymbolicParallelism::Serial => Self::Serial,
+            SymbolicParallelism::Parallel => Self::Parallel,
+        }
+    }
+}
+
+/// Configure whether Spenso may use Rayon for Symbolica operations.
+///
+/// `Auto` checks the Symbolica license once during this call. Tensor operations
+/// subsequently use the cached result without querying the license again.
+#[cfg_attr(
+    feature = "python_stubgen",
+    gen_stub_pyfunction(module = "symbolica.community.spenso")
+)]
+#[pyfunction]
+fn set_symbolica_rayon_enabled(policy: SymbolicParallelism) -> bool {
+    spenso::symbolic_parallelism::set_symbolica_rayon_enabled(policy.into());
+    spenso::symbolic_parallelism::symbolica_rayon_enabled()
+}
+
 impl SymbolicaCommunityModule for SpensoModule {
     fn get_name() -> String {
         "spenso".to_string()
@@ -76,6 +116,9 @@ impl SymbolicaCommunityModule for SpensoModule {
 
     fn initialize(_py: Python) -> PyResult<()> {
         idenso::representations::initialize();
+        spenso::symbolic_parallelism::set_symbolica_rayon_enabled(
+            spenso::symbolic_parallelism::SymbolicParallelism::Auto,
+        );
         Ok(())
     }
 }
@@ -87,6 +130,8 @@ pub(crate) fn initialize_spenso(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // m.add_function(?)?;
     SpensoNet::init(m)?;
     ExecutionMode::init(m)?;
+    m.add_class::<SymbolicParallelism>()?;
+    m.add_function(wrap_pyfunction!(set_symbolica_rayon_enabled, m)?)?;
     Spensor::init(m)?;
     LibrarySpensor::init(m)?;
     SpensoIndices::init(m)?;


### PR DESCRIPTION
## Summary

- add `SymbolicParallelism::{Auto, Serial, Parallel}` and cache the resolved Rayon decision globally
- default Rust initialization and Python module initialization to `Auto`, with one license check at resolution time and atomic reads thereafter
- guard every Rayon execution site in Spenso that can perform Symbolica work, including falling back from parallel network execution to sequential execution
- expose `set_symbolica_rayon_enabled` and `SymbolicParallelism` in the Python API
- add policy unit tests and an end-to-end sparse symbolic tensor sum regression test with a deterministic unlicensed probe

## Validation

- `cargo test -p spenso --all-features symbolic_parallelism -- --test-threads=1`
- `cargo test -p spenso --all-features auto_serializes_unlicensed_symbolic_fast_tensor_sum -- --nocapture --test-threads=1`
- negative control: forcing `Parallel` makes the symbolic regression fail its cached-serial assertion; restored `Auto` passes
- `cargo clippy -p spenso -p spynso3 --all-features --all-targets -- -D warnings`
- `git diff --check`
- `just test_gammaloop` was started from the final state and progressed through compilation of the modified Spenso and dependent GammaLoop crates without an error; it was stopped before completion at user direction to use PR CI as the full gate

## Notes

The checked-in Symbolica build reports licensed locally, so the integration test injects an unlicensed result through a `cfg(test)`-only probe hook. Production `Auto` calls `LicenseManager::is_licensed()` directly exactly once per setter invocation. The test then executes the real sparse `Atom::add_many` fast-sum path that was previously unconditionally dispatched to Rayon.