### PR TITLE
Fill and read the NixCI cache from local builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,24 @@ These rules are intentionally broad and should shape most code changes.
   symbol, try building with `EXTRA_MACOS_LIBS_FOR_GNU_GCC=T`; see `build.rs`
   for the impact of this setting.
 
+## NixCI Cache
+
+NixCI substitutes anything it has already built, and anything you have built,
+so a commit whose checks already pass locally leaves CI with nothing to build.
+Get `nix flake check` to pass before you push.
+
+All you need for that is a NixCI token in `~/.netrc`; see
+[the NixCI cache documentation](https://nix-ci.com/documentation/nix-ci-cache).
+
+With that file in place the dev shell needs no further setup: it points Nix at
+your `~/.netrc` and at a push script as its `post-build-hook`, so every
+derivation you build from `nix develop` lands in the cache. Reading back from
+it is configured in `flake.nix`.
+
+Nix honours a post-build-hook from the command line only for a trusted user,
+which `nix store info --json` reports. If nothing is being pushed, that is the
+first thing to check.
+
 ## Version Control Workflow
 
 ### jj

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,14 @@
 {
   description = "Gammaloop";
 
+  # Substitute what NixCI has already built instead of building it again.
+  # Reading from this cache needs a token in your netrc as well, and Nix asks
+  # before it trusts these settings; see CONTRIBUTING.md.
+  nixConfig = {
+    extra-substituters = ["https://cache.nix-ci.com"];
+    extra-trusted-public-keys = ["nix-ci:g3xV5BDTLtIBZr/A00IU1x0EtKKlb7YLgBN2SgYgM6A="];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
@@ -2502,6 +2510,27 @@
           echo "All NixCI build and test jobs passed."
         '';
       };
+
+      # Nix runs this after every build in the dev shell, so that a commit
+      # whose checks already pass locally leaves NixCI with nothing to build.
+      # See https://nix-ci.com/documentation/nix-ci-cache
+      pushToNixCiCache = pkgs.writeShellScript "push-to-nix-ci-cache" ''
+        set -eu
+        set -f
+        export IFS=' '
+
+        # Keep the throwaway XDG_CACHE_HOME. Without it this machine remembers
+        # the unsigned narinfo it built locally, and then refuses to
+        # substitute back the paths it pushed itself.
+        XDG_CACHE_HOME="$(mktemp -d)"
+        export XDG_CACHE_HOME
+        trap 'rm -rf "$XDG_CACHE_HOME"' EXIT
+
+        # Nix fails the build whose post-build-hook fails, so being offline or
+        # without a token must not come out of here non-zero.
+        nix copy --to 'https://cache.nix-ci.com?compression=xz&parallel-compression=true' ''${OUT_PATHS-} \
+          || echo "push-to-nix-ci-cache: could not push to the NixCI cache." >&2
+      '';
     in {
       checks =
         {
@@ -2600,6 +2629,16 @@
           #   export CXX="${nixCxx}"
           #   export ${cargoLinkerVar}="${nixCc}"
           # '';
+
+          # The hook runs as the Nix daemon user, which finds the cache token
+          # through the netrc-file setting it inherits from here. Nix honours
+          # both settings only for a trusted user; see CONTRIBUTING.md.
+          shellHook = ''
+            if [ -r "$HOME/.netrc" ]; then
+              NIX_CONFIG="$(printf '%s\nnetrc-file = %s\npost-build-hook = %s' "''${NIX_CONFIG-}" "$HOME/.netrc" "${pushToNixCiCache}")"
+              export NIX_CONFIG
+            fi
+          '';
 
           packages = with pkgs;
             [


### PR DESCRIPTION
Following up on the CI cost thread: the cheapest CI job is the one whose result is already built. One commit, `flake.nix` and `CONTRIBUTING.md`, independent of #104.

NixCI substitutes from the NixCI cache, but nothing currently puts your local builds there, so most derivations get built twice: once on the machine that wrote the code, once on a worker. This wires up both directions in the flake, per checkout, with no system configuration:

- the dev shell points Nix's `post-build-hook` at a script that copies every path Nix builds here to the cache;
- `nixConfig` adds that cache as a substituter in return.

All a contributor has to do is put a token from <https://nix-ci.com/account/auth-tokens> in `~/.netrc`. CONTRIBUTING.md says what this repository wires up and links the [cache documentation](https://nix-ci.com/documentation/nix-ci-cache) for the rest, along with the advice that goes with it: get `nix flake check` to pass locally before pushing, and CI has nothing left to build.

The hook is the one from that documentation, plus a single fallback line: a post-build-hook that exits non-zero fails the build it was called for, so a machine with no token, or no network, has to keep building exactly as it does today. It runs as the Nix daemon user and still finds the token, because Nix hands the daemon the client's `netrc-file` setting, which the dev shell points at `$HOME/.netrc`. Nothing outside the checkout is touched.

Nix honours a post-build-hook from a client only for a trusted user, which `nix store info --json` reports. For anyone else the dev shell simply pushes nothing, and CONTRIBUTING.md names that as the first thing to check.

Tried out on this branch:

- the dev shell really does arm it: `nix develop` comes out with `netrc-file` and `post-build-hook` set in `NIX_CONFIG`;
- a path built with the hook armed is in the cache afterwards (`narinfo` responds `200`), and comes back out of it into an empty store with its signature verified against the key this flake adds;
- with `netrc-file` pointed at a nonexistent file, the same build succeeds and the hook prints one warning line.

Note that a suite for this branch alone will fail at the config step, because `nix-ci.nix` on `dev` reads `nix/ci-workspace-graph.json` and NixCI cannot read it. #104 fixes that, and is otherwise unrelated to this change. Tried out together on my fork: <https://staging.nix-ci.com/gh:NorfairKing:gammaloop/nix-ci-cache-locally>

Docs: <https://nix-ci.com/documentation/nix-ci-cache>