### PR TITLE
Prevent cold NixCI artifact cache stampedes

### DIFF
--- a/.github/workflows/hestia-gc.yml
+++ b/.github/workflows/hestia-gc.yml
@@ -17,6 +17,10 @@ concurrency:
 permissions:
   contents: read
 
+# Keep GC in the same cache namespace as the Nix workflow.
+env:
+  HESTIA_CACHE_VERSION_SALT: gammaloop-no-closure-v1
+
 jobs:
   gc:
     name: Garbage collect

--- a/.github/workflows/hestia-gc.yml
+++ b/.github/workflows/hestia-gc.yml
@@ -1,0 +1,38 @@
+name: Hestia cache GC
+
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Plan cache cleanup without changing stored data
+        type: boolean
+        default: false
+
+concurrency:
+  group: hestia-gc
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  gc:
+    name: Garbage collect
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: NixOS/nix-installer-action@main
+      - uses: Mic92/hestia@v3
+        with:
+          version: v3.0.0
+      - name: Run garbage collection
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          "$HESTIA_BIN" gc \
+            ${{ inputs.dry-run && '--dry-run' || '' }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,123 @@
+name: Nix
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Impure Nix evaluation embeds this value in derivations cached by Hestia, so
+# keep it public instead of exposing secrets.SYMBOLICA_LICENSE to pull requests.
+env:
+  CARGO_TERM_COLOR: always
+  HESTIA_DRAIN_TIMEOUT: 7200
+  RUST_BACKTRACE: "1"
+  SYMBOLICA_LICENSE: GAMMALOOP_USER
+
+jobs:
+  # Hestia's matrix transfers drv closures, not dependency outputs. Build the
+  # shared roots here so the matrix drain publishes them before consumers run.
+  prepare:
+    name: Prepare shared artifacts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      any-jobs: ${{ steps.matrix.outputs.any-jobs }}
+      manifest-version: ${{ steps.matrix.outputs.manifest-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: NixOS/nix-installer-action@main
+      - uses: Mic92/hestia@v3
+        with:
+          version: v3.0.0
+          drain-timeout: ${{ env.HESTIA_DRAIN_TIMEOUT }}
+          upstream-cache-filter: true
+      - name: Build shared artifacts
+        run: |
+          nix build \
+            --impure \
+            --keep-going \
+            --no-link \
+            --print-build-logs \
+            .#packages.x86_64-linux.cargoArtifacts \
+            .#packages.x86_64-linux.gammaloopApiPackageArtifacts \
+            .#packages.x86_64-linux.gammaloop-python-module \
+            .#checks.x86_64-linux.gammaloop-nextest-binaries
+      # The composite matrix action drains for only five minutes and treats a
+      # timeout as non-fatal. These Cargo trees can take much longer to upload,
+      # so keep the producer barrier intact with the CLI's longer timeout.
+      - id: matrix
+        name: Create Hestia matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$HESTIA_BIN" matrix \
+            --flake ".#hydraJobs.x86_64-linux" \
+            --socket "$HESTIA_SOCKET" \
+            --nix-eval-jobs "nix run nixpkgs#nix-eval-jobs -- --impure" \
+            --attr-prefix "hydraJobs.x86_64-linux" \
+            --drain-timeout "$HESTIA_DRAIN_TIMEOUT"
+      - name: Confirm producer manifest
+        if: steps.matrix.outputs.any-jobs == 'true'
+        env:
+          MANIFEST_VERSION: ${{ steps.matrix.outputs.manifest-version }}
+        run: test "$MANIFEST_VERSION" -gt 0
+
+  build:
+    name: ${{ matrix.name }} (${{ matrix.system }})
+    needs: prepare
+    if: needs.prepare.outputs.any-jobs == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - uses: NixOS/nix-installer-action@main
+      - uses: Mic92/hestia@v3
+        with:
+          version: v3.0.0
+          drain-timeout: ${{ env.HESTIA_DRAIN_TIMEOUT }}
+          upstream-cache-filter: true
+          wait-manifest-version: ${{ needs.prepare.outputs.manifest-version }}
+      - name: Prefetch derivation closures
+        shell: bash
+        run: |
+          set -o pipefail
+          hashes=$(printf '%s\n' ${{ matrix.installables }} |
+            awk -F/ '{printf "%s%s", (NR > 1 ? "," : ""), substr($NF, 1, 32)}')
+          curl -fsS "http://$HESTIA_LISTEN/closure/$hashes" | nix-store --import
+      - name: Build checks
+        run: nix build --keep-going --no-link --print-build-logs ${{ matrix.installables }}
+
+  flake-checks:
+    name: Flake checks
+    needs: [prepare, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm matrix result
+        env:
+          PREPARE_RESULT: ${{ needs.prepare.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          ANY_JOBS: ${{ needs.prepare.outputs.any-jobs }}
+        run: |
+          test "$PREPARE_RESULT" = success
+          if [ "$ANY_JOBS" = true ]; then
+            test "$BUILD_RESULT" = success
+          else
+            test "$ANY_JOBS" = false
+            test "$BUILD_RESULT" = skipped
+          fi

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,24 +17,30 @@ concurrency:
   group: nix-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Impure Nix evaluation embeds this value in derivations cached by Hestia, so
-# keep it public instead of exposing secrets.SYMBOLICA_LICENSE to pull requests.
+# Matrix evaluation embeds this value in derivations registered with Hestia, so
+# keep it public. Licensed worker builds re-evaluate their attributes locally.
 env:
   CARGO_TERM_COLOR: always
+  HESTIA_CACHE_WRITABLE: >-
+    ${{ github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+        github.actor != 'dependabot[bot]') }}
   HESTIA_DRAIN_TIMEOUT: 7200
+  # Bump this only for an intentional Hestia cache-format migration.
+  HESTIA_CACHE_VERSION_SALT: gammaloop-no-closure-v1
   RUST_BACKTRACE: "1"
   SYMBOLICA_LICENSE: GAMMALOOP_USER
 
 jobs:
-  # Hestia's matrix transfers drv closures, not dependency outputs. Build the
-  # shared roots here so the matrix drain publishes them before consumers run.
+  # Publish shared roots here so consumers wait on their manifest before
+  # running in parallel.
   prepare:
     name: Prepare shared artifacts
     runs-on: ubuntu-24.04
     timeout-minutes: 360
     outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-      any-jobs: ${{ steps.matrix.outputs.any-jobs }}
+      matrix: ${{ steps.filter-matrix.outputs.matrix }}
+      any-jobs: ${{ steps.filter-matrix.outputs.any-jobs }}
       manifest-version: ${{ steps.matrix.outputs.manifest-version }}
     steps:
       - uses: actions/checkout@v4
@@ -43,24 +49,59 @@ jobs:
         with:
           version: v3.0.0
           drain-timeout: ${{ env.HESTIA_DRAIN_TIMEOUT }}
+          no-closure: true
           upstream-cache-filter: true
-      - name: Build shared artifacts
+      - name: Build and publish shared artifacts
+        shell: bash
         run: |
-          nix build \
-            --impure \
-            --keep-going \
-            --no-link \
-            --print-build-logs \
-            .#packages.x86_64-linux.cargoArtifacts \
-            .#packages.x86_64-linux.gammaloopApiPackageArtifacts \
-            .#packages.x86_64-linux.gammaloop-python-module \
-            .#checks.x86_64-linux.gammaloop-nextest-binaries
-      # The composite matrix action drains for only five minutes and treats a
-      # timeout as non-fatal. These Cargo trees can take much longer to upload,
-      # so keep the producer barrier intact with the CLI's longer timeout.
+          set -euo pipefail
+          # Avoid publishing every large intermediate Crane merge tree.
+          test -z "$(nix --option post-build-hook "" config show post-build-hook)"
+          producer_output_lines=$(
+            nix --option post-build-hook "" build \
+              --impure \
+              --keep-going \
+              --no-link \
+              --print-build-logs \
+              --print-out-paths \
+              .#packages.x86_64-linux.crane-ci-prebuild \
+              .#packages.x86_64-linux.gammaloop \
+              .#packages.x86_64-linux.gammaloop-python-module \
+              .#checks.x86_64-linux.gammaloop-nextest-binaries
+          )
+          mapfile -t producer_outputs <<< "$producer_output_lines"
+          test "${#producer_outputs[@]}" -eq 4
+          publish_path_lines=$(
+            nix-store --query --requisites "${producer_outputs[@]}" | LC_ALL=C sort -u
+          )
+          mapfile -t publish_paths <<< "$publish_path_lines"
+          test "${#publish_paths[@]}" -gt 0
+          # no-closure makes this explicit, compact path set the upload boundary.
+          closure_bytes=$(nix path-info --json --recursive "${producer_outputs[@]}" |
+            jq '[.[] | .narSize] | add')
+          echo "Selected producer closure: $closure_bytes raw NAR bytes (${#publish_paths[@]} paths)"
+          test "$closure_bytes" -lt $((8 * 1024 * 1024 * 1024))
+          "$HESTIA_BIN" hook --socket "$HESTIA_SOCKET" "${publish_paths[@]}"
+          "$HESTIA_BIN" drain \
+            --socket "$HESTIA_SOCKET" \
+            --timeout "$HESTIA_DRAIN_TIMEOUT"
+          if [ "$HESTIA_CACHE_WRITABLE" = true ]; then
+            # The hook is deliberately non-fatal, so verify its committed roots.
+            for output in "${producer_outputs[@]}"; do
+              store_hash=${output#/nix/store/}
+              store_hash=${store_hash%%-*}
+              curl -fsS "http://$HESTIA_LISTEN/$store_hash.narinfo" >/dev/null
+            done
+          fi
+      # The composite matrix action treats a drain timeout as non-fatal. Keep
+      # the producer barrier enforceable with the CLI's manifest-version output.
       - id: matrix
         name: Create Hestia matrix
         shell: bash
+        # Keep licensed checks uncached in this public evaluation. Workers
+        # re-evaluate them with the secret, which produces distinct drv paths.
+        env:
+          SYMBOLICA_LICENSE: GAMMALOOP_MATRIX_${{ github.run_id }}
         run: |
           set -euo pipefail
           "$HESTIA_BIN" matrix \
@@ -69,8 +110,29 @@ jobs:
             --nix-eval-jobs "nix run nixpkgs#nix-eval-jobs -- --impure" \
             --attr-prefix "hydraJobs.x86_64-linux" \
             --drain-timeout "$HESTIA_DRAIN_TIMEOUT"
+      - id: filter-matrix
+        name: Filter unavailable licensed tests
+        env:
+          LICENSE: ${{ secrets.SYMBOLICA_LICENSE }}
+          MATRIX: ${{ steps.matrix.outputs.matrix }}
+        run: |
+          set -euo pipefail
+          if [ -n "$LICENSE" ]; then
+            filtered="$MATRIX"
+          else
+            echo "::notice::Skipping Nix-sandboxed doctest and nextest rows because the Symbolica secret is unavailable"
+            filtered=$(jq -c '
+              .include |= map(select(
+                (.attr == "hydraJobs.x86_64-linux.gammaloop-doctest"
+                  or (.attr | startswith("hydraJobs.x86_64-linux.gammaloop-nextest-")))
+                | not
+              ))
+            ' <<< "$MATRIX")
+          fi
+          echo "matrix=$filtered" >> "$GITHUB_OUTPUT"
+          echo "any-jobs=$(jq -r '.include | length > 0' <<< "$filtered")" >> "$GITHUB_OUTPUT"
       - name: Confirm producer manifest
-        if: steps.matrix.outputs.any-jobs == 'true'
+        if: steps.filter-matrix.outputs.any-jobs == 'true' && env.HESTIA_CACHE_WRITABLE == 'true'
         env:
           MANIFEST_VERSION: ${{ steps.matrix.outputs.manifest-version }}
         run: test "$MANIFEST_VERSION" -gt 0
@@ -85,22 +147,34 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
+      - uses: actions/checkout@v4
       - uses: NixOS/nix-installer-action@main
       - uses: Mic92/hestia@v3
         with:
           version: v3.0.0
           drain-timeout: ${{ env.HESTIA_DRAIN_TIMEOUT }}
+          no-closure: true
           upstream-cache-filter: true
           wait-manifest-version: ${{ needs.prepare.outputs.manifest-version }}
-      - name: Prefetch derivation closures
-        shell: bash
-        run: |
-          set -o pipefail
-          hashes=$(printf '%s\n' ${{ matrix.installables }} |
-            awk -F/ '{printf "%s%s", (NR > 1 ? "," : ""), substr($NF, 1, 32)}')
-          curl -fsS "http://$HESTIA_LISTEN/closure/$hashes" | nix-store --import
       - name: Build checks
-        run: nix build --keep-going --no-link --print-build-logs ${{ matrix.installables }}
+        env:
+          CHECK_ATTR: ${{ matrix.attr }}
+          SYMBOLICA_LICENSE: ${{ secrets.SYMBOLICA_LICENSE || 'GAMMALOOP_USER' }}
+        run: |
+          set -euo pipefail
+          nix_options=()
+          case "$CHECK_ATTR" in
+            *.gammaloop-doctest|*.gammaloop-nextest-*)
+              # Do not persist secret-derived test identities or results.
+              nix_options+=(--option post-build-hook "")
+              ;;
+          esac
+          nix "${nix_options[@]}" build \
+            --impure \
+            --keep-going \
+            --no-link \
+            --print-build-logs \
+            ".#$CHECK_ATTR"
 
   flake-checks:
     name: Flake checks

--- a/docs/architecture/nix-crane-cache-reuse.md
+++ b/docs/architecture/nix-crane-cache-reuse.md
@@ -1221,9 +1221,10 @@ ordinary integration tests.
 
 `crate-test-binaries-<package>` is now a genuine package-local derivation. It
 consumes that context's dependency artifact, receives the own-test source for
-that package alone, and runs `cargo test --no-run -p <package>`. Nextest archives
-merge these package-local binary artifacts directly. Dependency test sources and
-test binaries therefore never cross a downstream package boundary.
+that package alone, and runs `cargo test --no-run -p <package>`. Each nextest
+archive consumes its matching package-local binary artifact directly. Dependency
+test sources and test binaries therefore never cross a downstream package
+boundary.
 
 The own-test tier is split again at the archive boundary. Compilation and
 packaging receive Rust test, bench, example, and binary sources plus explicitly
@@ -1350,6 +1351,101 @@ reusable artifact producers. They consume the base dependency artifact to avoid
 starting completely cold, but they do not publish merged workspace target trees
 back to the cache.
 
+## Follow-up: cross-job producer barriers
+
+The cold NixCI fan-out exposed a scheduling problem outside Cargo and Crane:
+identical hidden derivations could start on separate workers before either copy
+reached the shared cache. The manual graph is still defined over all flake
+outputs, including `doNotBuild` outputs, but its NixCI projection now contracts
+each hidden path to the nearest job that NixCI actually builds. It stops at that
+first producer rather than adding the entire transitive closure as direct edges.
+
+An explicit producer attribute alone is not a sufficient barrier. NixCI
+memoizes a successful top-level derivation across commits and can report
+`Nothing to build: this was already built successfully before.` without asking
+a worker to realize its output or closure. If that nested Cargo artifact is no
+longer available to the next workers, every released consumer can still build
+the same derivation. A replacement run exposed 15 exact derivations built in
+two archive jobs each. Five were test-dependency producers and accounted for 25
+redundant `Compiling` lines.
+
+Scheduled Cargo artifact outputs are therefore exposed through a tiny
+revision-scoped barrier derivation. The barrier output is a symlink to the
+stable raw artifact, so building it realizes the artifact and lets NixCI's
+post-build hook publish the closure before dependent jobs start. Only the
+wrapper contains the flake revision: the Cargo artifact derivation and its
+cross-commit cache key remain unchanged. This adds no target-tree copy and
+preserves paths such as `${artifact}/target.tar.zst` through the output symlink.
+The wrappers cover the global artifact, package dependency artifacts, ordinary
+and contextual test dependencies and binaries, the Python module artifact
+chain, and the other scheduled shared Cargo artifacts. Hidden aliases such as
+the unused `spynso3` test outputs remain hidden.
+
+The ordinary Rust API and Python ABI lanes share
+`crate-deps-gammalooprs`, so that artifact is now an explicit producer barrier.
+Both lanes wait for this sequence before their distinct Cargo contexts branch:
+
+```text
+crate-deps-gammaloop-workspace-hack
+  -> cargoArtifacts
+  -> crate-deps-gammalooprs
+  -> {gammaloopApiPackageArtifacts, gammaloop-python-module}
+```
+
+Every non-hack `crate-deps-*` node also records its real `cargoArtifacts`
+dependency in the scheduling graph. The duplicate final-package and test-binary
+aliases for the workspace hack are hidden, leaving its `crate-deps-*` attribute
+as the single producer for that exact derivation. The `checks.gammaloop` alias
+is also hidden because it is the same derivation as `packages.gammaloop`.
+
+The nextest scheduling graph now matches the flake contexts:
+
+- the Spenso archive waits for `symbolica-utils`;
+- the Python API archive waits for a stable, target-named output for the
+  `python-api-tests` integration binary and its distinct dependency context;
+- the unconsumed `spynso3` test-dependency and test-binary outputs are not NixCI
+  jobs.
+
+Grouped archive commands were the remaining Cargo-context mismatch. Package
+test binaries are deliberately built from package-local sources and features,
+so each package now has a nextest archive derivation with the same singleton
+Cargo arguments. A lightweight link farm retains the existing group output. The
+corresponding group test job executes those archives sequentially, reports each
+JUnit result, and returns the first failing status. This retains one NixCI
+archive and test job per existing group without asking Cargo to reunify all
+packages in a new grouped compilation context or letting one archive command
+mutate another package's Cargo context.
+
+Three redundant materialization layers were also removed. Final crate builds
+consume their self-contained, stripped `crate-deps-*` archive directly, and the
+Python build and package phases consume their preceding self-contained archive
+instead of routing it through a one-input `mergeCargoArtifacts`. The terminal
+nextest archives consume the matching package-local incremental artifact, use
+Crane's symlink-heavy inheritance for its materialized base, and overlay its
+writable delta. Crane does not follow a `target.tar.zst.prev` link whose target
+is a directory, so the archive derivation explicitly inherits that base before
+Crane's normal post-patch hook applies the delta. This avoids both a new
+materialized group merge and publication of another Cargo target tree.
+
+The self-contained archive compaction step uses mtime epoch 1, matching Crane's
+artifact installer and Nix source timestamps. Using epoch 0 for the compacted
+target made Cargo treat every inherited artifact as older than its source when
+a consumer skipped the materializing merge layer.
+
+The static graph and derivation shapes can be checked without building the cold
+Cargo closure:
+
+```bash
+nix eval --json --file nix-ci.nix
+nix flake check --impure --no-build 'path:.'
+nix derivation show \
+  'path:.#checks.x86_64-linux.gammaloop-nextest-binaries-spenso'
+```
+
+A fresh NixCI run is still required to measure cross-worker execution counts and
+cache upload time; one local Nix daemon serializes identical derivations and
+therefore cannot reproduce the original stampede.
+
 ## Remaining caveats
 
 - Dependency-only derivations can still compile generated feature-anchor or
@@ -1366,8 +1462,9 @@ back to the cache.
 - Python ABI builds intentionally use different `gammaloop-api` features
   (`python_abi`, `pyo3-extension-module`) and remain a separate artifact family.
   Normal Rust test archives should not depend on that family.
-- `doNotLinkInheritedArtifacts = true` still deep-copies inherited artifacts in
-  some derivations. That should not cause recompilation, but it can add wall
-  time and larger outputs. If compile reuse is fixed but CI still spends a lot
-  of time copying artifact trees, the next follow-up is to remove that override
-  and use Crane's default symlink-heavy inheritance mode where safe.
+- `doNotLinkInheritedArtifacts = true` remains on producer paths whose archive
+  and stripping behavior still needs a focused chain test before switching to
+  Crane's symlink-heavy inheritance mode. It should not cause recompilation, but
+  it can add wall time. The next publication experiment should compare Crane's
+  `use-symlink` artifact-install mode across a complete
+  root-to-package-to-test-to-archive chain.

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
   };
 
   outputs = {
+    self,
     nixpkgs,
     crane,
     fenix,
@@ -35,6 +36,24 @@
     flake-utils.lib.eachSystem supportedSystems (system: let
       pkgs = nixpkgs.legacyPackages.${system};
       inherit (pkgs) lib;
+
+      nixCiBarrierRevision =
+        if self ? dirtyRev
+        then self.dirtyRev
+        else if self ? rev
+        then self.rev
+        else if self ? narHash
+        then self.narHash
+        else "local";
+      # NixCI memoizes successful top-level derivations across commits without
+      # re-realizing their closures. Salt only this zero-copy scheduling
+      # wrapper so each commit primes the stable artifact in the shared cache.
+      nixCiArtifactBarrier = name: artifact:
+        pkgs.runCommand "nix-ci-artifact-barrier-${name}" {
+          NIX_CI_BARRIER_REVISION = nixCiBarrierRevision;
+        } ''
+          ln -s ${artifact} "$out"
+        '';
 
       baseCraneLib = crane.mkLib pkgs;
       stableToolchain = fenix.packages.${system}.stable;
@@ -1337,10 +1356,7 @@
       '';
       gammaloop-python-lib = craneLib.buildPackage (ciArgs
         // {
-          cargoArtifacts = mergeCargoArtifacts "gammaloop-python-package-inputs" [
-            cranePythonBuildArtifacts
-          ];
-          doNotLinkInheritedArtifacts = true;
+          cargoArtifacts = cranePythonBuildArtifacts;
           pname = "gammaloop-api-python";
           src = workspacePackageSrcFor "gammaloop-api";
           cargoExtraArgs = cranePythonCargoArgs;
@@ -1805,6 +1821,10 @@
           }
 
           ${lib.concatMapStringsSep "\n" (artifact: "unpack_artifact ${artifact}") artifactList}
+
+          # Crane deletes inherited Cargo locks before using an artifact tree.
+          # Remove them here while the merged files are still ordinary files.
+          find "$out/target" -name .cargo-lock -delete
         '';
 
       mergeCargoArtifactsOrNull = name: artifacts: let
@@ -2009,7 +2029,9 @@
                     ${stripWorkspaceArtifactsScriptText}
                   )
 
-                  tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner -C "$tmp/target" -cf - . \
+                  # Match Crane's artifact and Nix source timestamps so Cargo
+                  # does not treat the compacted target as stale.
+                  tar --sort=name --mtime=@1 --owner=0 --group=0 --numeric-owner -C "$tmp/target" -cf - . \
                     | zstd -T0 --stdout > "$out/target.tar.zst.tmp"
                   mv "$out/target.tar.zst.tmp" "$out/target.tar.zst"
                   rm -f "$out/target.tar.zst.prev"
@@ -2140,13 +2162,10 @@
           else
             craneLib.cargoBuild (ciArgs
               // {
-                cargoArtifacts = mergeCargoArtifacts "gammaloop-crate-${package}-deps" (
-                  [
-                    cargoArtifacts
-                    cranePackageDependencyArtifacts.${package}
-                  ]
-                );
-                doNotLinkInheritedArtifacts = true;
+                cargoArtifacts =
+                  if cranePackageDependencyArtifacts.${package} == null
+                  then cargoArtifacts
+                  else cranePackageDependencyArtifacts.${package};
                 pname = "gammaloop-crate-${package}";
                 src = workspacePackageSrcFor package;
                 cargoExtraArgs =
@@ -2445,10 +2464,7 @@
 
       cranePythonBuildArtifacts = craneLib.cargoBuild (ciArgs
         // {
-          cargoArtifacts = mergeCargoArtifacts "gammaloop-python-build-inputs" [
-            cranePythonDependencyArtifacts
-          ];
-          doNotLinkInheritedArtifacts = true;
+          cargoArtifacts = cranePythonDependencyArtifacts;
           pname = "gammaloop-api-python-build";
           src = workspacePackageSrcFor "gammaloop-api";
           cargoExtraArgs = cranePythonCargoArgs;
@@ -2463,14 +2479,20 @@
 
       cranePackageDependencyOutputs = lib.listToAttrs (map (package: {
           name = "crate-deps-${package}";
-          value = cranePackageDependencyArtifacts.${package};
+          value =
+            nixCiArtifactBarrier
+            "crate-deps-${package}"
+            cranePackageDependencyArtifacts.${package};
         })
         (lib.filter (package: cranePackageDependencyArtifacts.${package} != null)
           workspacePackages));
 
       craneTestBinaryPackageOutputs = lib.listToAttrs (map (package: {
           name = "crate-test-binaries-${package}";
-          value = craneTestBinaryArtifacts.${package};
+          value =
+            nixCiArtifactBarrier
+            "crate-test-binaries-${package}"
+            craneTestBinaryArtifacts.${package};
         })
         workspacePackages);
 
@@ -2478,7 +2500,10 @@
           context = workspaceTestContextFor {packages = [representative];};
         in {
           name = "crate-test-dependencies-${representative}";
-          value = craneTestDependencyArtifacts.${context.key};
+          value =
+            nixCiArtifactBarrier
+            "crate-test-dependencies-${representative}"
+            craneTestDependencyArtifacts.${context.key};
         })
         workspaceTestDependencyComponentRepresentatives);
 
@@ -2641,7 +2666,7 @@
           ++ lib.optional (nextestFeatureArgsFor target != "") (nextestFeatureArgsFor target)
         );
 
-      nextestArchiveNameFor = target: "gammaloop-nextest-${target.name}.tar.zst";
+      nextestArchiveNameFor = target: package: "gammaloop-nextest-${target.name}-${package}.tar.zst";
 
       nextestPackageTestBinaryArtifactFor = target: package: let
         context = nextestPackageContextFor target package;
@@ -2651,21 +2676,16 @@
         then craneTestBinaryArtifacts.${package}
         else craneTestBinaryArtifactFor context package;
 
-      nextestArchiveCargoArtifactsFor = target:
-        mergeCargoArtifacts "gammaloop-nextest-binaries-${target.name}-inputs" (
-          [
-            cargoArtifacts
-          ]
-          ++ map (nextestPackageTestBinaryArtifactFor target) target.packages
-        );
-
-      nextestArchiveFor = target:
+      nextestPackageArchiveFor = target: package: let
+        packageTarget = target // {packages = [package];};
+        context = nextestPackageContextFor target package;
+        packageCargoArtifacts = nextestPackageTestBinaryArtifactFor target package;
+      in
         craneLib.mkCargoDerivation (ciArgs
           // {
-            pname = "gammaloop-nextest-binaries-${target.name}";
-            src = nextestSrcFor target;
-            cargoArtifacts = nextestArchiveCargoArtifactsFor target;
-            doNotLinkInheritedArtifacts = true;
+            pname = "gammaloop-nextest-binaries-${target.name}-${package}";
+            src = nextestSrcFor packageTarget;
+            cargoArtifacts = packageCargoArtifacts;
             doCheck = false;
             doInstallCargoArtifacts = false;
             nativeBuildInputs =
@@ -2674,26 +2694,30 @@
               ++ lib.optionals (nextestUsesPythonModule target) [nextestPython];
             postPatch = ''
               ${workspaceMissingCargoTargetsScript}
-              ${lib.concatMapStringsSep "\n" (package: let
-                  context = nextestPackageContextFor target package;
-                in ''
-                  ${testBinaryFeatureAnchorSourceScriptFor context ""}
-                  ${testBinaryFeatureAnchorDevDependencyScriptFor context package ""}
-                '')
-                target.packages}
+              ${testBinaryFeatureAnchorSourceScriptFor context ""}
+              ${testBinaryFeatureAnchorDevDependencyScriptFor context package ""}
+
+              # Crane only follows file-valued incremental artifact links. The
+              # test-binary delta points directly to its materialized input
+              # directory, so inherit that base before Crane overlays the
+              # package-specific, writable delta in its post-patch hook.
+              if [ -d ${packageCargoArtifacts}/target.tar.zst.prev ]; then
+                inheritCargoArtifacts "$(realpath ${packageCargoArtifacts}/target.tar.zst.prev)" target
+              fi
             '';
             buildPhaseCargoCommand = ''
               mkdir -p "$out"
               if [ -d target ]; then
                 chmod -R u+w target
+                find target -name .cargo-lock -delete
               fi
               cargo nextest --version
               cargo nextest archive \
                 --cargo-profile ${ciCargoProfile} \
-                ${nextestCargoArgsFor target} \
-                ${nextestFilterFor target} \
+                ${nextestCargoArgsFor packageTarget} \
+                ${nextestFilterFor packageTarget} \
                 --profile ${nextestProfile} \
-                --archive-file "$out/${nextestArchiveNameFor target}"
+                --archive-file "$out/${nextestArchiveNameFor target package}"
             '';
             checkPhaseCargoCommand = "";
             installPhaseCommand = "";
@@ -2703,11 +2727,42 @@
             PYTHONPATH = "${gammaloop-python-module}/${pythonSitePackages}:${nextestPython}/${pythonSitePackages}";
           });
 
+      nextestArchiveFor = target: let
+        packageArchives = lib.genAttrs target.packages (nextestPackageArchiveFor target);
+      in
+        pkgs.linkFarm "gammaloop-nextest-binaries-${target.name}" (map (package: {
+            name = nextestArchiveNameFor target package;
+            path = "${packageArchives.${package}}/${nextestArchiveNameFor target package}";
+          })
+          target.packages);
+
       nextestBinarySets = lib.listToAttrs (map (target: {
           name = "gammaloop-nextest-binaries-${target.name}";
           value = nextestArchiveFor target;
         })
         checkedNextestPackageGroups);
+
+      nextestContextualTestOutputs = lib.listToAttrs (lib.concatMap (target:
+          lib.concatMap (package: let
+              context = nextestPackageContextFor target package;
+            in [
+              {
+                name = "crate-test-dependencies-${target.name}-${package}";
+                value =
+                  nixCiArtifactBarrier
+                  "crate-test-dependencies-${target.name}-${package}"
+                  craneTestDependencyArtifacts.${context.key};
+              }
+              {
+                name = "crate-test-binaries-${target.name}-${package}";
+                value =
+                  nixCiArtifactBarrier
+                  "crate-test-binaries-${target.name}-${package}"
+                  (nextestPackageTestBinaryArtifactFor target package);
+              }
+            ])
+          target.packages)
+        (lib.filter (target: target ? extraFeatures) checkedNextestPackageGroups));
 
       nextestBinarySetForTarget = target: nextestBinarySets."gammaloop-nextest-binaries-${target.name}";
 
@@ -2768,12 +2823,20 @@
 
           mkdir -p target/nextest
           set +e
-          cargo nextest run \
-            --archive-file ${nextestBinarySetForTarget target}/${nextestArchiveNameFor target} \
-            --workspace-remap . \
-            ${nextestBaseExtraArgs}
-          status=$?
-          nextest-failure-summary ${lib.escapeShellArg nextestJunitPath} || true
+          status=0
+          ${lib.concatMapStringsSep "\n" (package: ''
+              rm -f ${lib.escapeShellArg nextestJunitPath}
+              cargo nextest run \
+                --archive-file ${nextestBinarySetForTarget target}/${nextestArchiveNameFor target package} \
+                --workspace-remap . \
+                ${nextestBaseExtraArgs}
+              package_status=$?
+              nextest-failure-summary ${lib.escapeShellArg nextestJunitPath} || true
+              if [ "$package_status" -ne 0 ] && [ "$status" -eq 0 ]; then
+                status="$package_status"
+              fi
+            '')
+            target.packages}
           mkdir -p "$out"
           exit "$status"
         '');
@@ -2849,8 +2912,8 @@
           echo "All NixCI build and test jobs passed."
         '';
       };
-    in {
-      checks =
+
+      allChecks =
         {
           # Keep existing check names for CI compatibility.
           gammaloop = gammaloop-cli;
@@ -2888,25 +2951,43 @@
           gammaloop-nextest = nextestAggregate;
         };
 
+      # Hestia builds the binary producers before evaluating this consumer
+      # matrix. Omit those producers and the aggregate nextest check so each
+      # nextest execution remains an independent row without racing its leaves.
+      hestiaChecks = builtins.removeAttrs allChecks (
+        [
+          "gammaloop-nextest"
+          "gammaloop-nextest-binaries"
+        ]
+        ++ map (target: "gammaloop-nextest-binaries-${target.name}") checkedNextestPackageGroups
+      );
+    in {
+      checks = allChecks;
+
+      hydraJobs = hestiaChecks;
+
       packages =
         {
           default = gammaloop-cli;
           gammaloop = gammaloop-cli;
           inherit clinnet-cli;
-          "gammaloop-python-module" = gammaloop-python-module;
+          "gammaloop-python-module" = nixCiArtifactBarrier "gammaloop-python-module" gammaloop-python-module;
           "ci-workspace-graph-json" = guppyWorkspaceGraphJson;
-          inherit linnest-wasm linnestWasmCargoArtifacts;
+          inherit linnest-wasm;
+          linnestWasmCargoArtifacts =
+            nixCiArtifactBarrier "linnest-wasm-cargo-artifacts" linnestWasmCargoArtifacts;
           "crane-ci-prebuild" = cargoArtifacts;
-          inherit
-            cargoArtifacts
-            gammaloopApiPackageArtifacts
-            workspaceBuildArtifacts;
+          cargoArtifacts = nixCiArtifactBarrier "cargo-artifacts" cargoArtifacts;
+          gammaloopApiPackageArtifacts =
+            nixCiArtifactBarrier "gammaloop-api-package-artifacts" gammaloopApiPackageArtifacts;
+          inherit workspaceBuildArtifacts;
           "nix-ci-passed" = nixCiPassed;
         }
         // cranePackageDependencyOutputs
         // cranePackageOutputs
         // craneTestDependencyOutputs
         // craneTestBinaryPackageOutputs
+        // nextestContextualTestOutputs
         // impureCheckRunnerPackages
         // lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
           gammaloop-llvm-coverage = craneLib.cargoLlvmCov (commonArgs

--- a/nix-ci.nix
+++ b/nix-ci.nix
@@ -668,6 +668,10 @@ let
   cratePackageAttr = package: "packages.${system}.crate-${package}";
   crateTestDependencyAttr = representative: "packages.${system}.crate-test-dependencies-${representative}";
   crateTestBinaryAttr = package: "packages.${system}.crate-test-binaries-${package}";
+  nextestContextualTestDependencyAttr = target: package:
+    "packages.${system}.crate-test-dependencies-${target}-${package}";
+  nextestContextualTestBinaryAttr = target: package:
+    "packages.${system}.crate-test-binaries-${target}-${package}";
   workspaceHackPackage = "gammaloop-workspace-hack";
   # clinnet is binary-only: the flake exposes crate-clinnet, but no
   # crate-deps-clinnet artifact.
@@ -742,14 +746,19 @@ let
     builtins.filter (entry: entry.value != []) (map (package: {
         name = cratePackageDepsAttr package;
         value =
-          map cratePackageDepsAttr (workspaceDependencyNamesFor package)
+          (
+            if package == workspaceHackPackage
+            then []
+            else ["packages.${system}.cargoArtifacts"]
+          )
+          ++ map cratePackageDepsAttr (workspaceDependencyNamesFor package)
           ++ (
             if package != workspaceHackPackage && (workspaceDependencyNamesFor package) == [] && builtins.elem package workspaceGraph.symbolica_normal_packages
             then [workspaceHackCacheAttr]
             else []
           );
       })
-      workspacePackages)
+      workspacePackagesWithDependencyArtifacts)
   );
   workspaceCratePackageCacheArtifactDependencyEdges = builtins.concatLists (map (dependent:
       map (dependency: {
@@ -762,7 +771,7 @@ let
       value =
         [
           "packages.${system}.cargoArtifacts"
-          (workspacePackageGraphAttr workspaceHackPackage)
+          workspaceHackCacheAttr
         ]
         ++ map crateTestDependencyAttr (
           builtins.filter (
@@ -797,13 +806,14 @@ let
       "spenso"
       "spenso-hep-lib"
       "spenso-macros"
+      "symbolica-utils"
     ];
     vakint = ["vakint"];
   };
   nextestArchiveAttr = target: "checks.${system}.gammaloop-nextest-binaries-${target}";
   nextestPackageArtifactAttrFor = target: package:
     if target == "python-api"
-    then crateTestDependencyAttr (workspaceTestComponentRepresentativeFor package)
+    then nextestContextualTestBinaryAttr target package
     else crateTestBinaryAttr package;
   nextestArchiveDependenciesFor = target:
     ["packages.${system}.cargoArtifacts"]
@@ -834,6 +844,13 @@ let
         workspaceCratePackageDependencies.${cratePackageAttr "gammaloop-api"} or [];
       ${gammaloopApiPackageArtifactsAttr} = [(cratePackageAttr "gammaloop-api")];
       "packages.${system}.cargoArtifacts" = [workspaceHackCacheAttr];
+      ${nextestContextualTestDependencyAttr "python-api" "gammaloop-integration-tests"} =
+        workspaceTestDependencyArtifactDependencies.${crateTestDependencyAttr (workspaceTestComponentRepresentativeFor "gammaloop-integration-tests")}
+        ++ ["packages.${system}.gammaloop-python-module"];
+      ${nextestContextualTestBinaryAttr "python-api" "gammaloop-integration-tests"} = [
+        (nextestContextualTestDependencyAttr "python-api" "gammaloop-integration-tests")
+        "packages.${system}.gammaloop-python-module"
+      ];
       "checks.${system}.gammaloop-check" = ["packages.${system}.cargoArtifacts"];
       "checks.${system}.gammaloop-clippy" = ["packages.${system}.cargoArtifacts"];
       "checks.${system}.gammaloop-doc" = ["packages.${system}.cargoArtifacts"];
@@ -901,6 +918,7 @@ let
       dependencies;
   doNotBuild = unique (
     [
+      "checks.${system}.gammaloop"
       "checks.${system}.gammaloop-doctest"
       "checks.${system}.gammaloop-nextest"
       "checks.${system}.gammaloop-nextest-binaries"
@@ -917,50 +935,86 @@ let
       "packages.${system}.gammaloop-llvm-coverage"
       "packages.${system}.nix-ci-check-gammaloop-nextest"
     ]
-    ++ [(crateTestBinaryAttr workspaceHackPackage)]
+    ++ [
+      (crateTestDependencyAttr "spynso3")
+      (crateTestBinaryAttr workspaceHackPackage)
+      (crateTestBinaryAttr "spynso3")
+      (workspacePackageGraphAttr workspaceHackPackage)
+    ]
     ++ map cratePackageDepsAttr (
-      builtins.filter (package: package != workspaceHackPackage) workspacePackagesWithDependencyArtifacts
+      builtins.filter (
+        package: package != workspaceHackPackage && package != "gammalooprs"
+      )
+      workspacePackagesWithDependencyArtifacts
     )
     ++ map cratePackageAttr nonWorkspaceHackPackages
   );
   # NixCI only schedules jobs it actually builds, so a dependency edge that
   # references a doNotBuild job is rejected as pointing at a non-existent job.
   # The manual graph above is constructed over the full crate/artifact DAG
-  # (which keeps the drift and cycle asserts meaningful); here we drop every
-  # edge touching a doNotBuild job so only ordering between built jobs remains.
+  # (which keeps the drift and cycle asserts meaningful); here hidden paths are
+  # contracted to their nearest built dependency so their ordering is retained.
   doNotBuildSet = builtins.listToAttrs (map (job: {
       name = job;
       value = true;
     })
     doNotBuild);
   isBuiltJob = job: !(doNotBuildSet ? ${job});
+  builtDependencyFrontierFor = deps: dependent:
+    unique (map (entry: entry.key) (builtins.filter (
+        entry: isBuiltJob entry.key
+      ) (builtins.genericClosure {
+        startSet = map (dependency: {key = dependency;}) (deps.${dependent} or []);
+        operator = entry:
+          if isBuiltJob entry.key
+          then []
+          else map (dependency: {key = dependency;}) (deps.${entry.key} or []);
+      })));
   buildableDependencies = deps:
     builtins.listToAttrs (
       builtins.filter (entry: entry.value != []) (map (dependent: {
           name = dependent;
-          value = builtins.filter isBuiltJob deps.${dependent};
+          value = builtDependencyFrontierFor deps dependent;
         })
         (builtins.filter isBuiltJob (builtins.attrNames deps)))
     );
+  projectedDependencies = buildableDependencies validatedDependencies;
+  projectedDependencyClosureFor = dependent:
+    map (entry: entry.key) (builtins.genericClosure {
+      startSet = map (dependency: {key = dependency;}) (projectedDependencies.${dependent} or []);
+      operator = entry:
+        map (dependency: {key = dependency;}) (projectedDependencies.${entry.key} or []);
+    });
+  projectedDependencyCycles = builtins.filter (
+    attr: builtins.elem attr (projectedDependencyClosureFor attr)
+  ) (builtins.attrNames projectedDependencies);
+  validatedProjectedDependencies =
+    assert projectedDependencyCycles == []
+    || builtins.throw "projected NixCI dependency graph contains cycles through: ${builtins.concatStringsSep ", " projectedDependencyCycles}";
+      projectedDependencies;
 in {
   systems = [system];
   inherit doNotBuild;
   fail-fast = false;
+  fail-on-dangling-dependencies = true;
   # Keep dependency discovery manual. With generated Rust outputs,
   # automatic discovery asks NixCI to compute derivation paths for many
   # package/check attrs during `show`, including attrs listed in doNotBuild.
   # The manual graph below uses the Hakari workspace-hack cache artifact as the
   # root for Symbolica-containing cache jobs and orders nextest archive jobs
   # after the package-local test-binary artifacts that the archives reuse. The
+  # exported artifact attrs are revision-scoped symlink barriers around stable
+  # Cargo artifacts, so a memoized top-level result cannot release consumers
+  # without one worker realizing and publishing the underlying closure. The
   # graph is constructed over the full crate/artifact DAG so the drift and
-  # cycle asserts stay meaningful, then buildableDependencies drops every edge
-  # that references a doNotBuild job, since NixCI rejects edges to jobs it does
-  # not build. Ordinary crate package attrs are not CI roots, so test-binary
+  # cycle asserts stay meaningful, then hidden paths are contracted to their
+  # nearest built producer because NixCI rejects edges to jobs it does not
+  # build. Ordinary crate package attrs are not CI roots, so test-binary
   # generation can start before unrelated final package outputs.
   # See https://nix-ci.com/documentation/automatic-dependency-discovery
   # and https://nix-ci.com/documentation/manually-specified-dependencies
   dependency-discovery.enable = false;
-  dependencies = buildableDependencies validatedDependencies;
+  dependencies = validatedProjectedDependencies;
   test = {
     gammaloop-doctest = {
       package = "packages.${system}.nix-ci-check-gammaloop-doctest";


### PR DESCRIPTION
## Summary

- preserve NixCI scheduling dependencies through hidden `doNotBuild` nodes by projecting them to the nearest buildable producer
- add lightweight, revision-scoped barriers for shared Cargo/Crane artifact roots so producer jobs realize and publish their closures before consumers start
- correct the Spenso and Python nextest dependency graph and stop scheduling unused `spynso3` test artifacts
- build grouped nextest inputs in package-local Cargo contexts, then aggregate the archives without recompiling workspace crates
- reduce inherited target-tree copying and document the resulting cache architecture
- add a producer-first Hestia v3 GitHub Actions lane and daily cache GC, followed by independent checks from the generated `hydraJobs.x86_64-linux` matrix

## Why

The cold NixCI fan-out could start multiple consumers containing the same hidden Nix dependency before any worker had published it. In the audited run, 35 exact derivations ran more than once, causing 40 redundant executions and at least 880 repeated `Compiling` lines.

NixCI also memoized stable top-level producer attributes across commits. A cached producer job therefore did not necessarily realize or republish its nested Cargo closure. The revision-scoped barrier keeps the raw artifact derivation stable while forcing the small scheduling producer to run once for each commit.

The GitHub Actions lane applies the same producer ordering to Hestia without transferring every derivation and source closure. The prepare job disables automatic hook publication while it builds four roots, selects only their runtime closures, enforces an 8 GiB raw-NAR ceiling, and verifies that each producer root is available from Hestia. Both producer and worker jobs use Hestia's `no-closure` mode. Matrix workers check out the source and build `matrix.attr` locally, allowing ordinary Nix fallback if a cache entry has been evicted instead of failing a bulk `nix-store --import`.

Licensed checks use a run-scoped public value during matrix evaluation so no secret-bearing derivation is uploaded. Same-repository workers re-evaluate those rows with `secrets.SYMBOLICA_LICENSE`, with the Hestia hook disabled for the licensed build. Fork and Dependabot PRs omit the Nix-sandboxed licensed rows when the secret is unavailable; the regular Cargo CI lane retains its network-capable public-license coverage.

## Validation

- `actionlint` with ShellCheck integration on both Hestia workflows
- `SYMBOLICA_LICENSE=GAMMALOOP_USER nix flake check --impure --no-build --keep-going path:.`
- `nix eval --impure --json --file nix-ci.nix`
- Hestia-equivalent recursive `nix-eval-jobs` evaluation: 15 matrix attributes, zero duplicate derivation paths
- representative producer runtime-closure measurement and an enforced 8 GiB ceiling in CI
- successful [GitHub Nix run](https://github.com/alphal00p/gammaloop/actions/runs/31084907479): 2.275 GiB raw producer closure, 1.5 GiB Hestia upload in 15.4 seconds, and all 14 generated matrix workers passed
- replacement [NixCI run](https://nix-ci.com/gh:alphal00p:gammaloop/push-wuwqwyzrknqu/060c8f20c7d8007df3df10d680f3d27265dadb68):
  - overall success: 47 successful and 27 cached jobs
  - all 36 artifact producers executed their revision-scoped barrier
  - all nextest executions passed; grouped Core, Linnet, and Spenso archives compiled zero units
  - one compile-bearing derivation repeated, accounting for 7 redundant `Compiling` lines, down from at least 880

Three first attempts and the one remaining repeated compile were caused by HTTP/2 errors while downloading NARs from the NixCI cache; all retries succeeded. The remaining duplication is cache-transport fallback rather than a missing scheduling edge.