### PR TITLE
Let NixCI work out the CI job graph

### DIFF
--- a/nix-ci.nix
+++ b/nix-ci.nix
@@ -1,299 +1,56 @@
 let
   system = "x86_64-linux";
-  workspaceGraph = builtins.fromJSON (builtins.readFile ./nix/ci-workspace-graph.json);
-  unique = values:
-    builtins.attrNames (builtins.listToAttrs (map (value: {
-        name = value;
-        value = true;
-      })
-      values));
-  workspacePackages = workspaceGraph.packages;
-  cratePackageDepsAttr = package: "packages.${system}.crate-deps-${package}";
-  cratePackageAttr = package: "packages.${system}.crate-${package}";
-  crateTestSupportAttr = representative: "packages.${system}.crate-test-support-${representative}";
-  crateTestBinaryAttr = package: "packages.${system}.crate-test-binaries-${package}";
-  workspaceHackPackage = "gammaloop-workspace-hack";
-  # clinnet is binary-only: the flake exposes crate-clinnet, but no
-  # crate-deps-clinnet artifact.
-  workspacePackagesWithDependencyArtifacts = builtins.filter (package: package != "clinnet") workspacePackages;
-  nonWorkspaceHackPackages = builtins.filter (package: package != workspaceHackPackage) workspacePackages;
-  workspaceHackCacheAttr = cratePackageDepsAttr workspaceHackPackage;
-  gammaloopApiPackageArtifactsAttr = "packages.${system}.gammaloopApiPackageArtifacts";
-  workspacePackageGraphAttr = package: cratePackageAttr package;
-  mergeDependencySets = sets: let
-    attrs = unique (builtins.concatLists (map builtins.attrNames sets));
-  in
-    builtins.listToAttrs (map (attr: {
-        name = attr;
-        value = unique (builtins.concatLists (map (set: set.${attr} or []) sets));
-      })
-      attrs);
-  workspaceDependencyNamesFor = package:
-    workspaceGraph.resolved_normal_dependencies.${package} or [];
-  workspaceTestDependencyNamesFor = package:
-    workspaceGraph.test_dependencies.${package} or (workspaceGraph.normal_dependencies.${package} or []);
-  workspaceDependencyClosureFor = dependencyNamesFor: package:
-    unique (map (entry: entry.key) (builtins.genericClosure {
-      startSet = [{key = package;}];
-      operator = entry: map (dependency: {key = dependency;}) (dependencyNamesFor entry.key);
-    }));
-  workspaceTestDependencyClosureFor =
-    workspaceDependencyClosureFor workspaceTestDependencyNamesFor;
-  workspaceTestComponentMembersFor = package:
-    unique (builtins.filter (
-        other:
-          builtins.elem other (workspaceTestDependencyClosureFor package)
-          && builtins.elem package (workspaceTestDependencyClosureFor other)
-      )
-      workspacePackages);
-  workspaceTestComponentRepresentativeFor = package:
-    builtins.head (workspaceTestComponentMembersFor package);
-  workspaceTestComponentRepresentatives =
-    unique (map workspaceTestComponentRepresentativeFor workspacePackages);
-  workspaceTestSupportComponentRepresentatives =
-    builtins.filter (representative: representative != workspaceHackPackage) workspaceTestComponentRepresentatives;
-  workspaceTestComponentMembers =
-    builtins.listToAttrs (map (representative: {
-        name = representative;
-        value = workspaceTestComponentMembersFor representative;
-      })
-      workspaceTestComponentRepresentatives);
-  workspaceTestComponentDependencyRepresentativesFor = representative:
-    unique (builtins.filter (dependencyRepresentative: dependencyRepresentative != representative) (
-      map workspaceTestComponentRepresentativeFor (
-        builtins.concatLists (map workspaceTestDependencyNamesFor workspaceTestComponentMembers.${representative})
-      )
-    ));
-  workspaceCratePackageDependencies = builtins.listToAttrs (
-    builtins.filter (entry: entry.value != []) (map (package: {
-        name = workspacePackageGraphAttr package;
-        value = map workspacePackageGraphAttr (workspaceDependencyNamesFor package);
-      })
-      workspacePackages)
-  );
-  workspaceCratePackageDependencyEdges = builtins.concatLists (map (dependent:
-      map (dependency: {
-        inherit dependency dependent;
-      })
-      (workspaceCratePackageDependencies.${dependent} or []))
-    (builtins.attrNames workspaceCratePackageDependencies));
-  workspaceCratePackageCacheDependencies = builtins.listToAttrs (map (package: {
-      name = workspacePackageGraphAttr package;
-      value = [(cratePackageDepsAttr package)];
-    })
-    workspacePackagesWithDependencyArtifacts);
-  workspaceCratePackageCacheArtifactDependencies = builtins.listToAttrs (
-    builtins.filter (entry: entry.value != []) (map (package: {
-        name = cratePackageDepsAttr package;
-        value =
-          map cratePackageDepsAttr (workspaceDependencyNamesFor package)
-          ++ (
-            if package != workspaceHackPackage && (workspaceDependencyNamesFor package) == [] && builtins.elem package workspaceGraph.symbolica_normal_packages
-            then [workspaceHackCacheAttr]
-            else []
-          );
-      })
-      workspacePackages)
-  );
-  workspaceCratePackageCacheArtifactDependencyEdges = builtins.concatLists (map (dependent:
-      map (dependency: {
-        inherit dependency dependent;
-      })
-      (workspaceCratePackageCacheArtifactDependencies.${dependent} or []))
-    (builtins.attrNames workspaceCratePackageCacheArtifactDependencies));
-  workspaceTestSupportDependencies = builtins.listToAttrs (map (representative: {
-      name = crateTestSupportAttr representative;
-      value =
-        [(workspacePackageGraphAttr workspaceHackPackage)]
-        ++ map crateTestSupportAttr (
-          builtins.filter (
-            dependencyRepresentative: dependencyRepresentative != workspaceHackPackage
-          )
-          (workspaceTestComponentDependencyRepresentativesFor representative)
-        );
-    })
-    workspaceTestSupportComponentRepresentatives);
-  nextestPackageGroups = {
-    core = [
-      "gammaloop-api"
-      "gammaloop-tracing-filter"
-      "gammaloop-tracing-filter-macros"
-      "gammalooprs"
-    ];
-    integration = ["gammaloop-integration-tests"];
-    "python-api" = ["gammaloop-integration-tests"];
-    clinnet = ["clinnet"];
-    linnet = [
-      "linnet"
-      "linnet-py"
-      "linnest"
-    ];
-    spenso = [
-      "idenso"
-      "spenso"
-      "spenso-hep-lib"
-      "spenso-macros"
-    ];
-    vakint = ["vakint"];
-  };
-  nextestArchiveAttr = target: "checks.${system}.gammaloop-nextest-binaries-${target}";
-  nextestPackageTestSupportAttr = package:
-    crateTestSupportAttr (workspaceTestComponentRepresentativeFor package);
-  nextestArchiveDependenciesFor = target:
-    ["packages.${system}.cargoArtifacts"]
-    ++ unique (map nextestPackageTestSupportAttr nextestPackageGroups.${target})
-    ++ (
-      if target == "python-api"
-      then ["packages.${system}.gammaloop-python-module"]
-      else []
-    );
-  # The Hakari workspace-hack deps artifact is the root for the
-  # Symbolica-containing cache DAG. Higher-level crate cache jobs reach it
-  # through their Guppy-resolved workspace cache dependencies.
-  nextestBinaryChecks = map nextestArchiveAttr (builtins.attrNames nextestPackageGroups);
-  dependencies = mergeDependencySets [
-    workspaceCratePackageCacheArtifactDependencies
-    workspaceCratePackageCacheDependencies
-    workspaceCratePackageDependencies
-    workspaceTestSupportDependencies
-    {
-      "packages.${system}.gammaloop" = [
-        gammaloopApiPackageArtifactsAttr
-        "checks.${system}.gammaloop-fmt"
-      ];
-      "checks.${system}.gammaloop" = ["packages.${system}.gammaloop"];
-      "packages.${system}.default" = ["packages.${system}.gammaloop"];
-      "packages.${system}.gammaloop-python-module" =
-        workspaceCratePackageDependencies.${cratePackageAttr "gammaloop-api"} or [];
-      ${gammaloopApiPackageArtifactsAttr} = [(cratePackageAttr "gammaloop-api")];
-      "packages.${system}.cargoArtifacts" = [workspaceHackCacheAttr];
-      "checks.${system}.gammaloop-check" = ["packages.${system}.cargoArtifacts"];
-      "checks.${system}.gammaloop-clippy" = ["packages.${system}.cargoArtifacts"];
-      "checks.${system}.gammaloop-doc" = ["packages.${system}.cargoArtifacts"];
-      "checks.${system}.gammaloop-doctest" = ["packages.${system}.cargoArtifacts"];
-      "packages.${system}.workspaceBuildArtifacts" = ["packages.${system}.cargoArtifacts"];
-      "checks.${system}.gammaloop-nextest-binaries-core" = nextestArchiveDependenciesFor "core";
-      "checks.${system}.gammaloop-nextest-binaries-clinnet" = nextestArchiveDependenciesFor "clinnet";
-      "checks.${system}.gammaloop-nextest-binaries-integration" = nextestArchiveDependenciesFor "integration";
-      "checks.${system}.gammaloop-nextest-binaries-python-api" = nextestArchiveDependenciesFor "python-api";
-      "checks.${system}.gammaloop-nextest-binaries-linnet" = nextestArchiveDependenciesFor "linnet";
-      "checks.${system}.gammaloop-nextest-binaries-spenso" = nextestArchiveDependenciesFor "spenso";
-      "checks.${system}.gammaloop-nextest-binaries-vakint" = nextestArchiveDependenciesFor "vakint";
-      "checks.${system}.gammaloop-nextest-binaries" = nextestBinaryChecks;
-      "packages.${system}.linnest-wasm" = ["packages.${system}.linnestWasmCargoArtifacts"];
-      "checks.${system}.linnest-wasm" = ["packages.${system}.linnest-wasm"];
-      "packages.${system}.gammaloop-llvm-coverage" = ["packages.${system}.gammaloop"];
-      "packages.${system}.nix-ci-check-gammaloop-doctest" = ["packages.${system}.cargoArtifacts"];
-      "packages.${system}.nix-ci-check-gammaloop-nextest" =
-        nextestBinaryChecks
-        ++ ["packages.${system}.gammaloop-python-module"];
-      "packages.${system}.nix-ci-check-gammaloop-nextest-clinnet" = ["checks.${system}.gammaloop-nextest-binaries-clinnet"];
-      "packages.${system}.nix-ci-check-gammaloop-nextest-core" = ["checks.${system}.gammaloop-nextest-binaries-core"];
-      "packages.${system}.nix-ci-check-gammaloop-nextest-integration" = [
-        "checks.${system}.gammaloop-nextest-binaries-integration"
-      ];
-      "packages.${system}.nix-ci-check-gammaloop-nextest-python-api" = [
-        "checks.${system}.gammaloop-nextest-binaries-python-api"
-        "packages.${system}.gammaloop-python-module"
-      ];
-      "packages.${system}.nix-ci-check-gammaloop-nextest-linnet" = ["checks.${system}.gammaloop-nextest-binaries-linnet"];
-      "packages.${system}.nix-ci-check-gammaloop-nextest-spenso" = ["checks.${system}.gammaloop-nextest-binaries-spenso"];
-      "packages.${system}.nix-ci-check-gammaloop-nextest-vakint" = ["checks.${system}.gammaloop-nextest-binaries-vakint"];
-    }
-  ];
-  missingWorkspaceCratePackageEdges =
-    builtins.filter (
-      edge: !(builtins.elem edge.dependency (dependencies.${edge.dependent} or []))
-    )
-    workspaceCratePackageDependencyEdges;
-  missingWorkspaceCratePackageCacheArtifactEdges =
-    builtins.filter (
-      edge: !(builtins.elem edge.dependency (dependencies.${edge.dependent} or []))
-    )
-    workspaceCratePackageCacheArtifactDependencyEdges;
-  reciprocalWorkspaceCratePackageEdges =
-    builtins.filter (
-      edge: builtins.elem edge.dependent (workspaceCratePackageDependencies.${edge.dependency} or [])
-    )
-    workspaceCratePackageDependencyEdges;
-  formatDependencyEdge = edge: "${edge.dependency} -> ${edge.dependent}";
-  selfDependencies =
-    builtins.filter (
-      attr: builtins.elem attr (dependencies.${attr} or [])
-    )
-    (builtins.attrNames dependencies);
-  validatedDependencies =
-    assert missingWorkspaceCratePackageEdges == []
-    || builtins.throw "manual NixCI dependency graph is missing workspace crate package dependency edges: ${builtins.concatStringsSep ", " (map formatDependencyEdge missingWorkspaceCratePackageEdges)}";
-    assert missingWorkspaceCratePackageCacheArtifactEdges == []
-    || builtins.throw "manual NixCI dependency graph is missing workspace crate package cache dependency edges: ${builtins.concatStringsSep ", " (map formatDependencyEdge missingWorkspaceCratePackageCacheArtifactEdges)}";
-    assert reciprocalWorkspaceCratePackageEdges == []
-    || builtins.throw "manual NixCI dependency graph contains reciprocal workspace crate package dependency edges: ${builtins.concatStringsSep ", " (map formatDependencyEdge reciprocalWorkspaceCratePackageEdges)}";
-    assert selfDependencies == []
-    || builtins.throw "manual NixCI dependency graph contains self dependencies: ${builtins.concatStringsSep ", " selfDependencies}";
-      dependencies;
-  doNotBuild = unique (
-    [
-      "checks.${system}.gammaloop-doctest"
-      "checks.${system}.gammaloop-nextest"
-      "checks.${system}.gammaloop-nextest-binaries"
-      "checks.${system}.gammaloop-nextest-clinnet"
-      "checks.${system}.gammaloop-nextest-core"
-      "checks.${system}.gammaloop-nextest-integration"
-      "checks.${system}.gammaloop-nextest-python-api"
-      "checks.${system}.gammaloop-nextest-linnet"
-      "checks.${system}.gammaloop-nextest-spenso"
-      "checks.${system}.gammaloop-nextest-vakint"
-      "packages.${system}.default"
-      "packages.${system}.crane-ci-prebuild"
-      "packages.${system}.workspaceBuildArtifacts"
-      "packages.${system}.gammaloop-llvm-coverage"
-      "packages.${system}.nix-ci-check-gammaloop-nextest"
-    ]
-    ++ map crateTestBinaryAttr workspacePackages
-    ++ map cratePackageDepsAttr (
-      builtins.filter (package: package != workspaceHackPackage) workspacePackagesWithDependencyArtifacts
-    )
-    ++ map cratePackageAttr nonWorkspaceHackPackages
-  );
-  # NixCI only schedules jobs it actually builds, so a dependency edge that
-  # references a doNotBuild job is rejected as pointing at a non-existent job.
-  # The manual graph above is constructed over the full crate/artifact DAG
-  # (which keeps the drift and cycle asserts meaningful); here we drop every
-  # edge touching a doNotBuild job so only ordering between built jobs remains.
-  doNotBuildSet = builtins.listToAttrs (map (job: {
-      name = job;
-      value = true;
-    })
-    doNotBuild);
-  isBuiltJob = job: !(doNotBuildSet ? ${job});
-  buildableDependencies = deps:
-    builtins.listToAttrs (
-      builtins.filter (entry: entry.value != []) (map (dependent: {
-          name = dependent;
-          value = builtins.filter isBuiltJob deps.${dependent};
-        })
-        (builtins.filter isBuiltJob (builtins.attrNames deps)))
-    );
 in {
   systems = [system];
-  inherit doNotBuild;
+  doNotBuild = [
+    "checks.${system}.gammaloop-doctest"
+    "checks.${system}.gammaloop-nextest"
+    "checks.${system}.gammaloop-nextest-binaries"
+    "checks.${system}.gammaloop-nextest-clinnet"
+    "checks.${system}.gammaloop-nextest-core"
+    "checks.${system}.gammaloop-nextest-integration"
+    "checks.${system}.gammaloop-nextest-linnet"
+    "checks.${system}.gammaloop-nextest-python-api"
+    "checks.${system}.gammaloop-nextest-spenso"
+    "checks.${system}.gammaloop-nextest-vakint"
+    "packages.${system}.crane-ci-prebuild"
+    "packages.${system}.default"
+    "packages.${system}.gammaloop-llvm-coverage"
+    "packages.${system}.nix-ci-check-gammaloop-nextest"
+    "packages.${system}.workspaceBuildArtifacts"
+  ];
   fail-fast = false;
-  # Keep dependency discovery manual. With generated Rust outputs,
-  # automatic discovery asks NixCI to compute derivation paths for many
-  # package/check attrs during `show`, including attrs listed in doNotBuild.
-  # The manual graph below uses the Hakari workspace-hack cache artifact as the
-  # root for Symbolica-containing cache jobs and orders nextest archive jobs
-  # after the shared test-support artifacts that the archives reuse. The graph
-  # is constructed over the full crate/artifact DAG so the drift and cycle
-  # asserts stay meaningful, then buildableDependencies drops every edge that
-  # references a doNotBuild job, since NixCI rejects edges to jobs it does not
-  # build. Ordinary crate package attrs are not CI roots, so test-binary
-  # generation can start before unrelated final package outputs.
+  # Automatic discovery derives the job graph from the derivations themselves,
+  # so a dependency nobody wrote down here is still ordered correctly, and
+  # synchronous means no job starts before the graph is known: nothing gets
+  # scheduled that discovery would have ruled out as already building
+  # elsewhere.
   # See https://nix-ci.com/documentation/automatic-dependency-discovery
-  # and https://nix-ci.com/documentation/manually-specified-dependencies
-  dependency-discovery.enable = false;
-  dependencies = buildableDependencies validatedDependencies;
+  dependency-discovery = {
+    enable = true;
+    synchronous = true;
+  };
+  # Only the orderings discovery cannot see, because they are not derivation
+  # dependencies at all. The impure test runners are small scripts that run
+  # `nix build` themselves, so nothing in their derivations mentions the
+  # archives and artifacts they will ask for, and without these edges each of
+  # them would build its own. Formatting gates the package rather than
+  # feeding it.
+  # See https://nix-ci.com/documentation/manually-specified-dependencies
+  dependencies = {
+    "packages.${system}.gammaloop" = ["checks.${system}.gammaloop-fmt"];
+    "packages.${system}.nix-ci-check-gammaloop-doctest" = ["packages.${system}.cargoArtifacts"];
+    "packages.${system}.nix-ci-check-gammaloop-nextest-clinnet" = ["checks.${system}.gammaloop-nextest-binaries-clinnet"];
+    "packages.${system}.nix-ci-check-gammaloop-nextest-core" = ["checks.${system}.gammaloop-nextest-binaries-core"];
+    "packages.${system}.nix-ci-check-gammaloop-nextest-integration" = ["checks.${system}.gammaloop-nextest-binaries-integration"];
+    "packages.${system}.nix-ci-check-gammaloop-nextest-linnet" = ["checks.${system}.gammaloop-nextest-binaries-linnet"];
+    "packages.${system}.nix-ci-check-gammaloop-nextest-python-api" = [
+      "checks.${system}.gammaloop-nextest-binaries-python-api"
+      "packages.${system}.gammaloop-python-module"
+    ];
+    "packages.${system}.nix-ci-check-gammaloop-nextest-spenso" = ["checks.${system}.gammaloop-nextest-binaries-spenso"];
+    "packages.${system}.nix-ci-check-gammaloop-nextest-vakint" = ["checks.${system}.gammaloop-nextest-binaries-vakint"];
+  };
   test = {
     gammaloop-doctest = {
       package = "packages.${system}.nix-ci-check-gammaloop-doctest";


### PR DESCRIPTION
**Your CI is currently rejected before it builds anything, and this fixes that.** Every suite since `db6a836d` fails at the config step:

```
https://nix-ci.com/gh:alphal00p:gammaloop/dev/a0ccfb94 → config [failed]

!!! nix-ci.nix reads nix !!!
NixCI reads nix-ci.nix out of your repository on its own, so it has to be a
single self-contained file.
```

NixCI reads `nix-ci.nix` straight out of the forge, without cloning the repository, so reading `nix/ci-workspace-graph.json` from it is rejected rather than read. `db6a836d` still passed, so the rule reached NixCI between that commit and `a0ccfb94`.

Following up on the CI cost thread, this is one commit on `nix-ci.nix`, 361 lines to 118, doing three things.

**Making the file self-contained**, which is what unblocks the above: `doNotBuild` and `dependencies` are written out rather than computed.

**Letting discovery derive the job graph.** Discovery works the graph out from the derivations themselves and merges what it finds with what is configured here, so what is left to configure are the ten orderings that are not derivation dependencies at all:

- the impure test runners are small scripts that run `nix build` themselves, so nothing in their derivations mentions the nextest archives, the python module or the cargo artifacts they ask for at runtime. Without these edges each runner builds its own copy;
- `gammaloop-fmt` gates `packages.gammaloop` rather than feeding it.

I measured which edges those are rather than judging by eye: for each of the 80 edges the old graph produced, is the dependency's derivation in the dependent's input closure. Seventy are, so discovery finds them.

**Dropping the per-crate exclusions.** They existed because those artifacts were roots with hand-written edges; ordered by discovery they can be jobs like any other, built once and reused. `doNotBuild` is back to the aggregates and duplicates that must not be built at all. This does mean the per-crate artifacts appear as jobs of their own, which is more jobs but not more building; if the job overhead outweighs the reuse, putting those entries back is a one-line change.

`synchronous = true` means no job starts before the graph is known. An edge missing from a hand-written graph lets two jobs build the same derivation at the same time and you pay for both, which is what [this job](https://nix-ci.com/gh:alphal00p:gammaloop/codex%2Fraised_energy_cff_wip_optimized_phase_fix/26b57b78674315af2eda53ec3b135ce4ffd16e95/9364512c-cdfe-4efd-b009-6b61b7f56865) and [this one](https://nix-ci.com/gh:alphal00p:gammaloop/codex%2Fraised_energy_cff_wip_optimized_phase_fix/26b57b78674315af2eda53ec3b135ce4ffd16e95/cdbbfe3f-4abb-4fbb-b1f4-992b466bfaf1) look like from outside.

The impure tests, the deploy job and `fail-fast` are untouched.

Tried out: the config validator accepts it, `alejandra --check nix-ci.nix` is clean, `nix flake check` passes locally except the nextest runs that need the real `SYMBOLICA_LICENSE` secret (the `GAMMALOOP_USER` fallback gives a restricted Symbolica, limited to one instance per machine and wanting a license server the sandbox cannot reach), and a suite runs on my fork: <https://staging.nix-ci.com/gh:NorfairKing:gammaloop/nix-ci-dependency-discovery>

Everything that did build is pushed to the NixCI cache, so the first suite here should substitute most of it rather than build it.

Docs: <https://nix-ci.com/documentation/configuration>, <https://nix-ci.com/documentation/automatic-dependency-discovery>, <https://nix-ci.com/documentation/manually-specified-dependencies>

Two knobs I left alone deliberately, since they are cost policy rather than simplification: `fail-fast = false` pays for the rest of a suite after a job has failed, and `auto-retry` (on by default) pays for every failed job twice.

#105 sits on top of this in practice: its own suite cannot pass until this merges, since the config step reads `dev`.